### PR TITLE
Wallets now can hold currency

### DIFF
--- a/code/game/objects/items/storage/wallets.dm
+++ b/code/game/objects/items/storage/wallets.dm
@@ -15,6 +15,7 @@
 	STR.max_items = 4
 	STR.can_hold = typecacheof(list(
 		/obj/item/stack/spacecash,
+		/obj/item/stack/f13Cash,
 		/obj/item/card,
 		/obj/item/clothing/mask/cigarette,
 		/obj/item/flashlight/pen,


### PR DESCRIPTION
## Description
Adds Fallout currency to accepted items for the wallet

## Motivation and Context
Wallets used to not be able to hold caps & coin stacks.

## How Has This Been Tested?
Tested in private server. Wallets can hold currency.
