### PR TITLE
Slot machine payout fix

### DIFF
--- a/code/game/machinery/slotmachine.dm
+++ b/code/game/machinery/slotmachine.dm
@@ -292,7 +292,7 @@
 
 /obj/machinery/computer/slot_machine/proc/give_money(amount)
 	var/amount_to_give = money >= amount ? amount : money
-	var/surplus = amount_to_give - give_coins(amount_to_give)
+	var/surplus = give_coins(amount_to_give)
 	money = max(0, money - amount)
 	balance += surplus
 


### PR DESCRIPTION
## Description
Removed some math that did the exact opposite of what should be done.

## Motivation and Context
The slot machine used to reward you twice when you get a payout: the first time by spawning caps, and the second time by giving the machine the same amount in its internal balance which can be withdrawn again.
Fix for #265 

## How Has This Been Tested?
Spent 10 minutes with 6 spawned slot machines until I got a payout. The slot machine did not get an extra payout in its internal balance.
