### PR TITLE
Nerfs chemistry satchels

### DIFF
--- a/code/game/objects/items/storage/bags.dm
+++ b/code/game/objects/items/storage/bags.dm
@@ -335,7 +335,7 @@
 	icon = 'icons/obj/chemical.dmi'
 	icon_state = "bag"
 	desc = "A bag for storing pills, patches, and bottles."
-	w_class = WEIGHT_CLASS_TINY
+	w_class = WEIGHT_CLASS_NORMAL
 	resistance_flags = FLAMMABLE
 
 /obj/item/storage/bag/chemistry/ComponentInitialize()


### PR DESCRIPTION
## Description
Makes chemistry satchels weight more so you can't fit them into your pockets.

## Motivation and Context
To stop carrying 30 healing powder bags/patches in your pocket slot

## How Has This Been Tested?
Its a simple weight class change.
