### PR TITLE
Rangemaster & Remington ammo intercompatibility

### DIFF
--- a/code/modules/projectiles/boxes_magazines/ammo_boxes.dm
+++ b/code/modules/projectiles/boxes_magazines/ammo_boxes.dm
@@ -91,7 +91,7 @@
 	name = "lowpower double stacked stripper clip (7.62mm)"
 	desc = "A 762 lowpower stripper."
 	icon_state = "762a"
-	ammo_type = /obj/item/ammo_casing/a762lp
+	ammo_type = /obj/item/ammo_casing/a762/lp
 	max_ammo = 10
 	multiple_sprites = 1
 	materials = list(MAT_METAL = 10000)

--- a/code/modules/projectiles/boxes_magazines/internal/rifle.dm
+++ b/code/modules/projectiles/boxes_magazines/internal/rifle.dm
@@ -15,8 +15,8 @@
 
 //Fallout 13
 /obj/item/ammo_box/magazine/internal/rangemaster
-	ammo_type = /obj/item/ammo_casing/a762lp
-	caliber = "a762lp"
+	ammo_type = /obj/item/ammo_casing/a762
+	caliber = "a762"
 	max_ammo = 10
 	multiload = 1
 

--- a/code/modules/projectiles/guns/ballistic/automatic.dm
+++ b/code/modules/projectiles/guns/ballistic/automatic.dm
@@ -692,11 +692,11 @@
 	caliber = "357"
 	projectile_type = /obj/item/projectile/bullet/medbullet
 
-/obj/item/ammo_casing/a762lp
+/obj/item/ammo_casing/a762/lp
 	name = "7.62 lowpower bullet casing"
 	desc = "A 7.62 bullet casing."
 	icon_state = "762-casing"
-	caliber = "a762lp"
+	caliber = "a762"
 	projectile_type = /obj/item/projectile/bullet/medbullet
 
 //MedAP

--- a/code/modules/research/designs/autolathe_designs.dm
+++ b/code/modules/research/designs/autolathe_designs.dm
@@ -774,7 +774,7 @@
 	category = list("initial", "Security")
 
 /datum/design/doublestacked
-	name = "Rangermaster Stripper Clip (7.62mm)"
+	name = "Rangemaster Stripper Clip (7.62mm)"
 	id = "doublestacked"
 	build_type = AUTOLATHE
 	materials = list(MAT_METAL = 10000)


### PR DESCRIPTION
## Description
Both the Rangemaster and the Remington now accept normal 7.62 and lowpower 7.62 ammo.
Also fixed a spelling error in the autolathe for the Rangemaster.

## Motivation and Context
The NCR Patrol Ranger spawns with doublestacked 7.62 strips and a scoped Remington. Before this change, they were not able to reload their rifle. Instead of just making them spawn with normal clips, I decided to make it so that 7.62 rifles can accept ammo from both low-power 10-round clips and armor-piercing 5-round clips to give players the choice between carrying more ammo or dealing more damage per shot.
And no, this does not mean that the Remington now has a 10-round magazine, it only holds 5 bullets at a time no matter the clip you use to reload it.

## How Has This Been Tested?
Tested out both the Rangemaster and Remington rifles. They all accept ammo from both types of clips.
