### PR TITLE
Fix for loot spawning outside of closets, crates

### DIFF
--- a/code/game/objects/structures/crates_lockers/closets.dm
+++ b/code/game/objects/structures/crates_lockers/closets.dm
@@ -40,7 +40,8 @@
 	update_icon()
 	PopulateContents()
 	if(mapload && !opened) //now takes it first because timery thingies does not work with these
-		take_contents()
+		spawn(0)
+			take_contents()
 
 //USE THIS TO FILL IT, NOT INITIALIZE OR NEW
 /obj/structure/closet/proc/PopulateContents()


### PR DESCRIPTION
## Description
Crates and closets now wait for other objects to spawn before trying to move them to their contents.

## Motivation and Context
Makes it so that randomized loot spawns inside of containers instead of on top of them.

## How Has This Been Tested?
Randomized loot now spawns inside of containers properly.
Compared initialization times before and after the change, noticed no discrepancy.

