### PR TITLE
Age & gender show up on examine

### DIFF
--- a/code/modules/mob/living/carbon/human/examine.dm
+++ b/code/modules/mob/living/carbon/human/examine.dm
@@ -7,13 +7,26 @@
 	var/t_has = p_have()
 	var/t_is = p_are()
 	var/obscure_name
+	var/ex_age
 
 	if(isliving(user))
 		var/mob/living/L = user
 		if(L.has_trait(TRAIT_PROSOPAGNOSIA))
 			obscure_name = TRUE
 
-	var/msg = "<span class='info'>*---------*\nThis is <EM>[!obscure_name ? name : "Unknown"]</EM>!\n"
+	switch(age)
+		if(1 to 19) //Children are non-essential.
+			ex_age = "teenage"
+		if(20 to 29)
+			ex_age = "young adult"
+		if(30 to 44)
+			ex_age = "adult"
+		if(45 to 64)
+			ex_age = "middle-aged"
+		if(65 to INFINITY) //Respect your immortal elders.
+			ex_age = "elderly"
+
+	var/msg = "<span class='info'>*---------*\nThis is <EM>[!obscure_name ? name : "Unknown"]</EM>, \an [ex_age] [gender == MALE ? "man" : "woman"]!\n"
 
 	var/list/obscured = check_obscured_slots()
 	var/skipface = (wear_mask && (wear_mask.flags_inv & HIDEFACE)) || (head && (head.flags_inv & HIDEFACE))


### PR DESCRIPTION
## Description
Examining someone now also tells you their age group and gender.

## Motivation and Context
Before this, you had literally no way of knowing whether someone was 17 or 80 years old unless they told you. This will make interactions more realistic, and will help you avoid embarrassment when you accidentally hit on a grandma.

## How Has This Been Tested?
Tested on private server, all the different age-groups show up correctly, along with gender.
