### PR TITLE
Adding limited loadout for Pusher role

### DIFF
--- a/code/modules/jobs/job_types/wasteland.dm
+++ b/code/modules/jobs/job_types/wasteland.dm
@@ -216,11 +216,15 @@ Pusher
 	satchel = /obj/item/storage/backpack/satchel/explorer
 
 	uniform =  		/obj/item/clothing/under/jabroni
+	suit = /obj/item/clothing/suit/f13/duster
 /datum/outfit/job/f13pusher/pre_equip(mob/living/carbon/human/H)
 	..()
 	r_pocket = pick(
 		/obj/item/flashlight/flare/torch, \
 		/obj/item/flashlight/flare)
+	backpack_contents = list(
+		/obj/item/reagent_containers/pill/patch/jet=3, \
+		/obj/item/reagent_containers/syringe/medx=2)
 
 /*
 Preacher

--- a/code/modules/reagents/reagent_containers/pill.dm
+++ b/code/modules/reagents/reagent_containers/pill.dm
@@ -158,10 +158,10 @@
 	icon_state = "pill9"
 	color = "#454545"
 	list_reagents = list("shadowmutationtoxin" = 1)
-	
+
 /obj/item/reagent_containers/pill/mentat
 	name = "mentat pill"
-	desc = "A chalky pill that induces increased memory and cognotive functions, as well as heightened perception and creative faculties. \
+	desc = "A chalky pill that induces increased memory and cognitive functions, as well as heightened perception and creative faculties. \
 	Also known for fixing eye damage and blindness, for some reason."
 	icon_state = "pill20"
 	list_reagents = list("mentat" = 10)


### PR DESCRIPTION

## Description
Adding a Duster, 3 Jet, and 2 Med-x to the Pusher load out instead of it just being a box.

Also fixed a typo found for Mentats

## Motivation and Context
Pusher had box only for spawn

## How Has This Been Tested?
spawned as pusher. Confirmed loadout worked.