### PR TITLE
Makes Legate in setup invisible

### DIFF
--- a/code/modules/jobs/job_types/legion.dm
+++ b/code/modules/jobs/job_types/legion.dm
@@ -40,7 +40,7 @@ Needs whitelist
 */
 /datum/job/CaesarsLegion/Legionnaire/f13legate
 	title = "Legate"
-	faction = "Legion"
+//	faction = "Legion"
 	flag = F13LEGATE
 	head_announce = list("Security")
 	supervisors = "Caesar"


### PR DESCRIPTION
What jobs are displayed for setup are dependent on whether or not the faction is set to null or not, and it also determines where they appear in the list.

This does not actually influence whether or not players can join as that job slot.