### PR TITLE
Update sprite_accessories.dm

### DIFF
--- a/code/modules/mob/dead/new_player/sprite_accessories.dm
+++ b/code/modules/mob/dead/new_player/sprite_accessories.dm
@@ -64,56 +64,194 @@
 //////////////////////
 // Hair Definitions //
 //////////////////////
+// Please try to ABC lists from now on.
+
 /datum/sprite_accessory/hair
 	icon = 'icons/mob/human_face.dmi'	  // default icon for all hairs
 
-/datum/sprite_accessory/hair/short
-	name = "Short Hair"	  // try to capatilize the names please~ // try to spell
-	icon_state = "hair_a" // you do not need to define _s or _l sub-states, game automatically does this for you
+/datum/sprite_accessory/hair/antenna
+	name = "Ahoge"
+	icon_state = "hair_antenna"
 
-/datum/sprite_accessory/hair/shorthair2
-	name = "Short Hair 2"
-	icon_state = "hair_shorthair2"
+/datum/sprite_accessory/hair/afro
+	name = "Afro"
+	icon_state = "hair_afro"
 
-/datum/sprite_accessory/hair/shorthair3
-	name = "Short Hair 3"
-	icon_state = "hair_shorthair3"
+/datum/sprite_accessory/hair/afro2
+	name = "Afro 2"
+	icon_state = "hair_afro2"
+
+/datum/sprite_accessory/hair/afro_large
+	name = "Big Afro"
+	icon_state = "hair_bigafro"
+
+/datum/sprite_accessory/hair/bald
+	name = "Bald"
+	icon_state = null
+
+/datum/sprite_accessory/hair/balding
+	name = "Balding Hair"
+	icon_state = "hair_e"
+
+/datum/sprite_accessory/hair/bedhead
+	name = "Bedhead"
+	icon_state = "hair_bedhead"
+
+/datum/sprite_accessory/hair/bedhead2
+	name = "Bedhead 2"
+	icon_state = "hair_bedheadv2"
+
+/datum/sprite_accessory/hair/bedhead3
+	name = "Bedhead 3"
+	icon_state = "hair_bedheadv3"
+
+/datum/sprite_accessory/hair/beehive
+	name = "Beehive"
+	icon_state = "hair_beehive"
+
+/datum/sprite_accessory/hair/beehive2
+	name = "Beehive 2"
+	icon_state = "hair_beehivev2"
+
+/datum/sprite_accessory/hair/bigflattop
+	name = "Big Flat Top"
+	icon_state = "hair_bigflattop"
+
+/datum/sprite_accessory/hair/bigpompadour
+	name = "Big Pompadour"
+	icon_state = "hair_bigpompadour"
+
+/datum/sprite_accessory/hair/bob
+	name = "Bob"
+	icon_state = "hair_bobcut"
+
+/datum/sprite_accessory/hair/bob1
+	name = "Bob Hair"
+	icon_state = "hair_bob"
+
+/datum/sprite_accessory/hair/bob2
+	name = "Bob Hair 2"
+	icon_state = "hair_bob2"
+
+/datum/sprite_accessory/hair/bobcurl
+	name = "Bobcurl"
+	icon_state = "hair_bobcurl"
+
+/datum/sprite_accessory/hair/bowl
+	name = "Bowl"
+	icon_state = "hair_bowlcut"
+
+/datum/sprite_accessory/hair/braided
+	name = "Braided"
+	icon_state = "hair_braided"
+
+/datum/sprite_accessory/hair/braidtail
+	name = "Braided Tail"
+	icon_state = "hair_braidtail"
+
+/datum/sprite_accessory/hair/floorlength_braid
+	name = "Floorlength Braid"
+	icon_state = "hair_braid"
+
+/datum/sprite_accessory/hair/not_floorlength_braid
+	name = "High Braid"
+	icon_state = "hair_braid2"
+
+/datum/sprite_accessory/hair/shortbraid
+	name = "Short Braid"
+	icon_state = "hair_shortbraid"
+
+/datum/sprite_accessory/hair/bun
+	name = "Bun Head"
+	icon_state = "hair_bun"
+
+/datum/sprite_accessory/hair/bun2
+	name = "Bun Head 2"
+	icon_state = "hair_bunhead2"
+
+/datum/sprite_accessory/hair/largebun
+	name = "Large Bun"
+	icon_state = "hair_largebun"
+
+/datum/sprite_accessory/hair/business
+	name = "Business Hair"
+	icon_state = "hair_business"
+
+/datum/sprite_accessory/hair/business2
+	name = "Business Hair 2"
+	icon_state = "hair_business2"
+
+/datum/sprite_accessory/hair/business3
+	name = "Business Hair 3"
+	icon_state = "hair_business3"
+
+/datum/sprite_accessory/hair/business4
+	name = "Business Hair 4"
+	icon_state = "hair_business4"
+
+/datum/sprite_accessory/hair/buzz
+	name = "Buzzcut"
+	icon_state = "hair_buzzcut"
+
+/datum/sprite_accessory/hair/combover
+	name = "Combover"
+	icon_state = "hair_combover"
+
+/datum/sprite_accessory/hair/crew
+	name = "Crewcut"
+	icon_state = "hair_crewcut"
+
+/datum/sprite_accessory/hair/curls
+	name = "Curls"
+	icon_state = "hair_curls"
 
 /datum/sprite_accessory/hair/cut
 	name = "Cut Hair"
 	icon_state = "hair_c"
 
-/datum/sprite_accessory/hair/long
-	name = "Shoulder-length Hair"
-	icon_state = "hair_b"
+/datum/sprite_accessory/hair/leftsidecut
+	name = "Left Side Cut"
+	icon_state = "hair_leftside"
 
-/datum/sprite_accessory/hair/longer
-	name = "Long Hair"
-	icon_state = "hair_vlong"
+/datum/sprite_accessory/hair/rightsidecut
+	name = "Right Side Cut"
+	icon_state = "hair_rightside"
 
-/datum/sprite_accessory/hair/over_eye
-	name = "Over Eye"
-	icon_state = "hair_shortovereye"
+/datum/sprite_accessory/hair/devillock
+	name = "Devil Lock"
+	icon_state = "hair_devilock"
 
-/datum/sprite_accessory/hair/long_over_eye
-	name = "Long Over Eye"
-	icon_state = "hair_longovereye"
+/datum/sprite_accessory/hair/dreadlocks
+	name = "Dreadlocks"
+	icon_state = "hair_dreads"
 
-/datum/sprite_accessory/hair/longest2
-	name = "Very Long Over Eye"
-	icon_state = "hair_longest2"
+/datum/sprite_accessory/hair/drillhair
+	name = "Drill Hair"
+	icon_state = "hair_drillhair"
 
-/datum/sprite_accessory/hair/longest
-	name = "Very Long Hair"
-	icon_state = "hair_longest"
+/datum/sprite_accessory/hair/drillhairextended
+	name = "Extended Drill Hair"
+	icon_state = "hair_drillhairextended"
 
-/datum/sprite_accessory/hair/longfringe
-	name = "Long Fringe"
-	icon_state = "hair_longfringe"
+/datum/sprite_accessory/hair/emo
+	name = "Emo"
+	icon_state = "hair_emo"
 
-/datum/sprite_accessory/hair/longestalt
-	name = "Longer Fringe"
-	icon_state = "hair_vlongfringe"
+/datum/sprite_accessory/hair/fag
+	name = "Flow Hair"
+	icon_state = "hair_f"
+
+/datum/sprite_accessory/hair/feather
+	name = "Feather"
+	icon_state = "hair_feather"
+
+/datum/sprite_accessory/hair/front_braid
+	name = "Braided front"
+	icon_state = "hair_braidfront"
+
+/datum/sprite_accessory/hair/gelled
+	name = "Gelled Back"
+	icon_state = "hair_gelled"
 
 /datum/sprite_accessory/hair/gentle
 	name = "Gentle"
@@ -126,6 +264,158 @@
 /datum/sprite_accessory/hair/halfbang2
 	name = "Half-banged Hair 2"
 	icon_state = "hair_halfbang2"
+
+/datum/sprite_accessory/hair/halfshaved
+	name = "Half Shaved"
+	icon_state = "hair_halfshaved"
+
+/datum/sprite_accessory/hair/hedgehog
+	name = "Hedgehog Hair"
+	icon_state = "hair_hedgehog"
+
+/datum/sprite_accessory/hair/himecut
+	name = "Hime Cut"
+	icon_state = "hair_himecut"
+
+/datum/sprite_accessory/hair/himecut2
+	name = "Hime Cut 2"
+	icon_state = "hair_himecut2"
+
+/datum/sprite_accessory/hair/himeup
+	name = "Hime Updo"
+	icon_state = "hair_himeup"
+
+/datum/sprite_accessory/hair/hitop
+	name = "Hitop"
+	icon_state = "hair_hitop"
+
+/datum/sprite_accessory/hair/jensen
+	name = "Jensen Hair"
+	icon_state = "hair_jensen"
+
+/datum/sprite_accessory/hair/keanu
+	name = "Keanu Hair"
+	icon_state = "hair_keanu"
+
+/datum/sprite_accessory/hair/kusangi
+	name = "Kusanagi Hair"
+	icon_state = "hair_kusanagi"
+
+/datum/sprite_accessory/hair/long
+	name = "Shoulder-length Hair"
+	icon_state = "hair_b"
+
+/datum/sprite_accessory/hair/long1
+	name = "Long Hair 1"
+	icon_state = "hair_long"
+
+/datum/sprite_accessory/hair/long2
+	name = "Long Hair 2"
+	icon_state = "hair_long2"
+
+/datum/sprite_accessory/hair/long3
+	name = "Long Hair 3"
+	icon_state = "hair_long3"
+
+/datum/sprite_accessory/hair/long_over_eye
+	name = "Long Over Eye"
+	icon_state = "hair_longovereye"
+
+/datum/sprite_accessory/hair/longbangs
+	name = "Long Bangs"
+	icon_state = "hair_lbangs"
+
+/datum/sprite_accessory/hair/longemo
+	name = "Long Emo"
+	icon_state = "hair_longemo"
+
+/datum/sprite_accessory/hair/longfringe
+	name = "Long Fringe"
+	icon_state = "hair_longfringe"
+
+/datum/sprite_accessory/hair/longer
+	name = "Long Hair"
+	icon_state = "hair_vlong"
+
+/datum/sprite_accessory/hair/longest2
+	name = "Very Long Over Eye"
+	icon_state = "hair_longest2"
+
+/datum/sprite_accessory/hair/longest
+	name = "Very Long Hair"
+	icon_state = "hair_longest"
+
+/datum/sprite_accessory/hair/longestalt
+	name = "Longer Fringe"
+	icon_state = "hair_vlongfringe"
+
+/datum/sprite_accessory/hair/longsideemo
+	name = "Long Side Emo"
+	icon_state = "hair_longsideemo"
+
+/datum/sprite_accessory/hair/lowbraid
+	name = "Low Braid"
+	icon_state = "hair_hbraid"
+
+/datum/sprite_accessory/hair/megaeyebrows
+	name = "Mega Eyebrows"
+	icon_state = "hair_megaeyebrows"
+
+/datum/sprite_accessory/hair/messy
+	name = "Messy"
+	icon_state = "hair_messy"
+
+/datum/sprite_accessory/hair/mohawk
+	name = "Mohawk"
+	icon_state = "hair_d"
+
+/datum/sprite_accessory/hair/mohawk_reverse
+	name = "Reverse Mohawk"
+	icon_state = "hair_reversemohawk"
+
+/datum/sprite_accessory/hair/odango
+	name = "Odango"
+	icon_state = "hair_odango"
+
+/datum/sprite_accessory/hair/ombre
+	name = "Ombre"
+	icon_state = "hair_ombre"
+
+/datum/sprite_accessory/hair/oneshoulder
+	name = "One Shoulder"
+	icon_state = "hair_oneshoulder"
+
+/datum/sprite_accessory/hair/over_eye
+	name = "Over Eye"
+		icon_state = "hair_shortovereye"
+
+/datum/sprite_accessory/hair/parted
+	name = "Parted"
+	icon_state = "hair_parted"
+
+/datum/sprite_accessory/hair/side_parted
+	name = "Side Part"
+	icon_state = "hair_part"
+
+/datum/sprite_accessory/hair/kagami
+	name = "Pigtails"
+	icon_state = "hair_kagami"
+
+/datum/sprite_accessory/hair/pigtail2
+	name = "Pigtails 2"
+	icon_state = "hair_pigtails"
+
+/datum/sprite_accessory/hair/pigtail3
+	name = "Pigtails 3"
+	icon_state = "hair_pigtails2"
+
+/datum/sprite_accessory/hair/pixie
+	name = "Pixie Cut"
+	icon_state = "hair_pixie"
+
+/datum/sprite_accessory/hair/pompadour
+	name = "Pompadour"
+	icon_state = "hair_pompadour"
 
 /datum/sprite_accessory/hair/ponytail1
 	name = "Ponytail"
@@ -147,6 +437,34 @@
 	name = "Ponytail 5"
 	icon_state = "hair_ponytail5"
 
+/datum/sprite_accessory/hair/highponytail
+	name = "High Ponytail"
+	icon_state = "hair_highponytail"
+
+/datum/sprite_accessory/hair/longponytail
+	name = "Long Ponytail"
+	icon_state = "hair_longstraightponytail"
+
+
+/datum/sprite_accessory/hair/protagonist
+	name = "Slightly Long"
+	icon_state = "hair_protagonist"
+
+/datum/sprite_accessory/hair/quiff
+	name = "Quiff"
+	icon_state = "hair_quiff"
+
+/datum/sprite_accessory/hair/sargeant
+	name = "Flat Top"
+	icon_state = "hair_sargeant"
+
+/datum/sprite_accessory/hair/sidecut
+	name = "Sidecut"
+	icon_state = "hair_sidecut"
+
+/datum/sprite_accessory/hair/sidepartlongalt
+	name = "Long Side Part"
+	icon_state = "hair_longsidepart"
 
 /datum/sprite_accessory/hair/sidetail
 	name = "Side Pony"
@@ -164,145 +482,21 @@
 	name = "Side Pony 4"
 	icon_state = "hair_sidetail4"
 
-/datum/sprite_accessory/hair/oneshoulder
-	name = "One Shoulder"
-	icon_state = "hair_oneshoulder"
+/datum/sprite_accessory/hair/short
+	name = "Short Hair"	  // try to capatilize the names please~ // try to spell
+	icon_state = "hair_a" // you do not need to define _s or _l sub-states, game automatically does this for you
 
-/datum/sprite_accessory/hair/tressshoulder
-	name = "Tress Shoulder"
-	icon_state = "hair_tressshoulder"
+/datum/sprite_accessory/hair/shorthair2
+	name = "Short Hair 2"
+	icon_state = "hair_shorthair2"
 
-/datum/sprite_accessory/hair/parted
-	name = "Parted"
-	icon_state = "hair_parted"
+/datum/sprite_accessory/hair/shorthair3
+	name = "Short Hair 3"
+	icon_state = "hair_shorthair3"
 
-/datum/sprite_accessory/hair/pompadour
-	name = "Pompadour"
-	icon_state = "hair_pompadour"
-
-/datum/sprite_accessory/hair/bigpompadour
-	name = "Big Pompadour"
-	icon_state = "hair_bigpompadour"
-
-/datum/sprite_accessory/hair/quiff
-	name = "Quiff"
-	icon_state = "hair_quiff"
-
-/datum/sprite_accessory/hair/bedhead
-	name = "Bedhead"
-	icon_state = "hair_bedhead"
-
-/datum/sprite_accessory/hair/bedhead2
-	name = "Bedhead 2"
-	icon_state = "hair_bedheadv2"
-
-/datum/sprite_accessory/hair/bedhead3
-	name = "Bedhead 3"
-	icon_state = "hair_bedheadv3"
-
-/datum/sprite_accessory/hair/messy
-	name = "Messy"
-	icon_state = "hair_messy"
-
-/datum/sprite_accessory/hair/beehive
-	name = "Beehive"
-	icon_state = "hair_beehive"
-
-/datum/sprite_accessory/hair/beehive2
-	name = "Beehive 2"
-	icon_state = "hair_beehivev2"
-
-/datum/sprite_accessory/hair/bobcurl
-	name = "Bobcurl"
-	icon_state = "hair_bobcurl"
-
-/datum/sprite_accessory/hair/bob
-	name = "Bob"
-	icon_state = "hair_bobcut"
-
-/datum/sprite_accessory/hair/bowl
-	name = "Bowl"
-	icon_state = "hair_bowlcut"
-
-/datum/sprite_accessory/hair/buzz
-	name = "Buzzcut"
-	icon_state = "hair_buzzcut"
-
-/datum/sprite_accessory/hair/crew
-	name = "Crewcut"
-	icon_state = "hair_crewcut"
-
-/datum/sprite_accessory/hair/combover
-	name = "Combover"
-	icon_state = "hair_combover"
-
-/datum/sprite_accessory/hair/devillock
-	name = "Devil Lock"
-	icon_state = "hair_devilock"
-
-/datum/sprite_accessory/hair/drillhairextended
-	name = "Extended Drill Hair"
-	icon_state = "hair_drillhairextended"
-
-/datum/sprite_accessory/hair/dreadlocks
-	name = "Dreadlocks"
-	icon_state = "hair_dreads"
-
-/datum/sprite_accessory/hair/curls
-	name = "Curls"
-	icon_state = "hair_curls"
-
-/datum/sprite_accessory/hair/afro
-	name = "Afro"
-	icon_state = "hair_afro"
-
-/datum/sprite_accessory/hair/afro2
-	name = "Afro 2"
-	icon_state = "hair_afro2"
-
-/datum/sprite_accessory/hair/afro_large
-	name = "Big Afro"
-	icon_state = "hair_bigafro"
-
-/datum/sprite_accessory/hair/sargeant
-	name = "Flat Top"
-	icon_state = "hair_sargeant"
-
-/datum/sprite_accessory/hair/emo
-	name = "Emo"
-	icon_state = "hair_emo"
-
-/datum/sprite_accessory/hair/longemo
-	name = "Long Emo"
-	icon_state = "hair_longemo"
-
-/datum/sprite_accessory/hair/fag
-	name = "Flow Hair"
-	icon_state = "hair_f"
-
-/datum/sprite_accessory/hair/feather
-	name = "Feather"
-	icon_state = "hair_feather"
-
-/datum/sprite_accessory/hair/hitop
-	name = "Hitop"
-	icon_state = "hair_hitop"
-
-/datum/sprite_accessory/hair/mohawk
-	name = "Mohawk"
-	icon_state = "hair_d"
-
-/datum/sprite_accessory/hair/reversemohawk
-	name = "Reverse Mohawk"
-	icon_state = "hair_reversemohawk"
-
-/datum/sprite_accessory/hair/jensen
-	name = "Jensen Hair"
-	icon_state = "hair_jensen"
-
-/datum/sprite_accessory/hair/gelled
-	name = "Gelled Back"
-	icon_state = "hair_gelled"
+/datum/sprite_accessory/hair/skinhead
+	name = "Skinhead"
+	icon_state = "hair_skinhead"
 
 /datum/sprite_accessory/hair/spiky
 	name = "Spiky"
@@ -316,122 +510,6 @@
 	name = "Spiky 3"
 	icon_state = "hair_spiky2"
 
-/datum/sprite_accessory/hair/protagonist
-	name = "Slightly Long"
-	icon_state = "hair_protagonist"
-
-/datum/sprite_accessory/hair/kusangi
-	name = "Kusanagi Hair"
-	icon_state = "hair_kusanagi"
-
-/datum/sprite_accessory/hair/kagami
-	name = "Pigtails"
-	icon_state = "hair_kagami"
-
-/datum/sprite_accessory/hair/pigtail
-	name = "Pigtails 2"
-	icon_state = "hair_pigtails"
-
-/datum/sprite_accessory/hair/pigtail
-	name = "Pigtails 3"
-	icon_state = "hair_pigtails2"
-
-/datum/sprite_accessory/hair/himecut
-	name = "Hime Cut"
-	icon_state = "hair_himecut"
-
-/datum/sprite_accessory/hair/himecut2
-	name = "Hime Cut 2"
-	icon_state = "hair_himecut2"
-
-/datum/sprite_accessory/hair/himeup
-	name = "Hime Updo"
-	icon_state = "hair_himeup"
-
-/datum/sprite_accessory/hair/antenna
-	name = "Ahoge"
-	icon_state = "hair_antenna"
-
-/datum/sprite_accessory/hair/front_braid
-	name = "Braided front"
-	icon_state = "hair_braidfront"
-
-/datum/sprite_accessory/hair/lowbraid
-	name = "Low Braid"
-	icon_state = "hair_hbraid"
-
-/datum/sprite_accessory/hair/not_floorlength_braid
-	name = "High Braid"
-	icon_state = "hair_braid2"
-
-/datum/sprite_accessory/hair/shortbraid
-	name = "Short Braid"
-	icon_state = "hair_shortbraid"
-
-/datum/sprite_accessory/hair/braid
-	name = "Floorlength Braid"
-	icon_state = "hair_braid"
-
-/datum/sprite_accessory/hair/odango
-	name = "Odango"
-	icon_state = "hair_odango"
-
-/datum/sprite_accessory/hair/ombre
-	name = "Ombre"
-	icon_state = "hair_ombre"
-
-/datum/sprite_accessory/hair/updo
-	name = "Updo"
-	icon_state = "hair_updo"
-
-/datum/sprite_accessory/hair/skinhead
-	name = "Skinhead"
-	icon_state = "hair_skinhead"
-
-/datum/sprite_accessory/hair/longbangs
-	name = "Long Bangs"
-	icon_state = "hair_lbangs"
-
-/datum/sprite_accessory/hair/balding
-	name = "Balding Hair"
-	icon_state = "hair_e"
-
-/datum/sprite_accessory/hair/bald
-	name = "Bald"
-	icon_state = null
-
-/datum/sprite_accessory/hair/parted
-	name = "Side Part"
-	icon_state = "hair_part"
-
-/datum/sprite_accessory/hair/braided
-	name = "Braided"
-	icon_state = "hair_braided"
-
-/datum/sprite_accessory/hair/bun
-	name = "Bun Head"
-	icon_state = "hair_bun"
-
-/datum/sprite_accessory/hair/bun2
-	name = "Bun Head 2"
-	icon_state = "hair_bunhead2"
-
-/datum/sprite_accessory/hair/braidtail
-	name = "Braided Tail"
-	icon_state = "hair_braidtail"
-
-/datum/sprite_accessory/hair/bigflattop
-	name = "Big Flat Top"
-	icon_state = "hair_bigflattop"
-
-/datum/sprite_accessory/hair/drillhair
-	name = "Drill Hair"
-	icon_state = "hair_drillhair"
-
-/datum/sprite_accessory/hair/keanu
-	name = "Keanu Hair"
-	icon_state = "hair_keanu"
-
 /datum/sprite_accessory/hair/swept
 	name = "Swept Back Hair"
 	icon_state = "hair_swept"
@@ -440,97 +518,13 @@
 	name = "Swept Back Hair 2"
 	icon_state = "hair_swept2"
 
-/datum/sprite_accessory/hair/business
-	name = "Business Hair"
-	icon_state = "hair_business"
+/datum/sprite_accessory/hair/tressshoulder
+	name = "Tress Shoulder"
+	icon_state = "hair_tressshoulder"
 
-/datum/sprite_accessory/hair/business2
-	name = "Business Hair 2"
-	icon_state = "hair_business2"
-
-/datum/sprite_accessory/hair/business3
-	name = "Business Hair 3"
-	icon_state = "hair_business3"
-
-/datum/sprite_accessory/hair/business4
-	name = "Business Hair 4"
-	icon_state = "hair_business4"
-
-/datum/sprite_accessory/hair/hedgehog
-	name = "Hedgehog Hair"
-	icon_state = "hair_hedgehog"
-
-/datum/sprite_accessory/hair/bob
-	name = "Bob Hair"
-	icon_state = "hair_bob"
-
-/datum/sprite_accessory/hair/bob2
-	name = "Bob Hair 2"
-	icon_state = "hair_bob2"
-
-/datum/sprite_accessory/hair/boddicker
-	name = "Boddicker"
-	icon_state = "hair_boddicker"
-
-/datum/sprite_accessory/hair/long
-	name = "Long Hair 1"
-	icon_state = "hair_long"
-
-/datum/sprite_accessory/hair/long2
-	name = "Long Hair 2"
-	icon_state = "hair_long2"
-
-/datum/sprite_accessory/hair/long3
-	name = "Long Hair 3"
-	icon_state = "hair_long3"
-
-/datum/sprite_accessory/hair/pixie
-	name = "Pixie Cut"
-	icon_state = "hair_pixie"
-
-/datum/sprite_accessory/hair/megaeyebrows
-	name = "Mega Eyebrows"
-	icon_state = "hair_megaeyebrows"
-
-/datum/sprite_accessory/hair/highponytail
-	name = "High Ponytail"
-	icon_state = "hair_highponytail"
-
-/datum/sprite_accessory/hair/longponytail
-	name = "Long Ponytail"
-	icon_state = "hair_longstraightponytail"
-
-/datum/sprite_accessory/hair/sidepartlongalt
-	name = "Long Side Part"
-	icon_state = "hair_longsidepart"
-
-/datum/sprite_accessory/hair/sidecut
-	name = "Sidecut"
-	icon_state = "hair_sidecut"
-
-/datum/sprite_accessory/hair/largebun
-	name = "Large Bun"
-	icon_state = "hair_largebun"
-
-/datum/sprite_accessory/hair/halfshaved
-	name = "Half Shaved"
-	icon_state = "hair_halfshaved"
-
-/datum/sprite_accessory/hair/halfshavedemo
-	name = "Half Shaved Emo"
-	icon_state = "hair_halfshavedemo"
-
-/datum/sprite_accessory/hair/longsideemo
-	name = "Long Side Emo"
-	icon_state = "hair_longsideemo"
-
-/datum/sprite_accessory/hair/leftsidecut
-	name = "Left Side Cut"
-	icon_state = "hair_leftside"
-
-/datum/sprite_accessory/hair/rightsidecut
-	name = "Right Side Cut"
-	icon_state = "hair_rightside"
+/datum/sprite_accessory/hair/updo
+	name = "Updo"
+	icon_state = "hair_updo"
 
 
 /////////////////////////////
@@ -545,69 +539,29 @@
 	icon_state = null
 	gender = NEUTER
 
-/datum/sprite_accessory/facial_hair/watson
-	name = "Watson Mustache"
-	icon_state = "facial_watson"
-
-/datum/sprite_accessory/facial_hair/hogan
-	name = "Hulk Hogan Mustache"
-	icon_state = "facial_hogan" //-Neek
-
-/datum/sprite_accessory/facial_hair/vandyke
-	name = "Van Dyke Mustache"
-	icon_state = "facial_vandyke"
-
-/datum/sprite_accessory/facial_hair/chaplin
-	name = "Square Mustache"
-	icon_state = "facial_chaplin"
-
-/datum/sprite_accessory/facial_hair/selleck
-	name = "Selleck Mustache"
-	icon_state = "facial_selleck"
-
-/datum/sprite_accessory/facial_hair/neckbeard
-	name = "Neckbeard"
-	icon_state = "facial_neckbeard"
-
-/datum/sprite_accessory/facial_hair/fullbeard
-	name = "Full Beard"
-	icon_state = "facial_fullbeard"
-
-/datum/sprite_accessory/facial_hair/longbeard
-	name = "Long Beard"
-	icon_state = "facial_longbeard"
-
-/datum/sprite_accessory/facial_hair/vlongbeard
-	name = "Very Long Beard"
-	icon_state = "facial_wise"
-
-/datum/sprite_accessory/facial_hair/elvis
-	name = "Elvis Sideburns"
-	icon_state = "facial_elvis"
-
 /datum/sprite_accessory/facial_hair/abe
 	name = "Abraham Lincoln Beard"
 	icon_state = "facial_abe"
+
+/datum/sprite_accessory/facial_hair/brokenman
+	name = "Broken Man"
+	icon_state = "facial_brokenman"
+
+/datum/sprite_accessory/facial_hair/chaplin
+	name = "Chaplin Mustache"
+	icon_state = "facial_chaplin"
 
 /datum/sprite_accessory/facial_hair/chinstrap
 	name = "Chinstrap"
 	icon_state = "facial_chin"
 
-/datum/sprite_accessory/facial_hair/hip
-	name = "Hipster Beard"
-	icon_state = "facial_hip"
-
-/datum/sprite_accessory/facial_hair/gt
-	name = "Goatee"
-	icon_state = "facial_gt"
-
-/datum/sprite_accessory/facial_hair/jensen
-	name = "Jensen Beard"
-	icon_state = "facial_jensen"
-
 /datum/sprite_accessory/facial_hair/dwarf
 	name = "Dwarf Beard"
 	icon_state = "facial_dwarf"
+
+/datum/sprite_accessory/facial_hair/elvis
+	name = "Elvis Sideburns"
+	icon_state = "facial_elvis"
 
 /datum/sprite_accessory/facial_hair/fiveoclock
 	name = "Five o Clock Shadow"
@@ -617,14 +571,55 @@
 	name = "Fu Manchu"
 	icon_state = "facial_fumanchu"
 
-/datum/sprite_accessory/facial_hair/brokenman
-	name = "Broken Man"
-	icon_state = "facial_brokenman"
+/datum/sprite_accessory/facial_hair/fullbeard
+	name = "Full Beard"
+	icon_state = "facial_fullbeard"
 
+/datum/sprite_accessory/facial_hair/gt
+	name = "Goatee"
+	icon_state = "facial_gt"
+
+/datum/sprite_accessory/facial_hair/hogan
+	name = "Hulk Hogan Mustache"
+	icon_state = "facial_hogan" //-Neek
+
+/datum/sprite_accessory/facial_hair/hip
+	name = "Hipster Beard"
+	icon_state = "facial_hip"
+
+/datum/sprite_accessory/facial_hair/longbeard
+	name = "Long Beard"
+	icon_state = "facial_longbeard"
+
+/datum/sprite_accessory/facial_hair/vlongbeard
+	name = "Very Long Beard"
+	icon_state = "facial_wise"
+
+/datum/sprite_accessory/facial_hair/jensen
+	name = "Jensen Beard"
+	icon_state = "facial_jensen"
+
+/datum/sprite_accessory/facial_hair/neckbeard
+	name = "Neckbeard"
+	icon_state = "facial_neckbeard"
+
+/datum/sprite_accessory/facial_hair/selleck
+	name = "Selleck Mustache"
+	icon_state = "facial_selleck"
+
+/datum/sprite_accessory/facial_hair/vandyke
+	name = "Van Dyke Mustache"
+	icon_state = "facial_vandyke"
+
+/datum/sprite_accessory/facial_hair/watson
+	name = "Watson Mustache"
+	icon_state = "facial_watson"
 
 ///////////////////////////
 // Underwear Definitions //
 ///////////////////////////
+//Why are there a million icons instead of just a few icons and using RGB to adjust color as you please?
+
 /datum/sprite_accessory/underwear
 	icon = 'icons/mob/underwear.dmi'
 
@@ -633,19 +628,9 @@
 	icon_state = null
 	gender = NEUTER
 
-/datum/sprite_accessory/underwear/male_white
-	name = "Mens White"
-	icon_state = "male_white"
-	gender = MALE
-
-/datum/sprite_accessory/underwear/male_grey
-	name = "Mens Grey"
-	icon_state = "male_grey"
-	gender = MALE
-
-/datum/sprite_accessory/underwear/male_green
-	name = "Mens Green"
-	icon_state = "male_green"
+/datum/sprite_accessory/underwear/male_black
+	name = "Mens Black"
+	icon_state = "male_black"
 	gender = MALE
 
 /datum/sprite_accessory/underwear/male_blue
@@ -653,19 +638,24 @@
 	icon_state = "male_blue"
 	gender = MALE
 
-/datum/sprite_accessory/underwear/male_black
-	name = "Mens Black"
-	icon_state = "male_black"
+/datum/sprite_accessory/underwear/male_green
+	name = "Mens Green"
+	icon_state = "male_green"
 	gender = MALE
 
-/datum/sprite_accessory/underwear/male_mankini
-	name = "Mankini"
-	icon_state = "male_mankini"
+/datum/sprite_accessory/underwear/male_grey
+	name = "Mens Grey"
+	icon_state = "male_grey"
 	gender = MALE
 
-/datum/sprite_accessory/underwear/male_hearts
-	name = "Mens Hearts Boxer"
-	icon_state = "male_hearts"
+/datum/sprite_accessory/underwear/male_red
+	name = "Mens Red"
+	icon_state = "male_red"
+	gender = MALE
+
+/datum/sprite_accessory/underwear/male_white
+	name = "Mens White"
+	icon_state = "male_white"
 	gender = MALE
 
 /datum/sprite_accessory/underwear/male_blackalt
@@ -673,19 +663,24 @@
 	icon_state = "male_blackalt"
 	gender = MALE
 
+/datum/sprite_accessory/underwear/male_commie
+	name = "Mens Striped Commie Boxer"
+	icon_state = "male_commie"
+	gender = MALE
+
 /datum/sprite_accessory/underwear/male_greyalt
 	name = "Mens Grey Boxer"
 	icon_state = "male_greyalt"
 	gender = MALE
 
+/datum/sprite_accessory/underwear/male_hearts
+	name = "Mens Hearts Boxer"
+	icon_state = "male_hearts"
+	gender = MALE
+
 /datum/sprite_accessory/underwear/male_stripe
 	name = "Mens Striped Boxer"
 	icon_state = "male_stripe"
-	gender = MALE
-
-/datum/sprite_accessory/underwear/male_commie
-	name = "Mens Striped Commie Boxer"
-	icon_state = "male_commie"
 	gender = MALE
 
 /datum/sprite_accessory/underwear/male_uk
@@ -698,49 +693,24 @@
 	icon_state = "male_assblastusa"
 	gender = MALE
 
+/datum/sprite_accessory/underwear/male_mankini
+	name = "Mankini"
+	icon_state = "male_mankini"
+	gender = MALE
+
 /datum/sprite_accessory/underwear/male_kinky
 	name = "Mens Kinky"
 	icon_state = "male_kinky"
 	gender = MALE
-
-/datum/sprite_accessory/underwear/male_red
-	name = "Mens Red"
-	icon_state = "male_red"
-	gender = MALE
-
-/datum/sprite_accessory/underwear/female_red
-	name = "Ladies Red"
-	icon_state = "female_red"
-	gender = FEMALE
-
-/datum/sprite_accessory/underwear/female_white
-	name = "Ladies White"
-	icon_state = "female_white"
-	gender = FEMALE
-
-/datum/sprite_accessory/underwear/female_yellow
-	name = "Ladies Yellow"
-	icon_state = "female_yellow"
-	gender = FEMALE
-
-/datum/sprite_accessory/underwear/female_blue
-	name = "Ladies Blue"
-	icon_state = "female_blue"
-	gender = FEMALE
 
 /datum/sprite_accessory/underwear/female_black
 	name = "Ladies Black"
 	icon_state = "female_black"
 	gender = FEMALE
 
-/datum/sprite_accessory/underwear/female_thong
-	name = "Ladies Thong"
-	icon_state = "female_thong"
-	gender = FEMALE
-
-/datum/sprite_accessory/underwear/female_babydoll
-	name = "Babydoll"
-	icon_state = "female_babydoll"
+/datum/sprite_accessory/underwear/female_blue
+	name = "Ladies Blue"
+	icon_state = "female_blue"
 	gender = FEMALE
 
 /datum/sprite_accessory/underwear/female_babyblue
@@ -758,9 +728,19 @@
 	icon_state = "female_pink"
 	gender = FEMALE
 
-/datum/sprite_accessory/underwear/female_kinky
-	name = "Ladies Kinky"
-	icon_state = "female_kinky"
+/datum/sprite_accessory/underwear/female_red
+	name = "Ladies Red"
+	icon_state = "female_red"
+	gender = FEMALE
+
+/datum/sprite_accessory/underwear/female_yellow
+	name = "Ladies Yellow"
+	icon_state = "female_yellow"
+	gender = FEMALE
+
+/datum/sprite_accessory/underwear/female_white
+	name = "Ladies White"
+	icon_state = "female_white"
 	gender = FEMALE
 
 /datum/sprite_accessory/underwear/female_whitealt
@@ -773,19 +753,9 @@
 	icon_state = "female_blackalt"
 	gender = FEMALE
 
-/datum/sprite_accessory/underwear/female_white_neko
-	name = "Ladies White Neko"
-	icon_state = "female_neko_white"
-	gender = FEMALE
-
-/datum/sprite_accessory/underwear/female_black_neko
-	name = "Ladies Black Neko"
-	icon_state = "female_neko_black"
-	gender = FEMALE
-
-/datum/sprite_accessory/underwear/female_usastripe
-	name = "Ladies Freedom"
-	icon_state = "female_assblastusa"
+/datum/sprite_accessory/underwear/female_commie
+	name = "Ladies Commie"
+	icon_state = "female_commie"
 	gender = FEMALE
 
 /datum/sprite_accessory/underwear/female_uk
@@ -793,9 +763,9 @@
 	icon_state = "female_uk"
 	gender = FEMALE
 
-/datum/sprite_accessory/underwear/female_commie
-	name = "Ladies Commie"
-	icon_state = "female_commie"
+/datum/sprite_accessory/underwear/female_usastripe
+	name = "Ladies Freedom"
+	icon_state = "female_assblastusa"
 	gender = FEMALE
 
 /datum/sprite_accessory/underwear/swimsuit
@@ -823,6 +793,30 @@
 	icon_state = "swim_red"
 	gender = FEMALE
 
+/datum/sprite_accessory/underwear/female_babydoll
+	name = "Babydoll"
+	icon_state = "female_babydoll"
+	gender = FEMALE
+
+/datum/sprite_accessory/underwear/female_kinky
+	name = "Ladies Kinky"
+	icon_state = "female_kinky"
+	gender = FEMALE
+
+/datum/sprite_accessory/underwear/female_black_neko
+	name = "Ladies Black Neko"
+	icon_state = "female_neko_black"
+	gender = FEMALE
+
+/datum/sprite_accessory/underwear/female_white_neko
+	name = "Ladies White Neko"
+	icon_state = "female_neko_white"
+	gender = FEMALE
+
+/datum/sprite_accessory/underwear/female_thong
+	name = "Ladies Thong"
+	icon_state = "female_thong"
+	gender = FEMALE
 
 ////////////////////////////
 // Undershirt Definitions //

--- a/code/modules/mob/dead/new_player/sprite_accessories.dm
+++ b/code/modules/mob/dead/new_player/sprite_accessories.dm
@@ -64,7 +64,7 @@
 //////////////////////
 // Hair Definitions //
 //////////////////////
-// Please try to ABC lists from now on.
+// Please try to ABC lists from now on in a "smart" fashion with ABC -> associated.
 
 /datum/sprite_accessory/hair
 	icon = 'icons/mob/human_face.dmi'	  // default icon for all hairs
@@ -387,7 +387,7 @@
 
 /datum/sprite_accessory/hair/over_eye
 	name = "Over Eye"
-		icon_state = "hair_shortovereye"
+	icon_state = "hair_shortovereye"
 
 /datum/sprite_accessory/hair/parted
 	name = "Parted"
@@ -444,7 +444,6 @@
 /datum/sprite_accessory/hair/longponytail
 	name = "Long Ponytail"
 	icon_state = "hair_longstraightponytail"
-
 
 /datum/sprite_accessory/hair/protagonist
 	name = "Slightly Long"


### PR DESCRIPTION
Reorders hair and underwear into "smart" ABC order (associated clothing/haircuts go with associated things).

Unlocks previously locked hairstyles because they were named the same object in the hierarchy but have different icon-states.

Please try to order lists sensibly and in smart ABC order, particularly if players are going to interact with the lists in order to not trigger my autism in the future.

R&D probably needs the same sort of work.