### PR TITLE
Allows changing of protolathe's tech webs host research with tech disks

### DIFF
--- a/code/modules/research/machinery/_production.dm
+++ b/code/modules/research/machinery/_production.dm
@@ -331,3 +331,10 @@
 
 	l += "</tr></table></div>"
 	return l
+
+/obj/machinery/rnd/production/attackby(obj/item/I, mob/user)
+	if(istype(I, /obj/item/disk/tech_disk))
+		var/obj/item/disk/tech_disk/disk = I
+		host_research = disk.stored_research
+		to_chat(user, "You slap the [src.name] with the tech disk, replacing it's techweb with the one in the disk.")
+		update_research()


### PR DESCRIPTION
<!-- Thanks for choosing to take the time to contribute to our project! We have a few things below that we'd like you to fill out -->
<!-- The more detail you can give us, the faster we can code review, test, and merge your changes -->

<!--- Provide a general summary of your changes in the Title above -->
Allows changing of techwebs that departmental protolathes uses to sync and get designs from by slapping the protolathe with a tech disk. 
## Description
<!--- Describe your changes in detail -->
This fixes the issue of default departmental protolathes not being limited to just the global 'unknown' techweb, which was mainly a problem for vaulters not being able to use the science they researched at the protolathes like med, security and service.
## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
So the damm code can work

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- This helps us replicate your tests, to speed up review. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->
It hasn't; hope it works
## Screenshots (if appropriate):
