### PR TITLE
You can no longer move at permanent ephedrinespeed through creating oldschool nuka cola

### DIFF
--- a/code/modules/reagents/chemistry/reagents/drink_reagents.dm
+++ b/code/modules/reagents/chemistry/reagents/drink_reagents.dm
@@ -392,18 +392,6 @@
 	glass_name = "glass of Nuka Cola"
 	glass_desc = "Don't cry, Don't raise your eye, It's only nuclear wasteland."
 
-/datum/reagent/consumable/nuka_cola/on_mob_add(mob/M)
-	..()
-	if(isliving(M))
-		var/mob/living/L = M
-		L.add_trait(TRAIT_GOTTAGOFAST, id)
-
-/datum/reagent/consumable/nuka_cola/on_mob_delete(mob/M)
-	if(isliving(M))
-		var/mob/living/L = M
-		L.remove_trait(TRAIT_GOTTAGOFAST, id)
-	..()
-
 /datum/reagent/consumable/nuka_cola/on_mob_life(mob/living/M)
 	M.Jitter(20)
 	M.set_drugginess(30)


### PR DESCRIPTION
Basically, due to something nobody bothered to address, you could move at extremely high speeds by mixing regular nuka cola-uranium and cola. 

Uranium is everywhere in the wastes and cola is available quite commonly.

This is a balance concern because speed is everything in a fight and the downsides are negligible. I've used it to steamroll factions before because I can outrun them completely.

This isn't the actual cola you have in vendors-the REAL nuka cola is intentionally virtually unobtainable, and given that you removed ephedrine speed from actual ephedrine, there's no reason to have a commonly available drink even a raider could make do the same.