### PR TITLE
Fixes energy cells not reinserting in guns, #144

### DIFF
--- a/code/modules/power/cell.dm
+++ b/code/modules/power/cell.dm
@@ -380,11 +380,6 @@
 	maxcharge = 1200
 	chargerate = 300
 
-/obj/item/stock_parts/cell/ammo/mfc/core
-	name = "Weapon core microfusion cell"
-	desc = "A microfusion cell core, thats the orginal cell used in the energy weapon."
-	maxcharge = 1000
-
 /obj/item/stock_parts/cell/ammo/ecp
 	name = "electron charge pack"
 	desc = "An electron charge pack, typically used as ammunition for rapidly-firing energy weapons."

--- a/code/modules/power/cell.dm
+++ b/code/modules/power/cell.dm
@@ -380,6 +380,11 @@
 	maxcharge = 1200
 	chargerate = 300
 
+/obj/item/stock_parts/cell/ammo/mfc/core
+	name = "Weapon core microfusion cell"
+	desc = "A microfusion cell core, thats the orginal cell used in the energy weapon."
+	maxcharge = 1000
+
 /obj/item/stock_parts/cell/ammo/ecp
 	name = "electron charge pack"
 	desc = "An electron charge pack, typically used as ammunition for rapidly-firing energy weapons."

--- a/code/modules/projectiles/guns/energy.dm
+++ b/code/modules/projectiles/guns/energy.dm
@@ -5,7 +5,7 @@
 	icon = 'icons/obj/guns/energy.dmi'
 
 	var/obj/item/stock_parts/cell/cell //What type of power cell this uses
-	var/cell_type = /obj/item/stock_parts/cell
+	var/cell_type = /obj/item/stock_parts/cell/ammo/mfc/core
 	var/modifystate = 0
 	var/list/ammo_type = list(/obj/item/ammo_casing/energy)
 	var/select = 1 //The state of the select fire switch. Determines from the ammo_type list what kind of shot is fired next.

--- a/code/modules/projectiles/guns/energy.dm
+++ b/code/modules/projectiles/guns/energy.dm
@@ -5,7 +5,7 @@
 	icon = 'icons/obj/guns/energy.dmi'
 
 	var/obj/item/stock_parts/cell/cell //What type of power cell this uses
-	var/cell_type = /obj/item/stock_parts/cell/ammo/mfc/core
+	var/cell_type = /obj/item/stock_parts/cell/ammo/mfc
 	var/modifystate = 0
 	var/list/ammo_type = list(/obj/item/ammo_casing/energy)
 	var/select = 1 //The state of the select fire switch. Determines from the ammo_type list what kind of shot is fired next.

--- a/code/modules/projectiles/guns/energy/laser.dm
+++ b/code/modules/projectiles/guns/energy/laser.dm
@@ -255,7 +255,7 @@
 	pellets = 3
 	variance = 14
 	select_name = "scatter"
-	e_cost = 150
+	e_cost = 75
 
 /obj/item/ammo_casing/energy/laser/pistol
 	projectile_type = /obj/item/projectile/beam/laser/pistol


### PR DESCRIPTION
## Description
fixes energy cells not reinserting in guns

## Motivation and Context
#144 fixes issue report, energy cells not reinserting

## How Has This Been Tested?
Changes cell type into more lore friendly subtype, they are reinsertable now, and retain orginal shots.
tested on a local server. no runtimes, no exploits.
