### PR TITLE
Hotfixes runtiming walls

### DIFF
--- a/code/game/machinery/deployable.dm
+++ b/code/game/machinery/deployable.dm
@@ -74,7 +74,7 @@
 			to_chat(user, "<span class='notice'>You start adding [I] to [src]...</span>")
 			if(do_after(user, 50, target=src))
 				W.use(5)
-				new /turf/closed/wall/mineral/wood/nonmetal(get_turf(src))
+				new /turf/closed/wall/mineral/wood(get_turf(src))
 				qdel(src)
 				return
 	return ..()

--- a/code/game/machinery/deployable.dm
+++ b/code/game/machinery/deployable.dm
@@ -64,6 +64,7 @@
 	material = WOOD
 	var/drop_amount = 3
 
+/*
 /obj/structure/barricade/wooden/attackby(obj/item/I, mob/user)
 	if(istype(I,/obj/item/stack/sheet/mineral/wood))
 		var/obj/item/stack/sheet/mineral/wood/W = I
@@ -78,7 +79,7 @@
 				qdel(src)
 				return
 	return ..()
-
+*/
 
 /obj/structure/barricade/wooden/crude
 	name = "crude plank barricade"

--- a/code/game/turfs/simulated/wall/mineral_walls.dm
+++ b/code/game/turfs/simulated/wall/mineral_walls.dm
@@ -143,11 +143,14 @@
 			return
 	return ..()
 
+/*
 /turf/closed/wall/mineral/wood/nonmetal
 	desc = "A solidly wooden wall. It's a bit weaker than a wall made with metal."
 	girder_type = /obj/structure/barricade/wooden
 	hardness = 50
 	canSmoothWith = list(/turf/closed/wall/mineral/wood, /obj/structure/falsewall/wood, /turf/closed/wall/mineral/wood/nonmetal)
+*/
+//hotfixes by temporarily disabling building nonmetal walls at all.
 
 /turf/closed/wall/mineral/iron
 	name = "rough metal wall"

--- a/code/game/turfs/simulated/wall/mineral_walls.dm
+++ b/code/game/turfs/simulated/wall/mineral_walls.dm
@@ -131,7 +131,7 @@
 	sheet_type = /obj/item/stack/sheet/mineral/wood
 	hardness = 70
 	explosion_block = 0
-	canSmoothWith = list(/turf/closed/wall/mineral/wood, /obj/structure/falsewall/wood, /turf/closed/wall/mineral/wood/nonmetal)
+	canSmoothWith = list(/turf/closed/wall/mineral/wood, /obj/structure/falsewall/wood)
 
 /turf/closed/wall/mineral/wood/attackby(obj/item/W, mob/user)
 	if(W.sharpness && W.force)


### PR DESCRIPTION
Correct fix is re-writing girder and construction code. This will do for now.

Notably, there's a conflict between trying to call on contents, closed/open air turfs, and the fact that there's a conflict between it trying to figure out whether it's got a girder inside of it or a barricade. For now this just sidesteps the issue, but allows people to convert wooden barricades into metal girders by building on them then deconstructing the wall.