### PR TITLE
Scribe Changes and Survival Box

### DIFF
--- a/code/game/objects/items/storage/boxes.dm
+++ b/code/game/objects/items/storage/boxes.dm
@@ -98,7 +98,7 @@
 	new /obj/item/clothing/mask/bandana/black(src)
 	new /obj/item/reagent_containers/hypospray/medipen/stimpak(src)
 	new /obj/item/reagent_containers/blood/radaway(src)
-	new /obj/item/stack/medical/gauze/improvised(src)
+	new /obj/item/stack/medical/gauze(src)
 	new /obj/item/flashlight/flare(src)
 
 /obj/item/storage/box/survival/radio/PopulateContents()

--- a/code/modules/jobs/job_types/bos.dm
+++ b/code/modules/jobs/job_types/bos.dm
@@ -206,9 +206,10 @@ Scribe
 	glasses =		/obj/item/clothing/glasses/sunglasses/big
 	id = 			/obj/item/card/id/dogtag
 	backpack_contents = list(
+		/obj/item/stock_parts/cell/ammo/ec=2, \
 		/obj/item/kitchen/knife/combat=1, \
 		/obj/item/gun/energy/laser/pistol=1, \
-		/obj/item/reagent_containers/hypospray/medipen/stimpak=4) //super paks not in yet
+		/obj/item/reagent_containers/hypospray/medipen/stimpak=2) //super paks not in yet
 	//PA training not in yet
 
 /*


### PR DESCRIPTION
Scribes, due to their prevalence of healing equipment already (e.g., Medibeam and ability to do chemistry undisturbed) and finally start with two extra energy cells for their pistols

Survival boxes now also spawn with medical gauze instead of improvised gauze

(Changes requested by Ren)
