### PR TITLE
Replaces bugged Undefined Wanted Poster that is in Junkspawner

### DIFF
--- a/code/game/objects/effects/spawners/ss13.dm
+++ b/code/game/objects/effects/spawners/ss13.dm
@@ -1172,13 +1172,13 @@ obj
 								lb2.loc=src.loc
 								del src
 							if(2)
-								var/obj/item/poster/wanted/lb = new
+								var/obj/item/poster/random_contraband/lb = new
 								var/obj/item/multitool/lb2 = new
 								lb.loc=src.loc
 								lb2.loc=src.loc
 								del src
 							if(3)
-								var/obj/item/cigbutt/cigarbutt/lb = new
+								var/obj/item/poster/random_official/lb = new
 								var/obj/item/trash/sosjerky/lb2 = new
 								lb.loc=src.loc
 								lb2.loc=src.loc


### PR DESCRIPTION
## Description
Replaces Wanted poster that needs security records to define with a random contraband poster, adds random official poster in place of cigarbutt too. Solves Issue #195 

## Motivation and Context
Wanted poster can't even be used on the wall, and just disappears. It needs security records to function and cannot be spawned blank which it does in the junkspawner.

## How Has This Been Tested?
Hosted and Tested with a hundred Junkspawners
