### PR TITLE
Box movement removal

### DIFF
--- a/code/game/objects/structures/crates_lockers/closets/cardboardbox.dm
+++ b/code/game/objects/structures/crates_lockers/closets/cardboardbox.dm
@@ -13,21 +13,7 @@
 	material_drop = /obj/item/stack/sheet/cardboard
 	delivery_icon = "deliverybox"
 	anchorable = FALSE
-	var/move_speed_multiplier = 1
-	var/move_delay = FALSE
 	var/egged = 0
-
-/obj/structure/closet/cardboard/relaymove(mob/user, direction)
-	if(opened || move_delay || user.stat || user.IsStun() || user.IsKnockdown() || user.IsUnconscious() || !isturf(loc) || !has_gravity(loc))
-		return
-	move_delay = TRUE
-	if(step(src, direction))
-		addtimer(CALLBACK(src, .proc/ResetMoveDelay), CONFIG_GET(number/walk_delay) * move_speed_multiplier)
-	else
-		ResetMoveDelay()
-
-/obj/structure/closet/cardboard/proc/ResetMoveDelay()
-	move_delay = FALSE
 
 /obj/structure/closet/cardboard/open()
 	if(opened || !can_open())
@@ -64,7 +50,6 @@
 	max_integrity = 500
 	mob_storage_capacity = 5
 	resistance_flags = NONE
-	move_speed_multiplier = 2
 	cutting_tool = /obj/item/weldingtool
 	open_sound = 'sound/machines/click.ogg'
 	material_drop = /obj/item/stack/sheet/plasteel

--- a/code/game/objects/structures/plasticflaps.dm
+++ b/code/game/objects/structures/plasticflaps.dm
@@ -74,11 +74,6 @@
 	if(istype(A, /obj/structure/bed) && (B.has_buckled_mobs() || B.density))//if it's a bed/chair and is dense or someone is buckled, it will not pass
 		return 0
 
-	if(istype(A, /obj/structure/closet/cardboard))
-		var/obj/structure/closet/cardboard/C = A
-		if(C.move_delay)
-			return 0
-
 	if(ismecha(A))
 		return 0
 

--- a/code/modules/food_and_drinks/food/snacks_meat.dm
+++ b/code/modules/food_and_drinks/food/snacks_meat.dm
@@ -19,7 +19,7 @@
 	name = "carp fillet"
 	desc = "A fillet of spess carp meat."
 	icon_state = "fishfillet"
-	list_reagents = list("nutriment" = 3, "carpotoxin" = 2, "vitamin" = 2)
+	list_reagents = list("nutriment" = 3, "carpotoxin" = 5, "vitamin" = 2)
 	bitesize = 6
 	filling_color = "#FA8072"
 	tastes = list("fish" = 1)

--- a/code/modules/food_and_drinks/food/snacks_meat.dm
+++ b/code/modules/food_and_drinks/food/snacks_meat.dm
@@ -19,7 +19,7 @@
 	name = "carp fillet"
 	desc = "A fillet of spess carp meat."
 	icon_state = "fishfillet"
-	list_reagents = list("nutriment" = 3, "carpotoxin" = 5, "vitamin" = 2)
+	list_reagents = list("nutriment" = 3, "carpotoxin" = 2, "vitamin" = 2)
 	bitesize = 6
 	filling_color = "#FA8072"
 	tastes = list("fish" = 1)


### PR DESCRIPTION
## Description
This change removes the ability for characters to move around in large cardboard and metal boxes.

## Motivation and Context
Currently, there are several issues that face movement in boxes. Primarily, there's the glitch wherein moving diagonally at super speeds against walls, and the ability to dodge mobs (which may be intentional). Removing the feature detracts nothing from the game. The issues above can be fixed later, but require a lengthy series of changes as outlined by: https://github.com/tgstation/tgstation/commit/5f4b418eaaf3c0db305e3c590713d36245751dc7#diff-76ca7261cedb39098173aec6e356ad69

I fully intend to devote myself to fixing the issues ASAP, though perhaps we should remove the bugs until they've been fixed. I'll leave that up to the staff. But, in the meantime, here's the PR.

## How Has This Been Tested?
Tested in a private server, no runtimes were caused by the removal.
