### PR TITLE
Removes mining out entire mountains easily

### DIFF
--- a/code/modules/projectiles/guns/energy/special.dm
+++ b/code/modules/projectiles/guns/energy/special.dm
@@ -124,6 +124,7 @@
 	force = 12
 	sharpness = IS_SHARP
 	can_charge = 0
+	weapon_weight = WEAPON_HEAVY
 
 	heat = 3800
 	usesound = list('sound/items/welder.ogg', 'sound/items/welder2.ogg')

--- a/code/modules/projectiles/projectile/special/plasma.dm
+++ b/code/modules/projectiles/projectile/special/plasma.dm
@@ -3,12 +3,12 @@
 	icon_state = "plasmacutter"
 	damage_type = BRUTE
 	damage = 20
-	range = 4
+	range = 2
 	dismemberment = 20
 	impact_effect_type = /obj/effect/temp_visual/impact_effect/purple_laser
 	var/pressure_decrease_active = FALSE
 	var/pressure_decrease = 0.25
-	var/mine_range = 3 //mines this many additional tiles of rock
+	var/mine_range = 0 //mines this many additional tiles of rock
 	tracer_type = /obj/effect/projectile/tracer/plasma_cutter
 	muzzle_type = /obj/effect/projectile/muzzle/plasma_cutter
 	impact_type = /obj/effect/projectile/impact/plasma_cutter
@@ -33,8 +33,8 @@
 
 /obj/item/projectile/plasma/weak/adv
 	damage = 28
-	range = 5
-	mine_range = 5
+	range = 2
+	mine_range = 1
 
 /obj/item/projectile/plasma/weak/adv/mech
 	damage = 40


### PR DESCRIPTION
Ranges severely reduced on the cutters, and they require two hands to fire instead of one.

Range change requested by Ren, two handed suggested by ImprovedName

