### PR TITLE
Explosions will no longer make heat

### DIFF
--- a/code/datums/explosion.dm
+++ b/code/datums/explosion.dm
@@ -180,7 +180,7 @@ GLOBAL_LIST_EMPTY(explosions)
 				Trajectory = get_step_towards(Trajectory, epicenter)
 				dist += cached_exp_block[Trajectory]
 
-		var/flame_dist = dist < flame_range
+		//var/flame_dist = dist < flame_range
 		var/throw_dist = dist
 
 		if(dist < devastation_range)

--- a/code/datums/explosion.dm
+++ b/code/datums/explosion.dm
@@ -203,9 +203,9 @@ GLOBAL_LIST_EMPTY(explosions)
 				var/atom/A = O
 				if(!QDELETED(A))
 					A.ex_act(dist)
-
-		if(flame_dist && prob(40) && !isspaceturf(T) && !T.density)
-			new /obj/effect/hotspot(T) //Mostly for ambience!
+		//TG CLAW: No fire upon explosions, if it did then it makes areas perma heated because atmos gets heavily slowed down by all of the atmos things that never clear up
+		//if(flame_dist && prob(40) && !isspaceturf(T) && !T.density)
+		//	new /obj/effect/hotspot(T) //Mostly for ambience!
 
 		if(dist > EXPLODE_NONE)
 			T.explosion_level = max(T.explosion_level, dist)	//let the bigger one have it


### PR DESCRIPTION
<!-- Thanks for choosing to take the time to contribute to our project! We have a few things below that we'd like you to fill out -->
<!-- The more detail you can give us, the faster we can code review, test, and merge your changes -->

<!--- Provide a general summary of your changes in the Title above -->
## Description
<!--- Describe your changes in detail -->
Explosions will never make turfs heated
## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Stops atmos lag caused by hotspots, in addition because of all of the lag, hotspots would also make the area constantly do fire damage usually forever
## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- This helps us replicate your tests, to speed up review. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->
By blowing up things and seeing it doesn't create heat and no excessive atmos lag caused by it
## Screenshots (if appropriate):
