### PR TITLE
fixes issue with available_node in ui always checking vault techweb

### DIFF
--- a/code/modules/research/rdconsole.dm
+++ b/code/modules/research/rdconsole.dm
@@ -928,7 +928,7 @@ Nothing else in the console has ID requirements.
 	if(ls["research_node"])
 		if(!research_control)
 			return				//honestly should call them out for href exploiting :^)
-		if(!SSresearch.science_tech.available_nodes[ls["research_node"]])
+		if(!stored_research.available_nodes[ls["research_node"]])
 			return			//Nope!
 		research_node(ls["research_node"], usr)
 	if(ls["clear_tech"]) //Erase la on the technology disk.


### PR DESCRIPTION
<!-- Thanks for choosing to take the time to contribute to our project! We have a few things below that we'd like you to fill out -->
<!-- The more detail you can give us, the faster we can code review, test, and merge your changes -->

<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
issue found with rnd - once vault researches a node, no other techweb can research it


## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
makes this weird one sided race. If vault rushes the early nodes, it kills bos.


## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- This helps us replicate your tests, to speed up review. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->
researched node in BOS
confirmed node can be researched in vault
researched another node in vault
confirmed node can be researched in BOS

## Screenshots (if appropriate):
n/a