### PR TITLE
Changes the rules popup

### DIFF
--- a/config/config.txt
+++ b/config/config.txt
@@ -219,7 +219,7 @@ CHECK_RANDOMIZER
 # WIKIURL http://www.tgstation13.org/wiki
 
 ## Rules address
-RULESURL https://discord.gg/BAzDXnE
+RULESURL https://cdn.discordapp.com/attachments/523918729780789287/523957192790114306/unknown.png
 
 ## Github address
 GITHUBURL https://github.com/Digdugxx/TG-Claw


### PR DESCRIPTION
Changes the rules popup to a discord link for this 
![image](https://user-images.githubusercontent.com/7409796/50397344-9f0a9a00-0724-11e9-83bd-0a0f3c19080d.png)

until A. I can figure out how to make image popups work in byond/ss13 and B. Fox comes back from vacation to hand the file off.
