### PR TITLE
Change to DEFIB_TIME_LIMIT to increase alotted time

### DIFF
--- a/code/__DEFINES/misc.dm
+++ b/code/__DEFINES/misc.dm
@@ -294,7 +294,7 @@ GLOBAL_LIST_INIT(pda_styles, list(MONO, VT, ORBITRON, SHARE))
 #define MAP_MAXZ 6
 
 // Defib stats
-#define DEFIB_TIME_LIMIT 120
+#define DEFIB_TIME_LIMIT 300
 #define DEFIB_TIME_LOSS 60
 
 // Diagonal movement


### PR DESCRIPTION
DEFIB_TIME_LIMIT looks to be the cause of a two minute before oofed off plain of the living. gonna test this code on my Fork soon


## Description
the reasoning behind is this is issue #350 

## Motivation and Context
Issue #350 

## How Has This Been Tested?
Complied and hosted. Tested on a NPC, NPC dead timer laster long with changed time

## Screenshots (if appropriate):
