### PR TITLE
Fixes crosses

### DIFF
--- a/code/game/objects/structures/kitchen_spike.dm
+++ b/code/game/objects/structures/kitchen_spike.dm
@@ -76,26 +76,27 @@
 			L.forceMove(drop_location())
 			L.emote("scream")
 			L.add_splatter_floor()
-			L.adjustBruteLoss(30)
+			L.adjustBruteLoss(20)
 			L.setDir(2)
 			buckle_mob(L, force=1)
-			var/matrix/m180 = matrix(L.transform)
-			m180.Turn(180)
-			animate(L, transform = m180, time = 3)
-			L.pixel_y = L.get_standard_pixel_y_offset(180)
+			rotate_mob(L)
 	else if (has_buckled_mobs())
 		for(var/mob/living/L in buckled_mobs)
 			user_unbuckle_mob(L, user)
 	else
 		..()
 
-
+/obj/structure/kitchenspike/proc/rotate_mob(mob/living/L)
+		var/matrix/m180 = matrix(L.transform)
+		m180.Turn(180)
+		animate(L, transform = m180, time = 3)
+		L.pixel_y = L.get_standard_pixel_y_offset(180)
 
 /obj/structure/kitchenspike/user_buckle_mob(mob/living/M, mob/living/user) //Don't want them getting put on the rack other than by spiking
 	return
 
 /obj/structure/kitchenspike/user_unbuckle_mob(mob/living/buckled_mob, mob/living/carbon/human/user)
-	if(buckled_mob)
+	if(buckled_mob && buckled_mob.buckled == src)
 		var/mob/living/M = buckled_mob
 		if(M != user)
 			M.visible_message(\
@@ -114,7 +115,7 @@
 			"<span class='warning'>[M] struggles to break free from [src]!</span>",\
 			"<span class='notice'>You struggle to break free from [src], exacerbating your wounds! (Stay still for two minutes.)</span>",\
 			"<span class='italics'>You hear a wet squishing noise..</span>")
-			M.adjustBruteLoss(30)
+			M.adjustBruteLoss(25)
 			if(!do_after(M, 1200, target = src))
 				if(M && M.buckled)
 					to_chat(M, "<span class='warning'>You fail to free yourself!</span>")
@@ -128,7 +129,7 @@
 	m180.Turn(180)
 	animate(M, transform = m180, time = 3)
 	M.pixel_y = M.get_standard_pixel_y_offset(180)
-	M.adjustBruteLoss(30)
+	M.adjustBruteLoss(25)
 	src.visible_message(text("<span class='danger'>[M] falls free of [src]!</span>"))
 	unbuckle_mob(M,force=1)
 	M.emote("scream")
@@ -154,32 +155,22 @@
 	icon = 'icons/obj/cross.dmi'
 	icon_state = "cross"
 	desc = "Degenerates like you belong on one of these."
-	density = 1
-	anchored = 1
-	buckle_lying = 0
-	can_buckle = 1
+	anchored = TRUE
 	bound_height = 64
 
 /obj/structure/kitchenspike/cross/crowbar_act(mob/living/user, obj/item/I)
 	if(has_buckled_mobs())
-		to_chat(user, "<span class='notice'>You can't do that while something's on the spike!</span>")
-		return TRUE
-
+		to_chat(user, "<span class='notice'>You can't do that while something's on the cross!</span>")
+		return FALSE
 	if(I.use_tool(src, user, 20, volume=100))
 		deconstruct()
 	return TRUE
-
-/obj/structure/kitchenspike/cross/Destroy()
-	if(has_buckled_mobs())
-		for(var/mob/living/L in buckled_mobs)
-			release_mob(L)
-	return ..()
 
 /obj/structure/kitchenspike/cross/deconstruct()
 	new /obj/item/stack/sheet/mineral/wood(src.loc, 10)
 	qdel(src)
 
-/obj/structure/kitchenspike/cross/attackby(obj/item/I, mob/user, params)
+/obj/structure/kitchenspike/cross/attack_hand(mob/user)
 	if(VIABLE_MOB_CHECK(user.pulling) && user.a_intent == INTENT_GRAB && !has_buckled_mobs())
 		var/mob/living/L = user.pulling
 		if(do_mob(user, src, 120))
@@ -191,37 +182,36 @@
 				return
 			playsound(src.loc, "sound/effects/crossed.ogg", 20, 1) // thanks hippie
 			L.visible_message("<span class='danger'>[user] ties [L] to the cross!</span>", "<span class='userdanger'>[user] ties you to the cross!</span>")
-			L.loc = src.loc
-			L.emote("scream")
-			L.adjustBruteLoss(10)
-			L.buckled = src
-			L.dir = 2
+			L.forceMove(drop_location())
+			L.setDir(2)
 			buckle_mob(L, force=1)
 			L.pixel_y = 26
 			L.overlays += image('icons/obj/cross.dmi', "lashing")
-			return
 		to_chat(user, "<span class='danger'>You can't use that on the cross!</span>")
-		return
-	..()
+	else if (has_buckled_mobs())
+		for(var/mob/living/L in buckled_mobs)
+			user_unbuckle_mob(L, user)
+	else
+		..()
 
 /obj/structure/kitchenspike/cross/user_unbuckle_mob(mob/living/buckled_mob, mob/living/carbon/human/user)
 	if(buckled_mob && buckled_mob.buckled == src)
 		var/mob/living/M = buckled_mob
 		if(M != user)
 			M.visible_message(\
-				"[user.name] tries to pull [M.name] free of the [src]!",\
+				"[user] tries to pull [M] free of the [src]!",\
 				"<span class='notice'>[user.name] is trying to pull you off the [src], opening up fresh wounds!</span>",\
 				"<span class='italics'>You hear rope being unraveled.</span>")
 			if(!do_after(user, 300, target = src))
 				if(M && M.buckled)
 					M.visible_message(\
-					"[user.name] fails to free [M.name]!",\
-					"<span class='notice'>[user.name] fails to pull you off of the [src].</span>")
+					"[user] fails to free [M]!",\
+					"<span class='notice'>[user] fails to pull you off of the [src].</span>")
 				return
 
 		else
 			M.visible_message(\
-			"<span class='warning'>[M.name] struggles to break free from the [src]!</span>",\
+			"<span class='warning'>[M] struggles to break free from the [src]!</span>",\
 			"<span class='notice'>You struggle to break free from the [src], exacerbating your wounds! (Stay still for two minutes.)</span>",\
 			"<span class='italics'>You hear violent scraping and struggling.</span>")
 			M.adjustBruteLoss(20)
@@ -231,11 +221,20 @@
 				return
 		if(!M.buckled)
 			return
-		M.pixel_y = 0
-		M.adjustBruteLoss(40)
-		src.visible_message(text("<span class='danger'>[M] falls free of the [src]!</span>"))
-		unbuckle_mob()
-		M.emote("scream")
-		M.overlays -= image('icons/obj/cross.dmi', "lashing")
+		untie_mob(M)
+
+/obj/structure/kitchenspike/cross/proc/untie_mob(mob/living/M)
+	M.pixel_y = M.get_standard_pixel_y_offset()
+	M.adjustBruteLoss(15)
+	src.visible_message(text("<span class='danger'>[M] falls free of [src]!</span>"))
+	unbuckle_mob(M,force=1)
+	M.emote("collapse")
+	M.overlays -= image('icons/obj/cross.dmi', "lashing")
+
+/obj/structure/kitchenspike/cross/Destroy()
+	if(has_buckled_mobs())
+		for(var/mob/living/L in buckled_mobs)
+			untie_mob(L)
+	return ..()
 
 #undef VIABLE_MOB_CHECK


### PR DESCRIPTION
-Makes it so unbuckling from crosses actually works.

-Makes it so they don't arbitrarily damage you just for being strung up on one.

-Makes it so you aren't rotated upside-down when you get buckled to a cross (Really?)

-Plays the correct noises now.

-Does the correct animations now.

-Reduces damage from being pulled and put onto a cross.

-Better flavortext

-Better, less buggy interactions

-Very minorly reduces damage from being on a kitchen spike so you don't just resist free and then instantly die of bloodloss.

-Cleans up some code.

There's probably a way to rewrite this chunk of code so there's less copypasting.

##
tl;dr the entire cross code was busted and not being used and it was defaulting to parent kitchenspike code

@rhicora 