### PR TITLE
Get Rid of sec borgs

### DIFF
--- a/config/game_options.txt
+++ b/config/game_options.txt
@@ -267,7 +267,7 @@ EVENTS_MIN_PLAYERS_MUL 1
 
 ## Secborg ###
 ## Uncomment to prevent the security cyborg module from being chosen
-#DISABLE_SECBORG
+DISABLE_SECBORG
 
 ## Peacekeeper Borg ###
 ## Uncomment to prevent the peacekeeper cyborg module from being chosen


### PR DESCRIPTION
its a borg that can fire disabler with nearly no cooldown and have a stun baton and have a flash and on top of that it can be spammed if enough people is dead. Vault Makes it cancerous because they have the power to just spam sec borg

<!-- Thanks for choosing to take the time to contribute to our project! We have a few things below that we'd like you to fill out -->
<!-- The more detail you can give us, the faster we can code review, test, and merge your changes -->

<!--- Provide a general summary of your changes in the Title above -->

## Description
Most Annoying thing to fight againist and really abusable by the two tech powers aka BoS and Vault, Mainly Vault
## Motivation and Context
a borg that has rapid firing disabler gun and a stun baton as well as a cuffs so pretty powerful thus annoying because you either need to have EMPs or Ion Rifle (Ion carbine in this case)
## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- This helps us replicate your tests, to speed up review. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->

## Screenshots (if appropriate):
