### PR TITLE
healing powder crafting time nerf

### DIFF
--- a/code/modules/crafting/recipes.dm
+++ b/code/modules/crafting/recipes.dm
@@ -636,7 +636,7 @@
 	result = /obj/item/reagent_containers/pill/patch/healingpowder
 	reqs = list(/obj/item/reagent_containers/food/snacks/grown/broc = 1,
 				/obj/item/reagent_containers/food/snacks/grown/xander = 1)
-	time = 20
+	time = 150
 	category = CAT_DRUGS
 
 /datum/crafting_recipe/stimpak


### PR DESCRIPTION
per ghostecho.

it's just an increase to the crafting time of healing powder, to solve the problem of legionnaires crafting hundreds of healing powders every round in an enormous quantity and bringing plant bags with them to craft healing powder on the go and so forth.

instead of 30 healing powder per minute, they can now make 4.