### PR TITLE
Brings Laser Gun from RND sprite in line wit hcurrent sprites

### DIFF
--- a/code/modules/projectiles/guns/energy/laser.dm
+++ b/code/modules/projectiles/guns/energy/laser.dm
@@ -2,7 +2,7 @@
 	name = "laser gun"
 	desc = "A basic energy-based laser gun that fires concentrated beams of light which pass through glass and thin metal."
 	icon_state = "laser"
-	item_state = "laser"
+	item_state = "laser-rifle9"
 	w_class = WEIGHT_CLASS_BULKY
 	materials = list(MAT_METAL=2000)
 	ammo_type = list(/obj/item/ammo_casing/energy/lasergun)


### PR DESCRIPTION
Changes the in-hand sprite from the regular /tg/station laser rifle to the aer9 rifle, since it looks the same as the aer9

