### PR TITLE
Conveyors and Cameras Updates

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -199,3 +199,4 @@ tools/MapAtmosFixer/MapAtmosFixer/bin/*
 
 #GitHub Atom
 .atom-build.json
+*.class

--- a/code/game/machinery/camera/camera_assembly.dm
+++ b/code/game/machinery/camera/camera_assembly.dm
@@ -17,6 +17,7 @@
 	var/static/list/possible_upgrades = typecacheof(list(/obj/item/assembly/prox_sensor, /obj/item/stack/sheet/mineral/plasma, /obj/item/analyzer))
 	var/list/upgrades
 	var/state = 1
+	var/c_tag
 
 	/*
 			1 = Wrenched in place
@@ -109,7 +110,11 @@
 
 	C.network = tempnetwork
 	var/area/A = get_area(src)
-	C.c_tag = "[A.name] ([rand(1, 999)])"
+	var/name_input = stripped_input(user, "What would you like to name this camera? ", "Set Name", "")
+	if(name_input)
+		C.c_tag = name_input
+	else
+		C.c_tag = "[A.name] ([rand(1, 999)])"
 	return TRUE
 
 /obj/structure/camera_assembly/wirecutter_act(mob/user, obj/item/I)

--- a/code/modules/recycling/conveyor2.dm
+++ b/code/modules/recycling/conveyor2.dm
@@ -359,11 +359,17 @@ GLOBAL_LIST_EMPTY(conveyors_by_id)
 	icon = 'icons/obj/recycling.dmi'
 	icon_state = "switch-off"
 	w_class = WEIGHT_CLASS_BULKY
+	var/oneway = FALSE
 	var/id = "" //inherited by the switch
 
 /obj/item/conveyor_switch_construct/Initialize()
 	. = ..()
 	id = "[rand()]" //this couldn't possibly go wrong
+
+/obj/item/conveyor_switch_construct/attackby(obj/item/I, mob/user, params)
+	if(istype(I, /obj/item/multitool))
+		to_chat(user, "<span class='notice'>You set [src] to one direction mode.</span>")
+		oneway = TRUE
 
 /obj/item/conveyor_switch_construct/afterattack(atom/A, mob/user, proximity)
 	if(!proximity || user.stat || !isfloorturf(A) || istype(A, /area/shuttle))
@@ -376,7 +382,11 @@ GLOBAL_LIST_EMPTY(conveyors_by_id)
 	if(!found)
 		to_chat(user, "[icon2html(src, user)]<span class=notice>The conveyor switch did not detect any linked conveyor belts in range.</span>")
 		return
-	var/obj/machinery/conveyor_switch/NC = new/obj/machinery/conveyor_switch(A, id)
+	var/obj/machinery/conveyor_switch/oneway/NC
+	if(oneway)
+		NC = new/obj/machinery/conveyor_switch/oneway(A, id)
+	else
+		NC = new/obj/machinery/conveyor_switch(A, id)
 	transfer_fingerprints_to(NC)
 	qdel(src)
 


### PR DESCRIPTION
Adds: 
 - Tap conveyor switch with multitool before placing to place it in oneway mode!
 - Camera building now asks for a name to title the camera as when you're finishing