### PR TITLE
Changes farm animals and medical reagents

### DIFF
--- a/code/modules/mob/living/simple_animal/friendly/farm_animals.dm
+++ b/code/modules/mob/living/simple_animal/friendly/farm_animals.dm
@@ -129,6 +129,7 @@
 	var/obj/item/udder/udder = null
 	gold_core_spawnable = FRIENDLY_SPAWN
 	blood_volume = BLOOD_VOLUME_NORMAL
+	faction = list("neutral", "wastebot")
 
 /mob/living/simple_animal/cow/Initialize()
 	udder = new()
@@ -205,6 +206,7 @@
 	pass_flags = PASSTABLE | PASSGRILLE | PASSMOB
 	mob_size = MOB_SIZE_TINY
 	gold_core_spawnable = FRIENDLY_SPAWN
+	faction = list("neutral", "wastebot")
 
 /mob/living/simple_animal/chick/Initialize()
 	. = ..()
@@ -261,6 +263,7 @@
 	var/list/validColors = list("brown","black","white")
 	gold_core_spawnable = FRIENDLY_SPAWN
 	var/static/chicken_count = 0
+	faction = list("neutral", "wastebot")
 
 /mob/living/simple_animal/chicken/Initialize()
 	. = ..()

--- a/code/modules/reagents/chemistry/reagents/medicine_reagents.dm
+++ b/code/modules/reagents/chemistry/reagents/medicine_reagents.dm
@@ -1277,7 +1277,7 @@
 
 /datum/reagent/medicine/stimpak/overdose_process(mob/living/M)
 	M.adjustToxLoss(2.5*REM, 0)
-	M.adjustOxyLoss(4*REM, 0)
+	M.adjustOxyLoss(7*REM, 0)
 	..()
 	. = 1
 

--- a/code/modules/reagents/chemistry/reagents/medicine_reagents.dm
+++ b/code/modules/reagents/chemistry/reagents/medicine_reagents.dm
@@ -1276,8 +1276,8 @@
 	..()
 
 /datum/reagent/medicine/stimpak/overdose_process(mob/living/M)
-	M.adjustToxLoss(3*REM, 0)
-	M.adjustOxyLoss(5*REM, 0)
+	M.adjustToxLoss(2.5*REM, 0)
+	M.adjustOxyLoss(4*REM, 0)
 	..()
 	. = 1
 
@@ -1299,8 +1299,8 @@
 	..()
 
 /datum/reagent/medicine/healing_powder/overdose_process(mob/living/M)
-	M.adjustToxLoss(2.5*REM, 0)
-	M.adjustOxyLoss(3*REM, 0)
+	M.adjustToxLoss(2*REM, 0)
+	M.adjustOxyLoss(4*REM, 0)
 	..()
 	. = 1
 

--- a/code/modules/reagents/chemistry/reagents/medicine_reagents.dm
+++ b/code/modules/reagents/chemistry/reagents/medicine_reagents.dm
@@ -1258,6 +1258,7 @@
 	color = "#C8A5DC"
 	taste_description = "grossness"
 	metabolization_rate = 3 * REAGENTS_METABOLISM
+	overdose_threshold = 20
 
 /datum/reagent/medicine/stimpak/reaction_mob(mob/living/M, method=TOUCH, reac_volume, show_message = 1)
 	if(iscarbon(M) && M.stat != DEAD)
@@ -1274,6 +1275,12 @@
 	. = 1
 	..()
 
+/datum/reagent/medicine/stimpak/overdose_process(mob/living/M)
+	M.adjustToxLoss(3*REM, 0)
+	M.adjustOxyLoss(5*REM, 0)
+	..()
+	. = 1
+
 /datum/reagent/medicine/healing_powder
 	name = "Healing Powder"
 	id = "healing_powder"
@@ -1285,17 +1292,15 @@
 	overdose_threshold = 30
 
 /datum/reagent/medicine/healing_powder/on_mob_life(mob/living/M)
-	M.adjustFireLoss(-2*REM)
-	M.adjustBruteLoss(-2*REM)
+	M.adjustFireLoss(-3*REM)
+	M.adjustBruteLoss(-3*REM)
 	M.hallucination = max(M.hallucination, 5)
-	if(prob(7))
-		M.emote(pick("twitch","drool","moan","giggle"))
 	. = 1
 	..()
 
 /datum/reagent/medicine/healing_powder/overdose_process(mob/living/M)
-	M.adjustToxLoss(4*REM, 0)
-	M.adjustOxyLoss(4*REM, 0)
+	M.adjustToxLoss(2.5*REM, 0)
+	M.adjustOxyLoss(3*REM, 0)
 	..()
 	. = 1
 


### PR DESCRIPTION
Nerfs stimpak indirectly by giving it an OD threshold of 20 and a very vicious OD effect (again, this will never impact newbie players).

Improves healing powder back to before it was originally nerfed, and the OD has been made slightly more gentle (there was no reason to reduce it - the combination of hallucinations and absolutely fierce OD rating put harsh limits on usability in combat).

Gives farm animals the wastebot faction so robots no longer attack them.

Except for goats.

Goats are assholes.