### PR TITLE
Update living.dm

### DIFF
--- a/code/modules/mob/living/living.dm
+++ b/code/modules/mob/living/living.dm
@@ -7,7 +7,7 @@
 	medhud.add_to_hud(src)
 	faction += "[REF(src)]"
 	GLOB.mob_living_list += src
-
+	mob_sleep() // protects against mobs in spawn location, because they ignore sleeping targets
 
 /mob/living/prepare_huds()
 	..()
@@ -225,7 +225,7 @@
 			var/datum/disease/D = thing
 			if(D.spread_flags & DISEASE_SPREAD_CONTACT_SKIN)
 				ContactContractDisease(D)
-	
+
 		add_logs(src, M, "grabbed", addition="passive grab")
 		if(!supress_message)
 			visible_message("<span class='warning'>[src] has grabbed [M][(zone_selected == "l_arm" || zone_selected == "r_arm")? " by their hands":" passively"]!</span>")
@@ -233,7 +233,7 @@
 			M.LAssailant = null
 		else
 			M.LAssailant = usr
-			
+
 //mob verbs are a lot faster than object verbs
 //for more info on why this is not atom/pull, see examinate() in mob.dm
 /mob/living/verb/pulled(atom/movable/AM as mob|obj in oview(1))


### PR DESCRIPTION
-Creates a soft protection against mobs in spawn locations by spawning players asleep, because they ignore unconscious players.
-Nerfs heavy sleeper trait indirectly

## How Has This Been Tested?
Late join and new join players both spawn with mob_sleep() triggered.