### PR TITLE
Medx will no longer provide infinitely lasting IGNORE_SLOWDOWN

### DIFF
--- a/code/modules/reagents/chemistry/reagents/medicine_reagents.dm
+++ b/code/modules/reagents/chemistry/reagents/medicine_reagents.dm
@@ -1335,13 +1335,13 @@
 	overdose_threshold = 30
 	addiction_threshold = 20
 
-/datum/reagent/medicine/medx/on_mob_add(mob/liing/M)
+/datum/reagent/medicine/medx/on_mob_add(mob/M)
 	..()
 	if(isliving(M))
 		var/mob/living/L = M
 		L.add_trait(TRAIT_IGNORESLOWDOWN, id)
 
-/datum/reagent/medicine/medx/on_mob_delete(mob/living/M)
+/datum/reagent/medicine/medx/on_mob_delete(mob/M)
 	if(isliving(M))
 		var/mob/living/L = M
 		L.remove_trait(TRAIT_IGNORESLOWDOWN, id)

--- a/code/modules/reagents/chemistry/reagents/medicine_reagents.dm
+++ b/code/modules/reagents/chemistry/reagents/medicine_reagents.dm
@@ -1335,11 +1335,22 @@
 	overdose_threshold = 30
 	addiction_threshold = 20
 
+/datum/reagent/medicine/medx/on_mob_add(mob/liing/M)
+	..()
+	if(isliving(M))
+		var/mob/living/L = M
+		L.add_trait(TRAIT_IGNORESLOWDOWN, id)
+
+/datum/reagent/medicine/medx/on_mob_delete(mob/living/M)
+	if(isliving(M))
+		var/mob/living/L = M
+		L.remove_trait(TRAIT_IGNORESLOWDOWN, id)
+	..()
+
 /datum/reagent/medicine/medx/on_mob_life(mob/living/M)
 	if(iscarbon(M))
 		var/mob/living/carbon/N = M
 		N.hal_screwyhud = SCREWYHUD_HEALTHY
-		N.add_trait(TRAIT_IGNORESLOWDOWN, id)
 	M.AdjustStun(-30, 0)
 	M.AdjustKnockdown(-30, 0)
 	M.AdjustUnconscious(-30, 0)


### PR DESCRIPTION
<!-- Thanks for choosing to take the time to contribute to our project! We have a few things below that we'd like you to fill out -->
<!-- The more detail you can give us, the faster we can code review, test, and merge your changes -->

<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
Medx will no longer provide literally infinite ignoring slowdown trait until death
## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Cause it fixes a thing that gives major combat buffs
## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- This helps us replicate your tests, to speed up review. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->
Not tested but copied code off of morphine
## Screenshots (if appropriate):
