### PR TITLE
removes slime permanent rabidity

### DIFF
--- a/code/modules/mob/living/simple_animal/slime/slime.dm
+++ b/code/modules/mob/living/simple_animal/slime/slime.dm
@@ -50,7 +50,7 @@
 	var/mob/living/Leader = null // AI variable - tells the slime to follow this person
 
 	var/attacked = 0 // Determines if it's been attacked recently. Can be any number, is a cooloff-ish variable
-	var/rabid = 1 // If set to 1, the slime will attack and eat anything it comes in contact with
+	var/rabid = 0 // If set to 1, the slime will attack and eat anything it comes in contact with
 	var/holding_still = 0 // AI variable, cooloff-ish for how long it's going to stay in one place
 	var/target_patience = 0 // AI variable, cooloff-ish for how long it's going to follow its target
 


### PR DESCRIPTION
yeah basically that because it makes xeno noob bait and only really achievable by powergamers, which is the opposite of the intended effect

slime rabidity makes slimes always hostile so you had three ways to deal with them

1. you could hop yourself up on rezadone (via koibeans) and be immune to their cellular damage and transport them

2. you could synthesize BZ and stun them to transport them

3. you could use a monkey to bait the slime to attach to it in the one tile doorway and then transport it

the third option, which was apparently the intended option, is a bad one because it massively slows down xenobio and also means xenobiologists can get killed all the time by monkeys or by RNG because some idiot left the doors improperly locked when they mapped them and so monkeys can open them and let the slimes out.

none of this is mentioned anywhere, which, due to the lack of a wiki of our own,  means that newbies don't know how to handle rabid slimes on their own and get killed by them, where powergamers know how to actually get the slimes and so it's gatelocked to them only, just like the gutsy bunkers were and still are.

this makes slimes not rabid by default again, as they're vault only and thus not a problem (as they will no longer be a deciding factor in wasteland fights as vaulties will never actually contribute to wasteland fights without getting banned and the only relevant slimes can only come in at around the 1:30  hr-2hr period

i'll probably just straight remove the problem slimes later if people really want that to get the PR merged but there's no point in adding something just to make it obnoxiously hard so that nobody but the very knowledgeable can do it and then designing it to be easy noob bait so that people get killed by it

it'd be like adding NTSL and then making it electrocute you to crit when code was inputted wrong