### PR TITLE
Fixes nonexistant icon of tiled desert

### DIFF
--- a/code/game/turfs/simulated/floor.dm
+++ b/code/game/turfs/simulated/floor.dm
@@ -100,14 +100,12 @@
 	return
 
 /turf/open/floor/proc/update_icon()
-	..()
-	if(!update_visuals())
+	update_visuals()
+	if(!..()
 		return 0
 	if(!broken && !burnt)
 		if( !(icon_state in icons) )
 			icon_state = initial(icon_state)
-	update_visuals()
-	return 1
 
 /turf/open/floor/attack_paw(mob/user)
 	return attack_hand(user)

--- a/code/game/turfs/simulated/floor.dm
+++ b/code/game/turfs/simulated/floor.dm
@@ -102,7 +102,7 @@
 /turf/open/floor/proc/update_icon()
 	update_visuals()
 		return 1
-	if(!..()
+	if(!..())
 		return 0
 	if(!broken && !burnt)
 		if( !(icon_state in icons) )

--- a/code/game/turfs/simulated/floor.dm
+++ b/code/game/turfs/simulated/floor.dm
@@ -16,8 +16,11 @@
 	var/floor_tile = null //tile that this floor drops
 	var/list/broken_states
 	var/list/burnt_states
+	var/list/icons
+	icon_state = ""
 
 /turf/open/floor/Initialize(mapload)
+	broken_states = list("[initial(icon_state)]_dam")
 	if (!broken_states)
 		broken_states = list("damaged1", "damaged2", "damaged3", "damaged4", "damaged5")
 	if (!burnt_states)
@@ -47,6 +50,8 @@
 		icon_regular_floor = icon_state
 	if(mapload)
 		MakeDirty()
+	if (!icons)
+		icons = list()
 
 /turf/open/floor/ex_act(severity, target)
 	var/shielded = is_shielded()
@@ -97,6 +102,11 @@
 /turf/open/floor/proc/update_icon()
 	update_visuals()
 	return 1
+	if(!update_visuals())
+		return 0
+	if(!broken && !burnt)
+		if( !(icon_state in icons) )
+			icon_state = initial(icon_state)
 
 /turf/open/floor/attack_paw(mob/user)
 	return attack_hand(user)

--- a/code/game/turfs/simulated/floor.dm
+++ b/code/game/turfs/simulated/floor.dm
@@ -101,6 +101,7 @@
 
 /turf/open/floor/proc/update_icon()
 	update_visuals()
+		return 1
 	if(!..()
 		return 0
 	if(!broken && !burnt)

--- a/code/game/turfs/simulated/floor.dm
+++ b/code/game/turfs/simulated/floor.dm
@@ -100,6 +100,7 @@
 	return
 
 /turf/open/floor/proc/update_icon()
+	..()
 	if(!update_visuals())
 		return 0
 	if(!broken && !burnt)

--- a/code/game/turfs/simulated/floor.dm
+++ b/code/game/turfs/simulated/floor.dm
@@ -102,8 +102,6 @@
 /turf/open/floor/proc/update_icon()
 	..()
 	update_visuals()
-	if(!..())
-		return 0
 	if(!broken && !burnt)
 		if( !(icon_state in icons) )
 			icon_state = initial(icon_state)

--- a/code/game/turfs/simulated/floor.dm
+++ b/code/game/turfs/simulated/floor.dm
@@ -100,13 +100,14 @@
 	return
 
 /turf/open/floor/proc/update_icon()
+	..()
 	update_visuals()
-		return 1
 	if(!..())
 		return 0
 	if(!broken && !burnt)
 		if( !(icon_state in icons) )
 			icon_state = initial(icon_state)
+	return 1
 
 /turf/open/floor/attack_paw(mob/user)
 	return attack_hand(user)

--- a/code/game/turfs/simulated/floor.dm
+++ b/code/game/turfs/simulated/floor.dm
@@ -100,7 +100,8 @@
 	return
 
 /turf/open/floor/proc/update_icon()
-	..()
+	if(!..())
+		return 0
 	update_visuals()
 	if(!broken && !burnt)
 		if( !(icon_state in icons) )

--- a/code/game/turfs/simulated/floor.dm
+++ b/code/game/turfs/simulated/floor.dm
@@ -100,13 +100,13 @@
 	return
 
 /turf/open/floor/proc/update_icon()
-	update_visuals()
-	return 1
 	if(!update_visuals())
 		return 0
 	if(!broken && !burnt)
 		if( !(icon_state in icons) )
 			icon_state = initial(icon_state)
+	update_visuals()
+	return 1
 
 /turf/open/floor/attack_paw(mob/user)
 	return attack_hand(user)

--- a/code/game/turfs/simulated/floor/f13_floors.dm
+++ b/code/game/turfs/simulated/floor/f13_floors.dm
@@ -7,16 +7,16 @@
 */
 
 /turf/open/floor/plating/f13/outside
-
-/turf/open/floor/plating/f13
-	gender = PLURAL
 	name = "\proper desert"
-	baseturfs = /turf/open/floor/plating/f13
 	icon_state = "wasteland1"
 	icon = 'icons/turf/f13desert.dmi'
-	attachment_holes = FALSE
 	light_range = 3
 	light_power = 0.75
+
+/turf/open/floor/plating/f13 // don't use this for anything, /f13/ is essentially just the new /unsimulated/ but for planets and should probably be phased out entirely everywhere
+	gender = PLURAL
+	baseturfs = /turf/open/floor/plating/f13
+	attachment_holes = FALSE
 	planetary_atmos = TRUE
 
 /* so we can't break this */

--- a/code/game/turfs/simulated/floor/f13_floors.dm
+++ b/code/game/turfs/simulated/floor/f13_floors.dm
@@ -7,19 +7,13 @@
 */
 
 /turf/open/floor/plating/f13/outside
-	icon = 'icons/turf/f13desert.dmi'
-	icon_state = "wasteland1"
-	light_range = 3
-	light_power = 0.75
-	planetary_atmos = TRUE
 
 /turf/open/floor/plating/f13
 	gender = PLURAL
 	name = "\proper desert"
-	baseturfs = /turf/open/floor/plating/f13/outside
-	icon = 'icons/turf/f13desert.dmi'
+	baseturfs = /turf/open/floor/plating/f13
 	icon_state = "wasteland1"
-	icon_plating = "wasteland1"
+	icon = 'icons/turf/f13desert.dmi'
 	attachment_holes = FALSE
 	light_range = 3
 	light_power = 0.75
@@ -52,7 +46,6 @@
 	name = "\proper desert"
 	desc = "A stretch of desert."
 	icon = 'icons/turf/f13desert.dmi'
-	icon_state = "wasteland1"
 	var/obj/structure/flora/turfPlant = null
 	//light_color = LIGHT_COLOR_LAVA
 	slowdown = 2
@@ -66,6 +59,9 @@
 	//var/obj/dugpit/ground/mypit
 	//var/unburylevel = 0
 
+/turf/open/floor/plating/f13/outside/desert/New()
+	..()
+	icon_state = "wasteland[rand(1,31)]"
 
 /turf/open/floor/plating/f13/outside/desert/Initialize()
 	. = ..()
@@ -109,11 +105,6 @@
 	if(turfPlant)
 		qdel(turfPlant)
 	. =  ..()
-
-
-/turf/open/floor/plating/f13/outside/desert/New()
-	..()
-	icon_state = "wasteland[rand(1,31)]"
 
 /turf/open/floor/plating/f13/outside/road
 	name = "\proper road"

--- a/code/game/turfs/simulated/floor/f13_floors.dm
+++ b/code/game/turfs/simulated/floor/f13_floors.dm
@@ -7,7 +7,8 @@
 */
 
 /turf/open/floor/plating/f13/outside
-	name = "\proper desert"
+	name = "What the fuck mappers? why is this here"
+	desc = "If found, scream at the github repo about this"
 	icon_state = "wasteland1"
 	icon = 'icons/turf/f13desert.dmi'
 	light_range = 3

--- a/code/game/turfs/simulated/floor/f13_floors.dm
+++ b/code/game/turfs/simulated/floor/f13_floors.dm
@@ -59,12 +59,9 @@
 	//var/obj/dugpit/ground/mypit
 	//var/unburylevel = 0
 
-/turf/open/floor/plating/f13/outside/desert/New()
-	..()
-	icon_state = "wasteland[rand(1,31)]"
-
 /turf/open/floor/plating/f13/outside/desert/Initialize()
 	. = ..()
+	icon_state = "wasteland[rand(1,31)]"
 	//If no fences, machines (soil patches are machines), etc. try to plant grass
 	if(!(\
 			(locate(/obj/structure) in src) || \

--- a/code/game/turfs/simulated/floor/mineral_floor.dm
+++ b/code/game/turfs/simulated/floor/mineral_floor.dm
@@ -12,7 +12,6 @@
 /turf/open/floor/mineral
 	name = "mineral floor"
 	icon_state = ""
-	var/list/icons
 
 
 

--- a/code/game/turfs/simulated/floor/mineral_floor.dm
+++ b/code/game/turfs/simulated/floor/mineral_floor.dm
@@ -21,14 +21,6 @@
 	if (!icons)
 		icons = list()
 
-
-/turf/open/floor/mineral/update_icon()
-	if(!..())
-		return 0
-	if(!broken && !burnt)
-		if( !(icon_state in icons) )
-			icon_state = initial(icon_state)
-
 //PLASMA
 
 /turf/open/floor/mineral/plasma

--- a/code/game/turfs/simulated/floor/plasteel_floor.dm
+++ b/code/game/turfs/simulated/floor/plasteel_floor.dm
@@ -8,13 +8,6 @@
 	..()
 	to_chat(user, "<span class='notice'>There's a <b>small crack</b> on the edge of it.</span>")
 
-/turf/open/floor/plasteel/update_icon()
-	if(!..())
-		return 0
-	if(!broken && !burnt)
-		icon_state = icon_regular_floor
-
-
 /turf/open/floor/plasteel/airless
 	initial_gas_mix = "TEMP=2.7"
 


### PR DESCRIPTION
Refactoring and some cleanup as well.

Problems: Automatically reconfigures the underlying turf every time you crowbar up the tile, leading to a property where it resets the icon_state of the desert or road underneath.

In the former it sets it to something random and can even spawn grasses or, if random wildplants are added, could force them to spawn/despawn.

In the latter it sets icon_state =outermiddle.

This is caused because adding tiles literally transforms the turf into a completely different turf.

It is less of an obnoxious issue than a random purple-and-pink tile that crops every time you put floor tile down but still A Problem.

![image](https://user-images.githubusercontent.com/7409796/49042308-a61da700-f17c-11e8-931a-8f6d8d3df889.png)
