### PR TITLE
Fixes the porta turrets custom target by faction

### DIFF
--- a/code/game/machinery/porta_turret/portable_turret.dm
+++ b/code/game/machinery/porta_turret/portable_turret.dm
@@ -57,7 +57,7 @@
 	var/criminals = 1		//checks if it can shoot people on arrest
 	var/auth_weapons = 0	//checks if it can shoot people that have a weapon they aren't authorized to have
 	var/stun_all = 0		//if this is active, the turret shoots everything that isn't security or head of staff
-	var/check_anomalies = 1	//checks if it can shoot at unidentified lifeforms (ie xenos)
+	var/check_anomalies = 0	//checks if it can shoot at unidentified lifeforms (ie xenos)
 	var/shoot_unloyal = 0	//checks if it can shoot people that aren't loyalty implantd
 
 	var/attacked = 0		//if set to 1, the turret gets pissed off and shoots at people nearby (unless they have sec access!)
@@ -1061,9 +1061,11 @@
 			shootnonfaction = 1
 			if(islist(user.faction))
 				for(var/factionss in user.faction)
-					faction += factionss
+					if(factionss != "neutral")
+						faction += factionss
 			else
-				faction += user.faction
+				if(user.faction != "neutral")
+					faction += user.faction
 			user << "Targeting by non members of the faction set, members of the faction can still be shot by other settings."
 	else
 		var/safety2 = alert(user, "Do you want to disable faction control or add another faction?", "Turret Faction Control", "Disable Control", "Add A Faction")


### PR DESCRIPTION
## Description
<!--- Describe your changes in detail -->
Fixes the porta turret custom faction adding by making it not add neutral faction tag
## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
To make automatic defense easier
## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- This helps us replicate your tests, to speed up review. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->
By seeing that it targets people without the correct faction tag properly 
## Screenshots (if appropriate):
