### PR TITLE
Fix RND Server Linking

### DIFF
--- a/code/modules/research/machinery/_production.dm
+++ b/code/modules/research/machinery/_production.dm
@@ -331,3 +331,16 @@
 
 	l += "</tr></table></div>"
 	return l
+/* allows production machinery to be manually linked to rnd server as part of round setup */
+/obj/machinery/rnd/production/multitool_act(mob/living/user, obj/item/I)
+	if(istype(I, /obj/item/multitool))
+		var/obj/item/multitool/M = I
+		if(!istype(M.buffer, /obj/machinery/rnd/server))
+			to_chat(user, "<span class='warning'>The [I] has no linkage data in its buffer.</span>")
+			return FALSE
+		else
+			var/obj/machinery/rnd/server/S = M.buffer
+			host_research = S.stored_research
+			to_chat(user, "<span class='notice'>You link [src] to the server in [I]'s buffer.</span>")
+			INVOKE_ASYNC(src, .proc/update_research)
+			return TRUE

--- a/code/modules/research/server.dm
+++ b/code/modules/research/server.dm
@@ -189,3 +189,11 @@
 	var/obj/item/circuitboard/machine/B = new /obj/item/circuitboard/machine/rdserver(null)
 	B.apply_default_parts(src)
 
+
+/* so we can link lathes and such to this server's techweb */
+/obj/machinery/rnd/server/multitool_act(mob/living/user, obj/item/I)
+	if(istype(I, /obj/item/multitool))
+		var/obj/item/multitool/M = I
+		M.buffer = src
+		to_chat(user, "<span class='notice'>You store server information in [I]'s buffer.</span>")
+		return TRUE


### PR DESCRIPTION
<!-- Thanks for choosing to take the time to contribute to our project! We have a few things below that we'd like you to fill out -->
<!-- The more detail you can give us, the faster we can code review, test, and merge your changes -->

<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
added multitool action to rnd servers, so they can be linked to lathes and techfabs

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
So players can do rnd more extra time

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- This helps us replicate your tests, to speed up review. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->
Hit RND server in Vault, hit some protolathes to test they work + update their designs
repeated in BOS, totes works

## Screenshots (if appropriate):
![image](https://user-images.githubusercontent.com/22902112/48309042-a0d92d80-e5bc-11e8-84df-525bf071081b.png)
![image](https://user-images.githubusercontent.com/22902112/48309044-a3d41e00-e5bc-11e8-880f-dc244fc50483.png)
