### PR TITLE
Bodies disintegrate under excessive damage

### DIFF
--- a/code/modules/mob/death.dm
+++ b/code/modules/mob/death.dm
@@ -9,5 +9,10 @@
 /mob/proc/dust()
 	return
 
+//Proc for bodies liquifying.
+//I don't know why everything is so split up like this, it's horrible, but the bulk of these three procs is buried in mob/living/death.
+/mob/proc/liquefy()
+	return
+
 /mob/proc/death(gibbed)
 	return

--- a/code/modules/mob/living/carbon/carbon.dm
+++ b/code/modules/mob/living/carbon/carbon.dm
@@ -512,8 +512,15 @@
 	health = maxHealth - getOxyLoss() - getToxLoss() - getCloneLoss() - total_burn - total_brute
 	staminaloss = total_stamina
 	update_stat()
-	if(((maxHealth - total_burn) < HEALTH_THRESHOLD_DEAD) && stat == DEAD )
-		become_husk("burn")
+	if(stat == DEAD)
+		if((maxHealth - total_burn) < HEALTH_THRESHOLD_DEAD)
+			become_husk("burn")
+		if(total_burn >= 400)
+			dust(drop_items = TRUE)
+		if(toxloss >= 199)
+			liquefy()
+		if(total_brute >= 400)
+			gib()
 	med_hud_set_health()
 
 /mob/living/carbon/update_sight()

--- a/code/modules/mob/living/death.dm
+++ b/code/modules/mob/living/death.dm
@@ -45,6 +45,17 @@
 /mob/living/proc/spawn_dust(just_ash = FALSE)
 	new /obj/effect/decal/cleanable/ash(loc)
 
+/mob/living/liquefy(drop_items = TRUE)
+	death(TRUE)
+
+	if(drop_items)
+		unequip_everything()
+
+	if(buckled)
+		buckled.unbuckle_mob(src,force=1)
+
+	new /obj/effect/decal/cleanable/molten_object/large(loc)
+	qdel(src)
 
 /mob/living/death(gibbed)
 	stat = DEAD

--- a/code/modules/surgery/bodyparts/bodyparts.dm
+++ b/code/modules/surgery/bodyparts/bodyparts.dm
@@ -115,7 +115,6 @@
 		I.forceMove(T)
 
 //Applies brute and burn damage to the organ. Returns 1 if the damage-icon states changed at all.
-//Damage will not exceed max_damage using this proc
 //Cannot apply negative damage
 /obj/item/bodypart/proc/receive_damage(brute = 0, burn = 0, stamina = 0, updating_health = TRUE)
 	if(owner && (owner.status_flags & GODMODE))
@@ -135,17 +134,6 @@
 	switch(animal_origin)
 		if(ALIEN_BODYPART,LARVA_BODYPART) //aliens take double burn
 			burn *= 2
-
-	var/can_inflict = max_damage - (brute_dam + burn_dam)
-	if(can_inflict <= 0)
-		return FALSE
-
-	var/total_damage = brute + burn
-
-	if(total_damage > can_inflict)
-		var/excess = total_damage - can_inflict
-		brute = brute * (excess / total_damage)
-		burn = burn * (excess / total_damage)
 
 	brute_dam += brute
 	burn_dam += burn


### PR DESCRIPTION
After taking an excessive amount of burn, brute, or toxin damage, your body will be destroyed in a variety of methods.

Bodyparts can now take a hideous amount of damage as part of the update instead of arbitrarily capping.

Bodyparts causing their owner to die because you inflicted 1000 points of damage to the foot is Not A Thing Anymore, due to limbs being sawn off when you hit them enough.

[Not Recommended]: It seems like you might actually be able to increase a person's current health by taking off injured limbs, thus buying them more time in critical condition.