### PR TITLE
Med-X OD and Addiction Rebalance

### DIFF
--- a/code/modules/reagents/chemistry/reagents/medicine_reagents.dm
+++ b/code/modules/reagents/chemistry/reagents/medicine_reagents.dm
@@ -1339,8 +1339,8 @@
 	reagent_state = LIQUID
 	color = "#6D6374"
 	metabolization_rate = 0.5 * REAGENTS_METABOLISM
-	overdose_threshold = 30
-	addiction_threshold = 20
+	overdose_threshold = 20
+	addiction_threshold = 10
 
 /datum/reagent/medicine/medx/on_mob_add(mob/M)
 	..()


### PR DESCRIPTION
Med-X has become more addictive and dangerous across the wasteland

OD threshold down from 30 to 20
Addiction threshold down from 20 to 10

Balance suggested by Ren