### PR TITLE
Carp meat toxicity increase

### DIFF
--- a/code/modules/food_and_drinks/food/snacks_meat.dm
+++ b/code/modules/food_and_drinks/food/snacks_meat.dm
@@ -16,13 +16,13 @@
 	foodtype = MEAT
 
 /obj/item/reagent_containers/food/snacks/carpmeat
-	name = "carp fillet"
-	desc = "A fillet of spess carp meat."
+	name = "cazador fillet"
+	desc = "A fillet of cazador meat."
 	icon_state = "fishfillet"
 	list_reagents = list("nutriment" = 3, "carpotoxin" = 5, "vitamin" = 2)
 	bitesize = 6
 	filling_color = "#FA8072"
-	tastes = list("fish" = 1)
+	tastes = list("bug flesh" = 1)
 	foodtype = MEAT
 
 /obj/item/reagent_containers/food/snacks/carpmeat/Initialize()

--- a/code/modules/food_and_drinks/food/snacks_meat.dm
+++ b/code/modules/food_and_drinks/food/snacks_meat.dm
@@ -19,7 +19,7 @@
 	name = "carp fillet"
 	desc = "A fillet of spess carp meat."
 	icon_state = "fishfillet"
-	list_reagents = list("nutriment" = 3, "carpotoxin" = 2, "vitamin" = 2)
+	list_reagents = list("nutriment" = 3, "carpotoxin" = 5, "vitamin" = 2)
 	bitesize = 6
 	filling_color = "#FA8072"
 	tastes = list("fish" = 1)

--- a/code/modules/food_and_drinks/food/snacks_meat.dm
+++ b/code/modules/food_and_drinks/food/snacks_meat.dm
@@ -19,7 +19,7 @@
 	name = "carp fillet"
 	desc = "A fillet of spess carp meat."
 	icon_state = "fishfillet"
-	list_reagents = list("nutriment" = 3, "carpotoxin" = 5, "vitamin" = 2)
+	list_reagents = list("nutriment" = 3, "carpotoxin" = 2, "vitamin" = 2)
 	bitesize = 6
 	filling_color = "#FA8072"
 	tastes = list("fish" = 1)


### PR DESCRIPTION

## Description
This change increases the amount of carpotoxin in Cazador meat by three.

## Motivation and Context
My motivation in creating this push is to make more reagents available for Rezadone and Zombie Powder creation. It's also, frankly, to test out pushes and ensure that everything is functioning as it should.

## How Has This Been Tested?
I did manage to get my private server up and running - and the change is included, as per grinding Cazador meat.
