### PR TITLE
Fixes purple icons (again)

### DIFF
--- a/code/game/turfs/simulated/floor.dm
+++ b/code/game/turfs/simulated/floor.dm
@@ -20,7 +20,6 @@
 	icon_state = ""
 
 /turf/open/floor/Initialize(mapload)
-	broken_states = list("[initial(icon_state)]_dam")
 	if (!broken_states)
 		broken_states = list("damaged1", "damaged2", "damaged3", "damaged4", "damaged5")
 	if (!burnt_states)

--- a/code/game/turfs/simulated/floor/mineral_floor.dm
+++ b/code/game/turfs/simulated/floor/mineral_floor.dm
@@ -13,6 +13,14 @@
 	name = "mineral floor"
 	icon_state = ""
 
+
+
+/turf/open/floor/mineral/Initialize()
+	broken_states = list("[initial(icon_state)]_dam")
+	. = ..()
+	if (!icons)
+		icons = list()
+
 //PLASMA
 
 /turf/open/floor/mineral/plasma

--- a/code/game/turfs/simulated/floor/mineral_floor.dm
+++ b/code/game/turfs/simulated/floor/mineral_floor.dm
@@ -13,14 +13,6 @@
 	name = "mineral floor"
 	icon_state = ""
 
-
-
-/turf/open/floor/mineral/Initialize()
-	broken_states = list("[initial(icon_state)]_dam")
-	. = ..()
-	if (!icons)
-		icons = list()
-
 //PLASMA
 
 /turf/open/floor/mineral/plasma


### PR DESCRIPTION
Makes it so it properly generates icon-states of damaged, etc, instead of pointing at the wrong icon file.

![image](https://user-images.githubusercontent.com/7409796/50371524-56f74600-0571-11e9-9916-baafcbf5aa3c.png)