### PR TITLE
Grammar changes and slight buffs + new stuff

### DIFF
--- a/code/game/objects/items/mop.dm
+++ b/code/game/objects/items/mop.dm
@@ -14,8 +14,8 @@
 	resistance_flags = FLAMMABLE
 	var/mopping = 0
 	var/mopcount = 0
-	var/mopcap = 5
-	var/mopspeed = 20
+	var/mopcap = 7
+	var/mopspeed = 25
 	force_string = "robust... against germs"
 	var/insertable = TRUE
 
@@ -77,7 +77,7 @@
 /obj/item/mop/advanced
 	desc = "The most advanced tool in a custodian's arsenal, complete with a condenser for self-wetting! Just think of all the viscera you will clean up with this!"
 	name = "advanced mop"
-	mopcap = 10
+	mopcap = 20
 	icon_state = "advmop"
 	item_state = "mop"
 	lefthand_file = 'icons/mob/inhands/equipment/custodial_lefthand.dmi'
@@ -85,7 +85,7 @@
 	force = 6
 	throwforce = 8
 	throw_range = 4
-	mopspeed = 15
+	mopspeed = 45
 	var/refill_enabled = TRUE //Self-refill toggle for when a janitor decides to mop with something other than water.
 	var/refill_rate = 1 //Rate per process() tick mop refills itself
 	var/refill_reagent = "water" //Determins what reagent to use for refilling, just in case someone wanted to make a HOLY MOP OF PURGING

--- a/code/game/objects/items/powerfist.dm
+++ b/code/game/objects/items/powerfist.dm
@@ -1,5 +1,5 @@
 /obj/item/melee/powerfist
-	name = "power-fist"
+	name = "powerfist"
 	desc = "A metal gauntlet with a piston-powered ram ontop for that extra 'ompfh' in your punch."
 	icon_state = "powerfist"
 	item_state = "powerfist"

--- a/code/game/objects/items/shields.dm
+++ b/code/game/objects/items/shields.dm
@@ -87,6 +87,21 @@
 	resistance_flags = FLAMMABLE
 	block_chance = 25
 
+/obj/item/shield/legion/buckler
+	name = "legion buckler"
+	desc = "A lightweight well balanced shield made out of a hard oak and lashed together with solid iron bands. It has a legion emblem charred onto the inside."
+	icon_state = "buckler"
+	item_state = "buckler"
+	lefthand_file = 'icons/mob/inhands/equipment/shields_lefthand.dmi'
+	righthand_file = 'icons/mob/inhands/equipment/shields_righthand.dmi'
+	materials = list()
+	resistance_flags = FLAMMABLE
+	force = 15
+	block_chance = 35
+	throwforce = 15
+	throw_speed = 4
+	throw_range = 7
+
 /obj/item/shield/energy
 	name = "energy combat shield"
 	desc = "A shield that reflects almost all energy projectiles, but is useless against physical attacks. It can be retracted, expanded, and stored anywhere."

--- a/code/game/objects/items/twohanded.dm
+++ b/code/game/objects/items/twohanded.dm
@@ -219,7 +219,7 @@
 	icon_state = "fireaxe0"
 	lefthand_file = 'icons/mob/inhands/weapons/axes_lefthand.dmi'
 	righthand_file = 'icons/mob/inhands/weapons/axes_righthand.dmi'
-	name = "fire axe"
+	name = "fireaxe"
 	desc = "Truly, the weapon of a madman. Who would think to fight fire with an axe?"
 	force = 5
 	throwforce = 15

--- a/code/modules/clothing/head/ncr.dm
+++ b/code/modules/clothing/head/ncr.dm
@@ -1,5 +1,5 @@
 /obj/item/clothing/head/f13/ncr
-	name = "NCR helmet"
+	name = "NCR patrol helmet"
 	desc = "A standard issue NCR combat helmet."
 	icon_state = "ncr_helmet"
 	item_state = "ncr_helmet"
@@ -7,14 +7,14 @@
 	strip_delay = 50
 
 /obj/item/clothing/head/beret/ncr
-	name = "\improper NCR Officer's Beret"
+	name = "NCR officer's beret"
 	desc = "A green beret, standard issue for all commissioned NCR Officers."
 	icon_state = "ncr_beret"
 	item_state = "ncr_beret"
 	armor = list("melee" = 10, "bullet" = 16, "laser" = 0, "energy" = 0, "bomb" = 16, "bio" = 0, "rad" = 0, "fire" = 0, "acid" = 0)
 
 /obj/item/clothing/head/f13/ranger
-	name = "Ranger Hat"
+	name = "NCR ranger campaign hat"
 	desc = "An NCR ranger hat, standard issue amongst all patrol rangers."
 	icon_state = "drill_hat"
 	item_state = "drillhat"

--- a/code/modules/clothing/masks/gasmask.dm
+++ b/code/modules/clothing/masks/gasmask.dm
@@ -43,7 +43,7 @@
 	armor = list("melee" = 0, "bullet" = 0, "laser" = 2,"energy" = 2, "bomb" = 0, "bio" = 75, "rad" = 0, "fire" = 0, "acid" = 0)
 
 /obj/item/clothing/mask/gas/syndicate
-	name = "syndicate mask"
+	name = "chinese infiltrator mask"
 	desc = "A close-fitting tactical mask that can be connected to an air supply."
 	icon_state = "syndicate"
 	strip_delay = 60
@@ -140,7 +140,7 @@
 	resistance_flags = FLAMMABLE
 
 /obj/item/clothing/mask/gas/death_commando
-	name = "Death Commando Mask"
+	name = "death commando mask"
 	icon_state = "death_commando_mask"
 	item_state = "death_commando_mask"
 

--- a/code/modules/clothing/suits/armor.dm
+++ b/code/modules/clothing/suits/armor.dm
@@ -365,7 +365,7 @@
 	resistance_flags = LAVA_PROOF | FIRE_PROOF | ACID_PROOF
 
 /obj/item/clothing/suit/armor/f13/brokenpa/t45b
-	name = "Salvaged T-45b power armor"
+	name = "salvaged T-45b power armor"
 	desc = "It's a set of T-45b power armor recovered by the NCR during the NCR-Brotherhood War.<br>NCR technicians have restored it to working order by replacing the back-mounted cylinders with a custom air conditioning module and stripping out the joint servomotors."
 	icon_state = "t45bpowerarmor"
 	item_state = "t45bpowerarmor"
@@ -409,14 +409,14 @@
 	armor = list("melee" = 68, "bullet" = 62, "laser" = 39, "energy" = 39, "bomb" = 62, "bio" = 100, "rad" = 100, "fire" = 0, "acid" = 0)
 
 /obj/item/clothing/suit/armor/f13/power_armor/advanced
-	name = "Advanced power armor"
+	name = "advanced power armor"
 	desc = "An advanced suit of armor typically used by the Enclave.<br>It is composed of lightweight metal alloys, reinforced with ceramic castings at key stress points.<br>Additionally, like the T-51b power armor, it includes a recycling system that can convert human waste into drinkable water, and an air conditioning system for it's user's comfort."
 	icon_state = "advpowerarmor1"
 	item_state = "advpowerarmor1"
 	armor = list("melee" = 72, "bullet" = 72, "laser" = 48, "energy" = 48, "bomb" = 72, "bio" = 100, "rad" = 100, "fire" = 0, "acid" = 0)
 
 /obj/item/clothing/suit/armor/f13/power_armor/advanced/mk2
-	name = "Advanced power armor MKII"
+	name = "advanced power armor mark II"
 	desc = "It's an improved model of advanced power armor used exclusively by the Enclave military forces, developed after the Great War.<br>Like its older brother, the standard advanced power armor, it's matte black with a menacing appearance, but with a few significant differences - it appears to be composed entirely of lightweight ceramic composites rather than the usual combination of metal and ceramic plates.<br>Additionally, like the T-51b power armor, it includes a recycling system that can convert human waste into drinkable water, and an air conditioning system for it's user's comfort."
 	icon_state = "advpowerarmor2"
 	item_state = "advpowerarmor2"
@@ -445,7 +445,7 @@
 	armor = list("melee" = 25, "bullet" = 25, "laser" = 16, "energy" = 16, "bomb" = 25, "bio" = 0, "rad" = 0, "fire" = 0, "acid" = 0)
 
 /obj/item/clothing/suit/armor/f13/legvexil
-	name = "Legion vexillarius armor"
+	name = "legion vexillarius armor"
 	desc = "The armor appears to be based off of a suit of Legion veteran armor, with the addition of circular metal plates attached to the torso, as well as a banner displaying the flag of the Legion worn on the back."
 	icon_state = "legvexil"
 	item_state = "legvexil"
@@ -454,7 +454,7 @@
 	strip_delay = 60
 
 /obj/item/clothing/suit/armor/f13/legcenturion
-	name = "Legion centurion armor"
+	name = "legion centurion armor"
 	desc = "The Legion centurion armor is by far the strongest suit of armor available to Caesar's Legion. The armor is composed from other pieces of armor taken from that of the wearer's defeated opponents in combat."
 	icon_state = "legcenturion"
 	item_state = "legcenturion"
@@ -463,7 +463,7 @@
 	strip_delay = 60
 
 /obj/item/clothing/suit/armor/f13/leglegat
-	name = "Legion legat armor"
+	name = "legion legate armor"
 	desc = "The armor appears to be a full suit of heavy gauge steel and offers full body protection. It also has a cloak in excellent condition, but the armor itself bears numerous battle scars and the helmet is missing half of the left horn. The Legate's suit appears originally crafted, in contrast to other Legion armor which consists of repurposed pre-War sports equipment."
 	icon_state = "leglegat"
 	item_state = "leglegat"
@@ -543,7 +543,7 @@
 	armor = list("melee" = 25, "bullet" = 25, "laser" = 16, "energy" = 16, "bomb" = 25, "bio" = 0, "rad" = 0, "fire" = 0, "acid" = 0)
 
 /obj/item/clothing/suit/armor/f13/ghostechoe
-	name = "Tattered Peace Coat"
+	name = "tattered peace coat"
 	desc = "An old coat belonging to a Desert Ranger once. It has been stripped of most useful protection, and has seen better days. A crude peace symbol has been painted on the back in white."
 	icon_state = "ghostechoe"
 	item_state = "ghostechoe"
@@ -551,7 +551,7 @@
 	armor = list("melee" = 10, "bullet" = 16, "laser" = 0, "energy" = 0, "bomb" = 16, "bio" = 0, "rad" = 0, "fire" = 0, "acid" = 0)
 
 /obj/item/clothing/suit/armor/f13/headscribe
-    name = "Brotherhood Head Scribe's Robe"
+    name = "brotherhood head scribe robe"
     desc = "A red cloth robe with gold trimmings, worn eclusively by the Head Scribe of a chapter."
     icon_state = "headscribe"
     item_state = "headscribe"

--- a/code/modules/clothing/under/f13.dm
+++ b/code/modules/clothing/under/f13.dm
@@ -208,7 +208,7 @@
 	item_color = "combat_shirt"
 
 /obj/item/clothing/under/f13/Retro_Biker_Vest
-	name = "Future Vest"
+	name = "future vest"
 	desc = "A Pink Vest with Black Pants. Quite futuristic looking."
 	icon_state = "Biker"
 	item_state = "Biker"

--- a/code/modules/projectiles/ammunition/ballistic/pistol.dm
+++ b/code/modules/projectiles/ammunition/ballistic/pistol.dm
@@ -1,17 +1,17 @@
 // 10mm (Stechkin)
 
 /obj/item/ammo_casing/c10mm/ap
-	name = ".10mm armor-piercing bullet casing"
+	name = "10mm armor-piercing bullet casing"
 	desc = "A 10mm armor-piercing bullet casing."
 	projectile_type = /obj/item/projectile/bullet/medbullet
 
 /obj/item/ammo_casing/c10mm/hp
-	name = ".10mm hollow-point bullet casing"
+	name = "10mm hollow-point bullet casing"
 	desc = "A 10mm hollow-point bullet casing."
 	projectile_type = /obj/item/projectile/bullet/medbullet
 
 /obj/item/ammo_casing/c10mm/fire
-	name = ".10mm incendiary bullet casing"
+	name = "10mm incendiary bullet casing"
 	desc = "A 10mm incendiary bullet casing."
 	projectile_type = /obj/item/projectile/bullet/medbullet
 

--- a/code/modules/projectiles/ammunition/ballistic/shotgun.dm
+++ b/code/modules/projectiles/ammunition/ballistic/shotgun.dm
@@ -1,7 +1,7 @@
 // Shotgun
 
 /obj/item/ammo_casing/shotgun
-	name = "shotgun slug"
+	name = "12 gauge slug"
 	desc = "A 12 gauge lead slug."
 	icon_state = "blshell"
 	caliber = "shotgun"
@@ -9,19 +9,19 @@
 	materials = list(MAT_METAL=1000)
 
 /obj/item/ammo_casing/shotgun/beanbag
-	name = "beanbag slug"
+	name = "12 gauge beanbag slug"
 	desc = "A weak beanbag slug for riot control."
 	icon_state = "bshell"
 	projectile_type = /obj/item/projectile/bullet/shotgun_beanbag
 
 /obj/item/ammo_casing/shotgun/incendiary
-	name = "incendiary slug"
+	name = "12 gauge incendiary slug"
 	desc = "An incendiary-coated shotgun slug."
 	icon_state = "ishell"
 	projectile_type = /obj/item/projectile/bullet/incendiary/shotgun
 
 /obj/item/ammo_casing/shotgun/dragonsbreath
-	name = "dragonsbreath shell"
+	name = "12 gauge dragonsbreath shell"
 	desc = "A shotgun shell which fires a spread of incendiary pellets."
 	icon_state = "ishell2"
 	projectile_type = /obj/item/projectile/bullet/incendiary/shotgun/dragonsbreath
@@ -29,20 +29,20 @@
 	variance = 35
 
 /obj/item/ammo_casing/shotgun/stunslug
-	name = "taser slug"
+	name = "12 gauge taser slug"
 	desc = "A stunning taser slug."
 	icon_state = "stunshell"
 	projectile_type = /obj/item/projectile/bullet/shotgun_stunslug
 	materials = list(MAT_METAL=250)
 
 /obj/item/ammo_casing/shotgun/meteorslug
-	name = "meteorslug shell"
+	name = "12 gauge meteor slug"
 	desc = "A shotgun shell rigged with CMC technology, which launches a massive slug when fired."
 	icon_state = "mshell"
 	projectile_type = /obj/item/projectile/bullet/shotgun_meteorslug
 
 /obj/item/ammo_casing/shotgun/pulseslug
-	name = "pulse slug"
+	name = "12 gauge pulse slug"
 	desc = "A delicate device which can be loaded into a shotgun. The primer acts as a button which triggers the gain medium and fires a powerful \
 	energy blast. While the heat and power drain limit it to one use, it can still allow an operator to engage targets that ballistic ammunition \
 	would have difficulty with."
@@ -50,13 +50,13 @@
 	projectile_type = /obj/item/projectile/beam/pulse/shotgun
 
 /obj/item/ammo_casing/shotgun/frag12
-	name = "FRAG-12 slug"
+	name = "12 gauge FRAG-12 slug"
 	desc = "A high explosive breaching round for a 12 gauge shotgun."
 	icon_state = "heshell"
 	projectile_type = /obj/item/projectile/bullet/shotgun_frag12
 
 /obj/item/ammo_casing/shotgun/buckshot
-	name = "buckshot shell"
+	name = "12 gauge buckshot shell"
 	desc = "A 12 gauge buckshot shell."
 	icon_state = "gshell"
 	projectile_type = /obj/item/projectile/bullet/pellet/shotgun_buckshot
@@ -64,7 +64,7 @@
 	variance = 35
 
 /obj/item/ammo_casing/shotgun/rubbershot
-	name = "rubber shot"
+	name = "12 gauge riot control shell"
 	desc = "A shotgun casing filled with densely-packed rubber balls, used to incapacitate crowds from a distance."
 	icon_state = "bshell"
 	projectile_type = /obj/item/projectile/bullet/pellet/shotgun_rubbershot
@@ -72,7 +72,7 @@
 	variance = 35
 
 /obj/item/ammo_casing/shotgun/improvised
-	name = "improvised shell"
+	name = "12 gauge improvised shell"
 	desc = "An extremely weak shotgun shell with multiple small pellets made out of metal shards."
 	icon_state = "improvshell"
 	projectile_type = /obj/item/projectile/bullet/pellet/shotgun_improvised
@@ -81,7 +81,7 @@
 	variance = 35
 
 /obj/item/ammo_casing/shotgun/ion
-	name = "ion shell"
+	name = "12 gauge ion shell"
 	desc = "An advanced shotgun shell which uses a subspace ansible crystal to produce an effect similar to a standard ion rifle. \
 	The unique properties of the crystal split the pulse into a spread of individually weaker bolts."
 	icon_state = "ionshell"
@@ -90,19 +90,19 @@
 	variance = 35
 
 /obj/item/ammo_casing/shotgun/laserslug
-	name = "laser slug"
+	name = "12 gauge laser slug"
 	desc = "An advanced shotgun shell that uses a micro laser to replicate the effects of a laser weapon in a ballistic package."
 	icon_state = "lshell"
 	projectile_type = /obj/item/projectile/beam/laser
 
 /obj/item/ammo_casing/shotgun/techshell
-	name = "unloaded technological shell"
+	name = "12 gauge unloaded technological shell"
 	desc = "A high-tech shotgun shell which can be loaded with materials to produce unique effects."
 	icon_state = "cshell"
 	projectile_type = null
 
 /obj/item/ammo_casing/shotgun/dart
-	name = "shotgun dart"
+	name = "12 gauge shotgun dart"
 	desc = "A dart for use in shotguns. Can be injected with up to 15 units of any chemical."
 	icon_state = "cshell"
 	projectile_type = /obj/item/projectile/bullet/dart
@@ -110,7 +110,7 @@
 	var/reagent_react = TRUE
 
 /obj/item/ammo_casing/shotgun/dart/noreact
-	name = "cryostasis shotgun dart"
+	name = "12 gauge cryostasis shotgun dart"
 	desc = "A dart for use in shotguns, using similar technolgoy as cryostatis beakers to keep internal reagents from reacting. Can be injected with up to 10 units of any chemical."
 	icon_state = "cnrshell"
 	reagent_amount = 10

--- a/code/modules/projectiles/ammunition/ballistic/sniper.dm
+++ b/code/modules/projectiles/ammunition/ballistic/sniper.dm
@@ -1,20 +1,20 @@
 // .50 (Sniper)
 
 /obj/item/ammo_casing/p50
-	name = ".50 bullet casing"
+	name = ".50 BMG bullet casing"
 	desc = "A .50 bullet casing."
 	caliber = ".50"
 	projectile_type = /obj/item/projectile/bullet/p50
 	icon_state = ".50"
 
 /obj/item/ammo_casing/p50/soporific
-	name = ".50 soporific bullet casing"
+	name = ".50 BMG tranquilzier bullet casing"
 	desc = "A .50 bullet casing, specialised in sending the target to sleep, instead of hell."
 	projectile_type = /obj/item/projectile/bullet/p50/soporific
 	icon_state = "sleeper"
 	harmful = FALSE
 
 /obj/item/ammo_casing/p50/penetrator
-	name = ".50 penetrator round bullet casing"
+	name = ".50 BMG armor piercing bullet casing"
 	desc = "A .50 caliber penetrator round casing."
 	projectile_type = /obj/item/projectile/bullet/p50/penetrator

--- a/code/modules/projectiles/ammunition/caseless/_caseless.dm
+++ b/code/modules/projectiles/ammunition/caseless/_caseless.dm
@@ -1,5 +1,5 @@
 /obj/item/ammo_casing/caseless
-	desc = "A caseless bullet casing."
+	desc = "A caseless bullet casing. You get a headache from looking at this."
 	firing_effect_type = null
 	heavy_metal = FALSE
 

--- a/code/modules/projectiles/ammunition/caseless/rocket.dm
+++ b/code/modules/projectiles/ammunition/caseless/rocket.dm
@@ -1,11 +1,11 @@
 /obj/item/ammo_casing/caseless/a84mm
-	desc = "An 84mm anti-armour rocket."
+	desc = "84mm AT rocket"
 	caliber = "84mm"
 	icon_state = "s-casing-live"
 	projectile_type = /obj/item/projectile/bullet/a84mm
 
 /obj/item/ammo_casing/caseless/a75
-	desc = "A .75 bullet casing."
+	desc = ".75mm bullet casing."
 	caliber = "75"
 	icon_state = "s-casing-live"
 	projectile_type = /obj/item/projectile/bullet/gyro

--- a/code/modules/projectiles/boxes_magazines/external/pistol.dm
+++ b/code/modules/projectiles/boxes_magazines/external/pistol.dm
@@ -14,13 +14,13 @@
 	ammo_type = /obj/item/ammo_casing/c10mm/fire
 
 /obj/item/ammo_box/magazine/m10mm/hp
-	name = "pistol magazine (10mm HP)"
+	name = "pistol magazine (10mm hollowpoint)"
 	icon_state = "9x19pH"
 	desc= "A gun magazine. Loaded with hollow-point rounds, extremely effective against unarmored targets, but nearly useless against protective clothing."
 	ammo_type = /obj/item/ammo_casing/c10mm/hp
 
 /obj/item/ammo_box/magazine/m10mm/ap
-	name = "pistol magazine (10mm AP)"
+	name = "pistol magazine (10mm armor piercing)"
 	icon_state = "9x19pA"
 	desc= "A gun magazine. Loaded with rounds which penetrate armour, but are less effective against normal targets."
 	ammo_type = /obj/item/ammo_casing/c10mm/ap

--- a/code/modules/projectiles/boxes_magazines/external/rechargable.dm
+++ b/code/modules/projectiles/boxes_magazines/external/rechargable.dm
@@ -1,5 +1,5 @@
 /obj/item/ammo_box/magazine/recharge
- 	name = "power pack"
+ 	name = "microfusion cell"
  	desc = "A rechargeable, detachable battery that serves as a magazine for laser rifles."
  	icon_state = "oldrifle-20"
  	ammo_type = /obj/item/ammo_casing/caseless/laser

--- a/code/modules/projectiles/boxes_magazines/external/shotgun.dm
+++ b/code/modules/projectiles/boxes_magazines/external/shotgun.dm
@@ -11,36 +11,36 @@
 	icon_state = "[initial(icon_state)]-[CEILING(ammo_count(0)/8, 1)*8]"
 
 /obj/item/ammo_box/magazine/m12g/stun
-	name = "shotgun magazine (12g taser slugs)"
+	name = "shotgun drum magazine (12g taser slugs)"
 	icon_state = "m12gs"
 	ammo_type = /obj/item/ammo_casing/shotgun/stunslug
 
 /obj/item/ammo_box/magazine/m12g/slug
-	name = "shotgun magazine (12g slugs)"
+	name = "shotgun drum magazine (12g slugs)"
 	icon_state = "m12gb"    //this may need an unique sprite
 	ammo_type = /obj/item/ammo_casing/shotgun
 
 /obj/item/ammo_box/magazine/m12g/dragon
-	name = "shotgun magazine (12g dragon's breath)"
+	name = "shotgun drum magazine (12g dragon's breath)"
 	icon_state = "m12gf"
 	ammo_type = /obj/item/ammo_casing/shotgun/dragonsbreath
 
 /obj/item/ammo_box/magazine/m12g/bioterror
-	name = "shotgun magazine (12g bioterror)"
+	name = "shotgun drum magazine (12g bioterror)"
 	icon_state = "m12gt"
 	ammo_type = /obj/item/ammo_casing/shotgun/dart/bioterror
 
 /obj/item/ammo_box/magazine/m12g/meteor
-	name = "shotgun magazine (12g meteor slugs)"
+	name = "shotgun drum magazine (12g meteor slugs)"
 	icon_state = "m12gbc"
 	ammo_type = /obj/item/ammo_casing/shotgun/meteorslug
 
 /obj/item/ammo_box/magazine/m12g/rubbershot
-	name = "shotgun magazine (12g rubbershot)"
+	name = "shotgun drum magazine (12g rubbershot)"
 	icon_state = "m12gb"
 	ammo_type = /obj/item/ammo_casing/shotgun/rubbershot
 
  /obj/item/ammo_box/magazine/m12g/beanslug
-	name = "shotgun magazine (12g beanbag slug)"
+	name = "shotgun drum magazine (12g beanbag slug)"
 	icon_state = "m12gb"
 	ammo_type = /obj/item/ammo_casing/shotgun/beanbag

--- a/code/modules/projectiles/boxes_magazines/external/smg.dm
+++ b/code/modules/projectiles/boxes_magazines/external/smg.dm
@@ -1,5 +1,5 @@
 /obj/item/ammo_box/magazine/wt550m9
-	name = "wt550 magazine (4.6x30mm)"
+	name = "submachinegun magazine (4.6x30mm)"
 	icon_state = "46x30mmt-20"
 	ammo_type = /obj/item/ammo_casing/c46x30mm
 	caliber = "4.6x30mm"
@@ -10,7 +10,7 @@
 	icon_state = "46x30mmt-[round(ammo_count(),4)]"
 
 /obj/item/ammo_box/magazine/wt550m9/wtap
-	name = "wt550 magazine (Armour Piercing 4.6x30mm)"
+	name = "submachinegun magazine (Armour Piercing 4.6x30mm)"
 	icon_state = "46x30mmtA-20"
 	ammo_type = /obj/item/ammo_casing/c46x30mm/ap
 
@@ -19,7 +19,7 @@
 	icon_state = "46x30mmtA-[round(ammo_count(),4)]"
 
 /obj/item/ammo_box/magazine/wt550m9/wtic
-	name = "wt550 magazine (Incindiary 4.6x30mm)"
+	name = "submachinegun magazine (Incindiary 4.6x30mm)"
 	icon_state = "46x30mmtI-20"
 	ammo_type = /obj/item/ammo_casing/c46x30mm/inc
 
@@ -39,7 +39,7 @@
 	icon_state = "uzi9mm-[round(ammo_count(),4)]"
 
 /obj/item/ammo_box/magazine/smgm9mm
-	name = "SMG magazine (9mm)"
+	name = "submachinegun magazine (9mm)"
 	icon_state = "smg9mm-42"
 	ammo_type = /obj/item/ammo_casing/c9mm
 	caliber = "9mm"
@@ -50,15 +50,15 @@
 	icon_state = "smg9mm-[ammo_count() ? "42" : "0"]"
 
 /obj/item/ammo_box/magazine/smgm9mm/ap
-	name = "SMG magazine (Armour Piercing 9mm)"
+	name = "submachinegun magazine (Armour Piercing 9mm)"
 	ammo_type = /obj/item/ammo_casing/c9mm/ap
 
 /obj/item/ammo_box/magazine/smgm9mm/fire
-	name = "SMG Magazine (Incindiary 9mm)"
+	name = "submachinegun magazine (Incindiary 9mm)"
 	ammo_type = /obj/item/ammo_casing/c9mm/inc
 
 /obj/item/ammo_box/magazine/smgm45
-	name = "SMG magazine (.45)"
+	name = "submachinegun magazine (.45)"
 	icon_state = "c20r45-24"
 	ammo_type = /obj/item/ammo_casing/c45
 	caliber = ".45"

--- a/code/modules/projectiles/boxes_magazines/external/sniper.dm
+++ b/code/modules/projectiles/boxes_magazines/external/sniper.dm
@@ -1,5 +1,5 @@
 /obj/item/ammo_box/magazine/sniper_rounds
-	name = "sniper rounds (.50)"
+	name = "box magazine (.50 BMG)"
 	icon_state = ".50mag"
 	ammo_type = /obj/item/ammo_casing/p50
 	max_ammo = 6
@@ -12,7 +12,7 @@
 		icon_state = "[initial(icon_state)]"
 
 /obj/item/ammo_box/magazine/sniper_rounds/soporific
-	name = "sniper rounds (Zzzzz)"
+	name = "box magazine (50. BMG tranquilizer)"
 	desc = "Soporific sniper rounds, designed for happy days and dead quiet nights..."
 	icon_state = "soporific"
 	ammo_type = /obj/item/ammo_casing/p50/soporific
@@ -20,7 +20,7 @@
 	caliber = ".50"
 
 /obj/item/ammo_box/magazine/sniper_rounds/penetrator
-	name = "sniper rounds (penetrator)"
+	name = "box magazine (50. BMG armor piercing)"
 	desc = "An extremely powerful round capable of passing straight through cover and anyone unfortunate enough to be behind it."
 	ammo_type = /obj/item/ammo_casing/p50/penetrator
 	max_ammo = 5

--- a/code/modules/projectiles/guns/ballistic.dm
+++ b/code/modules/projectiles/guns/ballistic.dm
@@ -221,7 +221,7 @@
 
 /obj/item/suppressor
 	name = "suppressor"
-	desc = "A universal syndicate small-arms suppressor for maximum espionage."
+	desc = "A milled titanium suppressor with an adaptive mounting bracket allowing it to be mounted on any weapon."
 	icon = 'icons/obj/guns/projectile.dmi'
 	icon_state = "suppressor"
 	w_class = WEIGHT_CLASS_TINY
@@ -230,6 +230,6 @@
 
 /obj/item/suppressor/specialoffer
 	name = "cheap suppressor"
-	desc = "A foreign knock-off suppressor, it feels flimsy, cheap, and brittle. Still fits all weapons."
+	desc = "A thin aluminium suppressor with an adaptive mounting bracket allowing it to be mounted on any weapon. You hear something rattling inside it."
 	icon = 'icons/obj/guns/projectile.dmi'
 	icon_state = "suppressor"

--- a/code/modules/projectiles/guns/ballistic/automatic.dm
+++ b/code/modules/projectiles/guns/ballistic/automatic.dm
@@ -9,7 +9,7 @@
 	actions_types = list(/datum/action/item_action/toggle_firemode)
 
 /obj/item/gun/ballistic/automatic/proto
-	name = "\improper Nanotrasen Saber SMG"
+	name = "compact submachine gun"
 	desc = "A prototype three-round burst 9mm submachine gun, designated 'SABR'. Has a threaded barrel for suppressors."
 	icon_state = "saber"
 	mag_type = /obj/item/ammo_box/magazine/smgm9mm
@@ -84,7 +84,7 @@
 	return
 
 /obj/item/gun/ballistic/automatic/c20r
-	name = "\improper Advanced SMG"
+	name = "tactical submachine gun"
 	desc = "A bullpup three-round burst .45 SMG, can be suppressed."
 	icon_state = "c20r"
 	item_state = "c20r"
@@ -114,7 +114,7 @@
 	icon_state = "c20r[magazine ? "-[CEILING(get_ammo(0)/4, 1)*4]" : ""][chambered ? "" : "-e"][suppressed ? "-suppressed" : ""]"
 
 /obj/item/gun/ballistic/automatic/wt550
-	name = "Advanced SMG"
+	name = "manufactured submachine gun"
 	desc = "A very advanced SMG that can be suppressed, takes unique ammo and starts off with a advanced firing pin."
 	icon_state = "wt550"
 	item_state = "arg"
@@ -133,7 +133,7 @@
 	icon_state = "wt550[magazine ? "-[CEILING(get_ammo(0)/4, 1)*4]" : ""]"
 
 /obj/item/gun/ballistic/automatic/m90
-	name = "\improper M-90gl Carbine"
+	name = "\improper M90gl Carbine"
 	desc = "A three-round burst 5.56 toploading carbine, designated 'M-90gl'. Has an attached underbarrel grenade launcher which can be toggled on and off."
 	icon_state = "m90"
 	item_state = "m90"
@@ -204,7 +204,7 @@
 	return
 
 /obj/item/gun/ballistic/automatic/ar
-	name = "\improper Advanced Assault Rifle"
+	name = "combat rifle mark II"
 	desc = "A robust assault rifle used by most likely advanced fighting forces."
 	icon_state = "arg"
 	item_state = "arg"
@@ -219,7 +219,7 @@
 // Bulldog shotgun //
 
 /obj/item/gun/ballistic/automatic/shotgun/bulldog
-	name = "\improper Advanced Shotgun"
+	name = "assault shotgun"
 	desc = "A semi-auto, mag-fed shotgun for combat in narrow corridors. Compatible only with specialized 8-round drum magazines."
 	icon_state = "bulldog"
 	item_state = "bulldog"
@@ -331,7 +331,7 @@
 // SNIPER //
 
 /obj/item/gun/ballistic/automatic/sniper_rifle
-	name = "sniper rifle"
+	name = "anti materiel rifle"
 	desc = "A long ranged weapon that does significant damage. No, you can't quickscope."
 	icon_state = "sniper"
 	item_state = "sniper"
@@ -358,14 +358,14 @@
 
 
 /obj/item/gun/ballistic/automatic/sniper_rifle/syndicate
-	name = "syndicate sniper rifle"
+	name = "anti materiel rifle mark II"
 	desc = "An illegally modified .50 cal sniper rifle with suppression compatibility. Quickscoping still doesn't work."
 	pin = /obj/item/firing_pin/implant/pindicate
 
 // Old Semi-Auto Rifle //
 
 /obj/item/gun/ballistic/automatic/surplus
-	name = "Surplus Rifle"
+	name = "semi automatic rifle"
 	desc = "One of countless obsolete ballistic rifles that still sees use as a cheap deterrent. Uses 10mm ammo and its bulky frame prevents one-hand firing."
 	icon_state = "surplus"
 	item_state = "moistnugget"
@@ -552,7 +552,7 @@
 	zoom_out_amt = 13
 
 /obj/item/gun/ballistic/automatic/m72
-	name = "M72 Gauss Rifle"
+	name = "M72 gauss rifle"
 	desc = "The M72 rifle is of German design. It uses an electromagnetic field to propel rounds at tremendous speed... and pierce almost any obstacle. Its range, accuracy and stopping power is almost unparalleled."
 	icon_state = "m72"
 	item_state = "shotgun"
@@ -586,7 +586,7 @@
 //Fallout 13
 //Magazines
 /obj/item/ammo_box/magazine/r20
-	name = "r20 Magazine (5.56mm)"
+	name = ".556 Magazine (5.56mm)"
 	icon_state = "r20"
 	ammo_type = /obj/item/ammo_casing/a556
 	caliber = "a556"

--- a/code/modules/projectiles/guns/ballistic/launchers.dm
+++ b/code/modules/projectiles/guns/ballistic/launchers.dm
@@ -3,7 +3,7 @@
 
 /obj/item/gun/ballistic/revolver/grenadelauncher//this is only used for underbarrel grenade launchers at the moment, but admins can still spawn it if they feel like being assholes
 	desc = "A break-operated grenade launcher."
-	name = "grenade launcher"
+	name = "M79 grenade launcher"
 	icon_state = "dshotgun-sawn"
 	item_state = "gun"
 	mag_type = /obj/item/ammo_box/magazine/internal/grenadelauncher
@@ -21,7 +21,7 @@
 
 /obj/item/gun/ballistic/revolver/grenadelauncher/cyborg
 	desc = "A 6-shot grenade launcher."
-	name = "multi grenade launcher"
+	name = "Milkor MGL"
 	icon = 'icons/mecha/mecha_equipment.dmi'
 	icon_state = "mecha_grenadelnchr"
 	mag_type = /obj/item/ammo_box/magazine/internal/cylinder/grenademulti
@@ -76,7 +76,7 @@
 
 /obj/item/gun/ballistic/automatic/atlauncher
 	desc = "A pre-loaded, single shot anti-armour launcher."
-	name = "anti-armour grenade launcher"
+	name = "M72 LAW"
 	icon_state = "rocketlauncher"
 	item_state = "rocketlauncher"
 	mag_type = /obj/item/ammo_box/magazine/internal/rocketlauncher

--- a/code/modules/projectiles/guns/ballistic/shotgun.dm
+++ b/code/modules/projectiles/guns/ballistic/shotgun.dm
@@ -1,5 +1,5 @@
 /obj/item/gun/ballistic/shotgun
-	name = "Ithaca Model 37"
+	name = "Ithaca M37"
 	desc = "A traditional hunting shotgun with wood furniture and a four-shell capacity underneath."
 	icon_state = "Itaca"
 	item_state = "huntingshotgun"
@@ -260,7 +260,7 @@
 
 // RIOT SHOTGUN //
 /obj/item/gun/ballistic/shotgun/riot //for spawn in the armory
-	name = "BHS M1"
+	name = "Remington 870"
 	desc = "A Big Heavy Shotgun Model 1, the staple of pre-war riot controll grade shotguns with a longer magazine and a fixed heavy reinforced tactical stock designed for tactical use when tactically bashing heads."
 	icon_state = "riotshotgun"
 	item_state = "shotgunriot"

--- a/code/modules/projectiles/guns/energy/energy_gun.dm
+++ b/code/modules/projectiles/guns/energy/energy_gun.dm
@@ -51,7 +51,7 @@
 	icon_state = "decloner"
 
 /obj/item/gun/energy/e_gun/hos
-	name = "\improper X-01 MultiPhase Energy Gun"
+	name = "AER17 hybrid laser gun"
 	desc = "This is an expensive, modern recreation of an antique laser gun. This gun has several unique firemodes, but lacks the ability to recharge over time."
 	icon_state = "hoslaser"
 	force = 10
@@ -76,7 +76,7 @@
 	ammo_type = list(/obj/item/ammo_casing/energy/trap)
 
 /obj/item/gun/energy/e_gun/turret
-	name = "hybrid turret gun"
+	name = "heavy energy cannon"
 	desc = "A heavy hybrid energy cannon with two settings: Stun and kill."
 	icon_state = "turretlaser"
 	item_state = "turretlaser"

--- a/code/modules/projectiles/guns/energy/laser.dm
+++ b/code/modules/projectiles/guns/energy/laser.dm
@@ -138,7 +138,7 @@
 //Fallout
 
 /obj/item/gun/energy/laser/lasergatling
-	name = "H&K L30 Gatling laser"
+	name = "H&K L30 gatling laser"
 	desc = "Designed specifically for military use, these were in the prototype stage at the beginning of the Great War. Multiple barrels allowed longer firing before overheating."
 	icon_state = "lasergatling"
 	burst_size = 8
@@ -149,7 +149,7 @@
 	w_class = WEIGHT_CLASS_HUGE
 
 /obj/item/gun/energy/laser/aer9
-	name = "AER9 Laser Rifle"
+	name = "AER9 laser rifle"
 	desc = "A sturdy and advanced military grade pre-war service laser rifle"
 	icon_state = "laser"
 	item_state = "laser-rifle9"
@@ -168,7 +168,7 @@
 	cell_type = /obj/item/stock_parts/cell/ammo/ec
 
 /obj/item/gun/energy/laser/scatter
-	name = "Tri-beam Laser Rifle"
+	name = "tribeam laser rifle"
 	desc = "A modified AER9 equipped with a refraction kit that spreads its bolts. It is usually only given to high-ranking soldiers within the Brotherhood, due to it's level of technology, as well as its reputation of friendly fire."
 	item_state = "laser-rifle9"
 	ammo_type = list(/obj/item/ammo_casing/energy/laser/scatter)
@@ -176,7 +176,7 @@
 	w_class = WEIGHT_CLASS_BULKY
 
 /obj/item/gun/energy/laser/plasma
-	name ="A3-20 Plasma Rifle"
+	name ="plasma rifle"
 	item_state = "plasma"
 	icon_state = "plasma"
 	desc = "A top of line miniaturized plasma caster built by REPCONN in the wake of the Z43-521P failure. It is supperior to all previous rifles to enter service in the USCC."
@@ -185,7 +185,7 @@
 	w_class = WEIGHT_CLASS_BULKY
 
 /obj/item/gun/energy/laser/plasma/scatter
-	name = "A3e-20b Multiplas Rifle"
+	name = "multiplas Rifle"
 	item_state = "multiplas"
 	icon_state = "multiplas"
 	desc = "A modified A3-20 plasma caster built by REPCONN equipped with a multicasting kit that creates multiple weaker clots."
@@ -193,7 +193,7 @@
 	cell_type = /obj/item/stock_parts/cell/ammo/mfc
 
 /obj/item/gun/energy/laser/plasma/pistol
-	name ="MPL-A Plasma Pistol"
+	name ="plasma pistol"
 	item_state = "plasma-pistol"
 	icon_state = "plasma-pistol"
 	desc = "A pistol-sized miniaturized plasma caster built by REPCONN. It fires heavy low penetration plasma clots."

--- a/code/modules/projectiles/guns/energy/pulse.dm
+++ b/code/modules/projectiles/guns/energy/pulse.dm
@@ -73,7 +73,7 @@
 
 /obj/item/gun/energy/pulse/pistol/m1911
 	name = "\improper M1911-P"
-	desc = "A compact pulse core in a classic handgun frame for Nanotrasen officers. It's not the size of the gun, it's the size of the hole it puts through people."
+	desc = "A compact pulse core in a classic handgun frame for RobCo officers. It's not the size of the gun, it's the size of the hole it puts through people."
 	icon_state = "m1911"
 	item_state = "gun"
 	cell_type = "/obj/item/stock_parts/cell/infinite"

--- a/code/modules/projectiles/guns/energy/special.dm
+++ b/code/modules/projectiles/guns/energy/special.dm
@@ -73,7 +73,7 @@
 
 /obj/item/gun/energy/mindflayer
 	name = "\improper Mind Flayer"
-	desc = "A prototype weapon recovered from the ruins of Research-Station Epsilon."
+	desc = "A prototype weapon recovered from the ruins of Research-Site Epsilon."
 	icon_state = "xray"
 	item_state = null
 	ammo_type = list(/obj/item/ammo_casing/energy/mindflayer)
@@ -81,7 +81,7 @@
 
 /obj/item/gun/energy/kinetic_accelerator/crossbow
 	name = "mini energy crossbow"
-	desc = "A weapon favored by syndicate stealth specialists."
+	desc = "A weapon favored by communist stealth specialists."
 	icon_state = "crossbow"
 	item_state = "crossbow"
 	w_class = WEIGHT_CLASS_SMALL
@@ -98,14 +98,14 @@
 
 /obj/item/gun/energy/kinetic_accelerator/crossbow/halloween
 	name = "candy corn crossbow"
-	desc = "A weapon favored by Syndicate trick-or-treaters."
+	desc = "A weapon favored by communist trick-or-treaters."
 	icon_state = "crossbow_halloween"
 	item_state = "crossbow"
 	ammo_type = list(/obj/item/ammo_casing/energy/bolt/halloween)
 
 /obj/item/gun/energy/kinetic_accelerator/crossbow/large
 	name = "energy crossbow"
-	desc = "A reverse engineered weapon using syndicate technology."
+	desc = "A reverse engineered weapon using communist technology."
 	icon_state = "crossbowlarge"
 	w_class = WEIGHT_CLASS_NORMAL
 	materials = list(MAT_METAL=4000)
@@ -115,7 +115,7 @@
 
 /obj/item/gun/energy/plasmacutter
 	name = "plasma cutter"
-	desc = "A mining tool capable of expelling concentrated plasma bursts. You could use it to cut limbs off xenos! Or, you know, mine stuff."
+	desc = "A mining tool capable of expelling concentrated plasma bursts. You could use it to cut limbs off communist! Or, you know, mine stuff."
 	icon_state = "plasmacutter"
 	item_state = "plasmacutter"
 	ammo_type = list(/obj/item/ammo_casing/energy/plasma/weak)

--- a/code/modules/projectiles/guns/misc/beam_rifle.dm
+++ b/code/modules/projectiles/guns/misc/beam_rifle.dm
@@ -9,7 +9,7 @@
 #define AIMING_BEAM_ANGLE_CHANGE_THRESHOLD 0.1
 
 /obj/item/gun/energy/beam_rifle
-	name = "particle acceleration rifle"
+	name = "railgun"
 	desc = "An energy-based anti material marksman rifle that uses highly charged particle beams moving at extreme velocities to decimate whatever is unfortunate enough to be targetted by one. \
 		<span class='boldnotice'>Hold down left click while scoped to aim, when weapon is fully aimed (Tracer goes from red to green as it charges), release to fire. Moving while aiming or \
 		changing where you're pointing at while aiming will delay the aiming process depending on how much you changed.</span>"

--- a/code/modules/projectiles/guns/misc/chem_gun.dm
+++ b/code/modules/projectiles/guns/misc/chem_gun.dm
@@ -2,7 +2,7 @@
 //this is meant to hold reagents/obj/item/gun/syringe
 /obj/item/gun/chem
 	name = "reagent gun"
-	desc = "A Nanotrasen syringe gun, modified to automatically synthesise chemical darts, and instead hold reagents."
+	desc = "A US Army syringe gun, modified to automatically synthesise chemical darts, and instead hold reagents."
 	icon_state = "chemgun"
 	item_state = "chemgun"
 	w_class = WEIGHT_CLASS_NORMAL

--- a/code/modules/projectiles/guns/misc/medbeam.dm
+++ b/code/modules/projectiles/guns/misc/medbeam.dm
@@ -1,5 +1,5 @@
 /obj/item/gun/medbeam
-	name = "Medical Beamgun"
+	name = "medical beamgun"
 	desc = "Don't cross the streams!"
 	icon = 'icons/obj/chronos.dmi'
 	icon_state = "chronogun"

--- a/code/modules/security_levels/keycard_authentication.dm
+++ b/code/modules/security_levels/keycard_authentication.dm
@@ -6,7 +6,7 @@ GLOBAL_DATUM_INIT(keycard_events, /datum/events, new)
 
 /obj/machinery/keycard_auth
 	name = "Keycard Authentication Device"
-	desc = "This device is used to trigger station functions, which require more than one ID card to authenticate."
+	desc = "This device is used to trigger region functions, which require more than one ID card to authenticate."
 	icon = 'icons/obj/monitors.dmi'
 	icon_state = "auth_off"
 	use_power = IDLE_POWER_USE
@@ -120,7 +120,7 @@ GLOBAL_VAR_INIT(emergency_access, FALSE)
 		for(var/obj/machinery/door/airlock/D in A)
 			D.emergency = TRUE
 			D.update_icon(0)
-	minor_announce("Access restrictions on maintenance and external airlocks have been lifted.", "Attention! Station-wide emergency declared!",1)
+	minor_announce("Access restrictions on maintenance and external passages have been lifted.", "Attention! Region-wide emergency declared!",1)
 	GLOB.emergency_access = TRUE
 	SSblackbox.record_feedback("nested tally", "keycard_auths", 1, list("emergency maintenance access", "enabled"))
 
@@ -129,13 +129,13 @@ GLOBAL_VAR_INIT(emergency_access, FALSE)
 		for(var/obj/machinery/door/airlock/D in A)
 			D.emergency = FALSE
 			D.update_icon(0)
-	minor_announce("Access restrictions in maintenance areas have been restored.", "Attention! Station-wide emergency rescinded:")
+	minor_announce("Access restrictions in maintenance areas have been restored.", "Attention! Region-wide emergency rescinded:")
 	GLOB.emergency_access = FALSE
 	SSblackbox.record_feedback("nested tally", "keycard_auths", 1, list("emergency maintenance access", "disabled"))
 
 /proc/toggle_bluespace_artillery()
 	GLOB.bsa_unlock = !GLOB.bsa_unlock
-	minor_announce("Bluespace Artillery firing protocols have been [GLOB.bsa_unlock? "unlocked" : "locked"]", "Weapons Systems Update:")
+	minor_announce("Artillery firing protocols have been [GLOB.bsa_unlock? "unlocked" : "locked"]", "Weapons Systems Update:")
 	SSblackbox.record_feedback("nested tally", "keycard_auths", 1, list("bluespace artillery", GLOB.bsa_unlock? "unlocked" : "locked"))
 
 #undef KEYCARD_RED_ALERT

--- a/code/modules/station_goals/bsa.dm
+++ b/code/modules/station_goals/bsa.dm
@@ -3,14 +3,14 @@
 // Requires high amount of power
 // Requires high level stock parts
 /datum/station_goal/bluespace_cannon
-	name = "Bluespace Artillery"
+	name = "Artillery"
 
 /datum/station_goal/bluespace_cannon/get_report()
 	return {"Our military presence is inadequate in your sector.
-	 We need you to construct BSA-[rand(1,99)] Artillery position aboard your station.
+	 We need you to construct an artillery position within your region.
 
-	 Base parts are available for shipping via cargo.
-	 -Nanotrasen Naval Command"}
+	 Base parts are available for shipping via air drop.
+	 -Enclave 14th Fire Support Regiment"}
 
 /datum/station_goal/bluespace_cannon/on_report()
 	//Unlock BSA parts
@@ -35,7 +35,7 @@
 	return TRUE
 
 /obj/machinery/bsa/back
-	name = "Bluespace Artillery Generator"
+	name = "Artillery Generator"
 	desc = "Generates cannon pulse. Needs to be linked with a fusor."
 	icon_state = "power_box"
 
@@ -49,7 +49,7 @@
 	return TRUE
 
 /obj/machinery/bsa/front
-	name = "Bluespace Artillery Bore"
+	name = "Artillery Bore"
 	desc = "Do not stand in front of cannon during operation. Needs to be linked with a fusor."
 	icon_state = "emitter_center"
 
@@ -63,8 +63,8 @@
 	return TRUE
 
 /obj/machinery/bsa/middle
-	name = "Bluespace Artillery Fusor"
-	desc = "Contents classified by Nanotrasen Naval Command. Needs to be linked with the other BSA parts using multitool."
+	name = "Artillery Fusor"
+	desc = "Contents classified by Nanotrasen Naval Command. Needs to be linked with the other artillery parts using multitool."
 	icon_state = "fuel_chamber"
 	var/obj/machinery/bsa/back/back
 	var/obj/machinery/bsa/front/front
@@ -122,8 +122,8 @@
 
 
 /obj/machinery/bsa/full
-	name = "Bluespace Artillery"
-	desc = "Long range bluespace artillery."
+	name = "Artillery"
+	desc = "Long range artillery."
 	icon = 'icons/obj/lavaland/cannon.dmi'
 	icon_state = "orbital_cannon1"
 	var/static/mutable_appearance/top_layer
@@ -209,7 +209,7 @@
 	return
 
 /obj/machinery/computer/bsa_control
-	name = "bluespace artillery control"
+	name = "artillery control computer"
 	var/obj/machinery/bsa/full/cannon
 	var/notice
 	var/target
@@ -291,7 +291,7 @@
 
 	var/obj/machinery/bsa/middle/centerpiece = locate() in range(7)
 	if(!centerpiece)
-		notice = "No BSA parts detected nearby."
+		notice = "No artillery parts detected nearby."
 		return null
 	notice = centerpiece.check_completion()
 	if(notice)


### PR DESCRIPTION
## Description
anything that was a name of a object (baseball bat, golf club, machete) was made non-capitalized
anything with a brand name (Glock, SIG, Berreta) was given a model designation and capitalized
anything that had neither was given a simple name (assault shotgun, combat rifle) and so forth
anything that had a simple designation with a non-lore binding designation (R91 infiltrator and most of the r-series) had their designations updated for consistency
anything mentioning stuff from SS13 was changed or removed completely
adds a legion buckler
buffs mops significantly (literally the best change in the game)


## Motivation and Context
consistency in naming things, gives legion more than one kind of shield, and makes cleaning (objectively the most useful task in the game) easier by making the ONE feasible cleaning tool better at doing the one thing it exists for. Cleaning.

## How Has This Been Tested?
checked and travis

## Screenshots (if appropriate):

they arent
