### PR TITLE
Fixes kitchen processors

### DIFF
--- a/code/game/objects/items/circuitboards/machine_circuitboards.dm
+++ b/code/game/objects/items/circuitboards/machine_circuitboards.dm
@@ -379,22 +379,23 @@
 		/obj/item/stock_parts/manipulator = 1)
 	needs_anchored = FALSE
 
-/* /obj/item/circuitboard/machine/processor/attackby(obj/item/I, mob/user, params)
+/obj/item/circuitboard/machine/processor/attackby(obj/item/I, mob/user, params)
 	if(istype(I, /obj/item/screwdriver))
-		if(build_path == /obj/machinery/processor)
+/*		if(build_path == /obj/machinery/processor)
 			name = "Slime Processor (Machine Board)"
 			build_path = /obj/machinery/processor/slime
 			to_chat(user, "<span class='notice'>Name protocols successfully updated.</span>")
-		else
-			name = "Food Processor (Machine Board)"
-			build_path = /obj/machinery/processor
-			to_chat(user, "<span class='notice'>Defaulting name protocols.</span>")
+		else*/
+		name = "Food Processor (Machine Board)"
+		build_path = /obj/machinery/processor
+		to_chat(user, "<span class='notice'>Defaulting name protocols.</span>")
 	else
 		return ..()
 
+
 /obj/item/circuitboard/machine/processor/slime
 	name = "Slime Processor (Machine Board)"
-	build_path = /obj/machinery/processor/slime */
+	build_path = /obj/machinery/processor/slime
 
 /obj/item/circuitboard/machine/smartfridge
 	name = "Smartfridge (Machine Board)"

--- a/code/modules/food_and_drinks/kitchen_machinery/processor.dm
+++ b/code/modules/food_and_drinks/kitchen_machinery/processor.dm
@@ -31,12 +31,12 @@
 	else
 		qdel(what)
 
-/* /obj/machinery/processor/proc/select_recipe(X)
+/obj/machinery/processor/proc/select_recipe(X)
 	for (var/type in subtypesof(/datum/food_processor_process) - /datum/food_processor_process/mob)
 		var/datum/food_processor_process/recipe = new type()
 		if (!istype(X, recipe.input) || !istype(src, recipe.required_machine))
 			continue
-		return recipe */
+		return recipe
 
 /obj/machinery/processor/attackby(obj/item/O, mob/user, params)
 	if(processing)
@@ -138,7 +138,7 @@
 	for (var/mob/M in src)
 		M.forceMove(drop_location())
 
-/* /obj/machinery/processor/slime
+/obj/machinery/processor/slime
 	name = "slime processor"
 	desc = "An industrial grinder with a sticker saying appropriated for science department. Keep hands clear of intake area while operating."
 
@@ -193,4 +193,4 @@
 			var/atom/movable/item = new S.coretype(drop_location())
 			adjust_item_drop_location(item)
 			SSblackbox.record_feedback("tally", "slime_core_harvested", 1, S.colour)
-	..() */
+	..()

--- a/code/modules/food_and_drinks/recipes/processor_recipes.dm
+++ b/code/modules/food_and_drinks/recipes/processor_recipes.dm
@@ -44,7 +44,7 @@
 	input = /obj/item/reagent_containers/food/snacks/grown/parsnip
 	output = /obj/item/reagent_containers/food/snacks/roastparsnip
 
-/* /datum/food_processor_process/mob/slime
+/datum/food_processor_process/mob/slime
 	input = /mob/living/simple_animal/slime
 	output = null
-	required_machine = /obj/machinery/processor/slime */
+	required_machine = /obj/machinery/processor/slime


### PR DESCRIPTION
Reverts a chunk of #513 because it was disabling food processors.
@improvedname correct fix is to disallow the circuit imprinter from printing out the circuit.