### PR TITLE
Nerfs BHS-M1 Melee, Buffs Ithaca, Winchester and Remingtons

### DIFF
--- a/code/modules/projectiles/guns/ballistic/shotgun.dm
+++ b/code/modules/projectiles/guns/ballistic/shotgun.dm
@@ -4,7 +4,7 @@
 	icon_state = "Itaca"
 	item_state = "huntingshotgun"
 	w_class = WEIGHT_CLASS_BULKY
-	force = 10
+	force = 25
 	flags_1 =  CONDUCT_1
 	slot_flags = ITEM_SLOT_BACK
 	mag_type = /obj/item/ammo_box/magazine/internal/shot
@@ -264,7 +264,7 @@
 	desc = "A Big Heavy Shotgun Model 1, the staple of pre-war riot controll grade shotguns with a longer magazine and a fixed heavy reinforced tactical stock designed for tactical use when tactically bashing heads."
 	icon_state = "riotshotgun"
 	item_state = "shotgunriot"
-	force = 56
+	force = 40
 	mag_type = /obj/item/ammo_box/magazine/internal/shot/riot
 	sawn_desc = "Come with me if you want to live."
 	w_class = WEIGHT_CLASS_BULKY


### PR DESCRIPTION
Drops the BHS-M1 melee from 56 to 40 brute, changing it from 2 hits to 3 to crit an unarmored player

Buffs the Ithaca/Winchester/Remingtons from 10 to 25 melee as requested by Ren, changing it from 10 hits to 4 to crit an unarmored person

