### PR TITLE
Reverts "healing powder nerf"

### DIFF
--- a/code/modules/crafting/recipes.dm
+++ b/code/modules/crafting/recipes.dm
@@ -636,7 +636,7 @@
 	result = /obj/item/reagent_containers/pill/patch/healingpowder
 	reqs = list(/obj/item/reagent_containers/food/snacks/grown/broc = 1,
 				/obj/item/reagent_containers/food/snacks/grown/xander = 1)
-	time = 150
+	time = 20
 	category = CAT_DRUGS
 
 /datum/crafting_recipe/stimpak


### PR DESCRIPTION
Reverts #525

As quoted by the orginal pr by @AdamElTablawy 

> it's just an increase to the crafting time of healing powder, to solve the problem of legionnaires crafting hundreds of healing powders every round in an enormous quantity and bringing plant bags with them to craft healing powder on the go and so forth.

As first i like to point out this is a non existant issue.

> an enormous quantity and bringing plant bags with them to craft healing powder on the go and so forth

If anything they should be rewarded by doing this.
If the legion crafts powder on to go it encourages RP, and if they do it midbattle they should be rewarded for it. as it takes 2 seconds of standing still to make it and 2 seconds to apply it.

As not pointed out by the nerf, it still allows them to carry 30 healing powder bags in a chemistry satchel, which makes the plant bag issue irrelevant. preparation beats everything.

Considering the factors that this nerfs the legion, they can't use technology or any close relative thing. so they are stuck with healing powder.

While the NCR can use healing powder. and chem dispenser which is easily able to spit out 100 U heal beakers in a batch of 2-4 seconds. nerfing the healing powder crafting time has no point. just to serve as an inconvience. (i mean you can make a chainsaw faster then mixing broc and xander!) it also delays greatly stimpacks making by a full 17 seconds.

They have to grow the plants. harvest them. craft it into healing powder which takes around a couple of minutes.

> healing powder, to solve the problem of legionnaires crafting hundreds of healing powders every round

As again this is not a issue. its the only way legion can heal as they cannot use chems.

