### PR TITLE
Solar panel fix

### DIFF
--- a/code/modules/food_and_drinks/food/snacks_meat.dm
+++ b/code/modules/food_and_drinks/food/snacks_meat.dm
@@ -19,7 +19,7 @@
 	name = "carp fillet"
 	desc = "A fillet of spess carp meat."
 	icon_state = "fishfillet"
-	list_reagents = list("nutriment" = 3, "carpotoxin" = 2, "vitamin" = 2)
+	list_reagents = list("nutriment" = 3, "carpotoxin" = 5, "vitamin" = 2)
 	bitesize = 6
 	filling_color = "#FA8072"
 	tastes = list("fish" = 1)

--- a/code/modules/food_and_drinks/food/snacks_meat.dm
+++ b/code/modules/food_and_drinks/food/snacks_meat.dm
@@ -19,7 +19,7 @@
 	name = "carp fillet"
 	desc = "A fillet of spess carp meat."
 	icon_state = "fishfillet"
-	list_reagents = list("nutriment" = 3, "carpotoxin" = 5, "vitamin" = 2)
+	list_reagents = list("nutriment" = 3, "carpotoxin" = 2, "vitamin" = 2)
 	bitesize = 6
 	filling_color = "#FA8072"
 	tastes = list("fish" = 1)

--- a/code/modules/power/solar.dm
+++ b/code/modules/power/solar.dm
@@ -154,7 +154,7 @@
 	var/dx = SSsun.dx
 	var/dy = SSsun.dy
 
-	for(var/i = 1 to 20)		// 20 steps is enough
+	for(var/i = 1 to 5)		// 5 steps is enough
 		ax += dx	// do step
 		ay += dy
 


### PR DESCRIPTION

## Description
Currently, solar panels do not function as intended in most areas of the map. This is because the code that checks to see if the panel is obstructed checks out a whopping 20 squares of the map. I have lowered this value to 5, to reflect our more compact and lively map. This should allow solar panels to be used much more effectively, while still requiring that they be placed in an open area.

## How Has This Been Tested?
Tested on private server. Functions as intended.
