### PR TITLE
Checks for null mind when respawning

### DIFF
--- a/code/modules/mob/mob.dm
+++ b/code/modules/mob/mob.dm
@@ -402,7 +402,7 @@
 		return
 
 	/* if player has no body, allow instant respawn, otherwise do standard checks */
-	if(src.mind.current)
+	if(src.mind && src.mind.current) /* check if mind is null, as observers don't have one - they can instant respawn */
 		var/is_admin = check_rights_for(src.client, R_ADMIN)
 		var/deathtime = world.time - src.timeofdeath //How long dead for in deciseconds -- src can either be the corpse or ghost
 		/* check if the respawn cooldown has expired, and check for admin override if not */


### PR DESCRIPTION
<!-- Thanks for choosing to take the time to contribute to our project! We have a few things below that we'd like you to fill out -->
<!-- The more detail you can give us, the faster we can code review, test, and merge your changes -->

<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
allows observers to respawn 3 minutes after round start - fixes runtimes

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
so observers can respawn

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- This helps us replicate your tests, to speed up review. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->
Observed, waited for respawn, was able to respawn
Spawned as normal job, used suicide to die, was able to respawn afterwards
spawned as normal job, gibbed, was able to respawn
spawned as normal job, ghosted, was able to respawn

## Screenshots (if appropriate):
