### PR TITLE
Attempt numero uno on jobs and quirks not saving

### DIFF
--- a/code/__DEFINES/jobs.dm
+++ b/code/__DEFINES/jobs.dm
@@ -42,6 +42,8 @@
 #define MIME			(1<<12)
 #define ASSISTANT		(1<<13)
 
+#define JOB_DISPLAY_ORDER_DEFAULT 0
+
 //F13
 
 #define NCR				(1<<3)

--- a/code/__HELPERS/cmp.dm
+++ b/code/__HELPERS/cmp.dm
@@ -81,3 +81,24 @@ GLOBAL_VAR_INIT(cmp_field, "name")
 
 /proc/cmp_advdisease_resistance_asc(datum/disease/advance/A, datum/disease/advance/B)
 	return A.totalResistance() - B.totalResistance()
+
+/proc/cmp_quirk_asc(datum/quirk/A, datum/quirk/B)
+	var/a_sign = num2sign(initial(A.value) * -1)
+	var/b_sign = num2sign(initial(B.value) * -1)
+
+	// Neutral traits go last.
+	if(a_sign == 0)
+		a_sign = 2
+	if(b_sign == 0)
+		b_sign = 2
+
+	var/a_name = initial(A.name)
+	var/b_name = initial(B.name)
+
+	if(a_sign != b_sign)
+		return a_sign - b_sign
+	else
+		return sorttext(b_name, a_name)
+
+/proc/cmp_job_display_asc(datum/job/A, datum/job/B)
+	return A.display_order - B.display_order

--- a/code/__HELPERS/unsorted.dm
+++ b/code/__HELPERS/unsorted.dm
@@ -1595,3 +1595,11 @@ GLOBAL_DATUM_INIT(dview_mob, /mob/dview, new)
 	for(var/i in L)
 		if(condition.Invoke(i))
 			. |= i
+
+/proc/num2sign(numeric)
+	if(numeric > 0)
+		return 1
+	else if(numeric < 0)
+		return -1
+	else
+		return 0

--- a/code/controllers/subsystem/processing/quirks.dm
+++ b/code/controllers/subsystem/processing/quirks.dm
@@ -18,7 +18,9 @@ PROCESSING_SUBSYSTEM_DEF(quirks)
 	..()
 
 /datum/controller/subsystem/processing/quirks/proc/SetupQuirks()
-	for(var/V in subtypesof(/datum/quirk))
+	var/list/quirk_list = sortList(subtypesof(/datum/quirk), /proc/cmp_quirk_asc)
+
+	for(var/V in quirk_list)
 		var/datum/quirk/T = V
 		quirks[initial(T.name)] = T
 		quirk_points[initial(T.name)] = initial(T.value)
@@ -29,6 +31,4 @@ PROCESSING_SUBSYSTEM_DEF(quirks)
 		user.add_quirk(V, spawn_effects)
 
 /datum/controller/subsystem/processing/quirks/proc/GenerateQuirks(client/user)
-	if(user.prefs.character_quirks.len)
-		return
 	user.prefs.character_quirks = user.prefs.all_quirks

--- a/code/modules/client/preferences.dm
+++ b/code/modules/client/preferences.dm
@@ -671,7 +671,7 @@ GLOBAL_LIST_EMPTY(preferences_datums)
 
 		var/datum/job/overflow = SSjob.GetJob(SSjob.overflow_role)
 
-		for(var/datum/job/job in SSjob.occupations)
+		for(var/datum/job/job in sortList(SSjob.occupations, /proc/cmp_job_display_asc))
 
 			index += 1
 			if((index >= limit) || (job.title in splitJobs))

--- a/code/modules/client/preferences_savefile.dm
+++ b/code/modules/client/preferences_savefile.dm
@@ -252,7 +252,8 @@ SAVEFILE UPDATING/VERSIONING - 'Simplified', or rather, more coder-friendly ~Car
 	S["deity_name"]			>> custom_names["deity"]
 	S["prefered_security_department"] >> prefered_security_department
 
-	//Jobs
+//Jobs - Whoever put this together was a bastard - Nappist
+//SS13 roles
 	S["joblessrole"]		>> joblessrole
 	S["job_civilian_high"]	>> job_civilian_high
 	S["job_civilian_med"]	>> job_civilian_med
@@ -264,6 +265,36 @@ SAVEFILE UPDATING/VERSIONING - 'Simplified', or rather, more coder-friendly ~Car
 	S["job_engsec_med"]		>> job_engsec_med
 	S["job_engsec_low"]		>> job_engsec_low
 
+//Fallout13 roles
+	S["job_ncr_high"]		>> job_ncr_high
+	S["job_ncr_med"]		>> job_ncr_med
+	S["job_ncr_low"]		>> job_ncr_low
+
+	S["job_legion_high"]	>> job_legion_high
+	S["job_legion_med"]		>> job_legion_med
+	S["job_legion_low"]		>> job_legion_low
+
+	S["job_bos_high"]		>> job_bos_high
+	S["job_bos_med"]		>> job_bos_med
+	S["job_bos_low"]		>> job_bos_low
+
+	S["job_den_high"]		>> job_den_high
+	S["job_den_med"]		>> job_den_med
+	S["job_den_low"]		>> job_den_low
+
+	S["job_vault_high"]		>> job_vault_high
+	S["job_vault_med"]		>> job_vault_med
+	S["job_vault_low"]		>> job_vault_low
+
+	S["job_wasteland_high"]		>> job_wasteland_high
+	S["job_wasteland_med"]		>> job_wasteland_med
+	S["job_wasteland_low"]		>> job_wasteland_low
+
+	S["job_enclave_high"]		>> job_enclave_high
+	S["job_enclave_med"]		>> job_enclave_med
+	S["job_enclave_low"]		>> job_enclave_low
+
+
 	//Quirks
 	S["all_quirks"]			>> all_quirks
 	S["positive_quirks"]	>> positive_quirks
@@ -274,7 +305,8 @@ SAVEFILE UPDATING/VERSIONING - 'Simplified', or rather, more coder-friendly ~Car
 	if(needs_update >= 0)
 		update_character(needs_update, S)		//needs_update == savefile_version if we need an update (positive integer)
 
-	//Sanitize
+	//Sanitize this probably all needs to be reduced to a few lists with [job]_[faction]_[high | med | low] and inline  or something but I don't have the energy, so have some spaghetti - Nappist
+
 	metadata		= sanitize_text(metadata, initial(metadata))
 	real_name		= reject_bad_name(real_name)
 	if(!features["mcolor"] || features["mcolor"] == "#000")
@@ -324,6 +356,35 @@ SAVEFILE UPDATING/VERSIONING - 'Simplified', or rather, more coder-friendly ~Car
 	job_engsec_high = sanitize_integer(job_engsec_high, 0, 65535, initial(job_engsec_high))
 	job_engsec_med = sanitize_integer(job_engsec_med, 0, 65535, initial(job_engsec_med))
 	job_engsec_low = sanitize_integer(job_engsec_low, 0, 65535, initial(job_engsec_low))
+//F13 jobs
+
+	job_ncr_high = sanitize_integer(job_ncr_high, 0, 65535, initial(job_ncr_high))
+	job_ncr_med = sanitize_integer(job_ncr_med, 0, 65535, initial(job_ncr_med))
+	job_ncr_low = sanitize_integer(job_ncr_low, 0, 65535, initial(job_ncr_low))
+
+	job_legion_high = sanitize_integer(job_legion_high, 0, 65535, initial(job_legion_high))
+	job_legion_med = sanitize_integer(job_legion_med, 0, 65535, initial(job_legion_med))
+	job_legion_low = sanitize_integer(job_legion_low, 0, 65535, initial(job_legion_low))
+
+	job_bos_high = sanitize_integer(job_bos_high, 0, 65535, initial(job_bos_high))
+	job_bos_med = sanitize_integer(job_bos_med, 0, 65535, initial(job_bos_med))
+	job_bos_low = sanitize_integer(job_bos_low, 0, 65535, initial(job_bos_low))
+
+	job_den_high = sanitize_integer(job_den_high, 0, 65535, initial(job_den_high))
+	job_den_med = sanitize_integer(job_den_med, 0, 65535, initial(job_den_med))
+	job_den_low = sanitize_integer(job_den_low, 0, 65535, initial(job_den_low))
+
+	job_vault_high = sanitize_integer(job_vault_high, 0, 65535, initial(job_vault_high))
+	job_vault_med = sanitize_integer(job_vault_med, 0, 65535, initial(job_vault_med))
+	job_vault_low = sanitize_integer(job_vault_low, 0, 65535, initial(job_vault_low))
+
+	job_wasteland_high = sanitize_integer(job_wasteland_high, 0, 65535, initial(job_wasteland_high))
+	job_wasteland_med = sanitize_integer(job_wasteland_med, 0, 65535, initial(job_wasteland_med))
+	job_wasteland_low = sanitize_integer(job_wasteland_low, 0, 65535, initial(job_wasteland_low))
+
+	job_enclave_high = sanitize_integer(job_enclave_high, 0, 65535, initial(job_enclave_high))
+	job_enclave_med = sanitize_integer(job_enclave_med, 0, 65535, initial(job_enclave_med))
+	job_enclave_low = sanitize_integer(job_enclave_low, 0, 65535, initial(job_enclave_low))
 
 	all_quirks = SANITIZE_LIST(all_quirks)
 	positive_quirks = SANITIZE_LIST(positive_quirks)
@@ -382,16 +443,46 @@ SAVEFILE UPDATING/VERSIONING - 'Simplified', or rather, more coder-friendly ~Car
 	WRITE_FILE(S["prefered_security_department"] , prefered_security_department)
 
 	//Jobs
-	WRITE_FILE(S["joblessrole"]		, joblessrole)
+	WRITE_FILE(S["joblessrole"]			, joblessrole)
 	WRITE_FILE(S["job_civilian_high"]	, job_civilian_high)
 	WRITE_FILE(S["job_civilian_med"]	, job_civilian_med)
 	WRITE_FILE(S["job_civilian_low"]	, job_civilian_low)
-	WRITE_FILE(S["job_medsci_high"]	, job_medsci_high)
+	WRITE_FILE(S["job_medsci_high"]		, job_medsci_high)
 	WRITE_FILE(S["job_medsci_med"]		, job_medsci_med)
 	WRITE_FILE(S["job_medsci_low"]		, job_medsci_low)
-	WRITE_FILE(S["job_engsec_high"]	, job_engsec_high)
+	WRITE_FILE(S["job_engsec_high"]		, job_engsec_high)
 	WRITE_FILE(S["job_engsec_med"]		, job_engsec_med)
 	WRITE_FILE(S["job_engsec_low"]		, job_engsec_low)
+
+	//Fallout 13
+	WRITE_FILE(S["job_ncr_high"]		, job_ncr_high)
+	WRITE_FILE(S["job_ncr_med"]			, job_ncr_med)
+	WRITE_FILE(S["job_ncr_low"]			, job_ncr_low)
+
+	WRITE_FILE(S["job_legion_high"]		, job_legion_high)
+	WRITE_FILE(S["job_legion_med"]		, job_legion_med)
+	WRITE_FILE(S["job_legion_low"]		, job_legion_low)
+
+	WRITE_FILE(S["job_bos_high"]		, job_bos_high)
+	WRITE_FILE(S["job_bos_med"]			, job_bos_med)
+	WRITE_FILE(S["job_bos_low"]			, job_bos_low)
+
+	WRITE_FILE(S["job_den_high"]		, job_den_high)
+	WRITE_FILE(S["job_den_med"]			, job_den_med)
+	WRITE_FILE(S["job_den_low"]			, job_den_low)
+
+	WRITE_FILE(S["job_vault_high"]		, job_vault_high)
+	WRITE_FILE(S["job_vault_med"]		, job_vault_med)
+	WRITE_FILE(S["job_vault_low"]		, job_vault_low)
+
+	WRITE_FILE(S["job_wasteland_high"]	, job_wasteland_high)
+	WRITE_FILE(S["job_wasteland_med"]	, job_wasteland_med)
+	WRITE_FILE(S["job_wasteland_low"]	, job_wasteland_low)
+
+	WRITE_FILE(S["job_enclave_high"]	, job_enclave_high)
+	WRITE_FILE(S["job_enclave_med"]		, job_enclave_med)
+	WRITE_FILE(S["job_enclave_low"]		, job_enclave_low)
+
 
 	//Quirks
 	WRITE_FILE(S["all_quirks"]			, all_quirks)

--- a/code/modules/jobs/job_types/job.dm
+++ b/code/modules/jobs/job_types/job.dm
@@ -61,6 +61,8 @@
 	//can be overriden by antag_rep.txt config
 	var/antag_rep = 10
 
+	var/display_order = JOB_DISPLAY_ORDER_DEFAULT
+
 //Only override this proc
 //H is usually a human unless an /equip override transformed it
 /datum/job/proc/after_spawn(mob/living/H, mob/M, latejoin = FALSE)


### PR DESCRIPTION
Fixes quirk preferences being carried over, but isn't a real 'fix'.

Job preferences now save properly.

What's happening is that the datum is being saved somewhere in the interim state and then instead of being cleared and overwritten by selected slots, it's overwriting selected slots regardless of what they are.

Navigating this horrible maze is giving me a headache, so I'll pick this up later.