### PR TITLE
Stimpak Buff/Healing Powder nerf

### DIFF
--- a/code/modules/reagents/chemistry/reagents/medicine_reagents.dm
+++ b/code/modules/reagents/chemistry/reagents/medicine_reagents.dm
@@ -1268,9 +1268,9 @@
 	..()
 
 /datum/reagent/medicine/stimpak/on_mob_life(mob/living/M)
-	M.adjustBruteLoss(-3*REM, 0)
-	M.adjustFireLoss(-3*REM, 0)
-	M.adjustOxyLoss(-2*REM, 0)
+	M.adjustBruteLoss(-4*REM, 0)
+	M.adjustFireLoss(-4*REM, 0)
+	M.adjustOxyLoss(-3*REM, 0)
 	. = 1
 	..()
 
@@ -1285,8 +1285,8 @@
 	overdose_threshold = 30
 
 /datum/reagent/medicine/healing_powder/on_mob_life(mob/living/M)
-	M.adjustFireLoss(-3*REM)
-	M.adjustBruteLoss(-3*REM)
+	M.adjustFireLoss(-2*REM)
+	M.adjustBruteLoss(-2*REM)
 	M.hallucination = max(M.hallucination, 5)
 	if(prob(7))
 		M.emote(pick("twitch","drool","moan","giggle"))


### PR DESCRIPTION
## Description
- Healing Powder lasts forever, where as stimpacks last very briefly
- Buffs Stimpaks heal rates
- Nerfs Healing Powder heal rates

## How Has This Been Tested?
Not tests, value changes only
