### PR TITLE
Nerfs several alcohols so that they are no longer incredibly lethal (bye neurotoxin)

### DIFF
--- a/code/modules/reagents/chemistry/reagents/alcohol_reagents.dm
+++ b/code/modules/reagents/chemistry/reagents/alcohol_reagents.dm
@@ -545,18 +545,6 @@ All effects don't start immediately, but rather get worse over time; the rate is
 	glass_icon_state = "bravebullglass"
 	glass_name = "Brave Bull"
 	glass_desc = "Tequila and Coffee liqueur, brought together in a mouthwatering mixture. Drink up."
-	var/tough_text
-
-/datum/reagent/consumable/ethanol/brave_bull/on_mob_add(mob/living/M)
-	tough_text = pick("brawny", "tenacious", "tough", "hardy", "sturdy") //Tuff stuff
-	to_chat(M, "<span class='notice'>You feel [tough_text]!</span>")
-	M.maxHealth += 10 //Brave Bull makes you sturdier, and thus capable of withstanding a tiny bit more punishment.
-	M.health += 10
-
-/datum/reagent/consumable/ethanol/brave_bull/on_mob_delete(mob/living/M)
-	to_chat(M, "<span class='notice'>You no longer feel [tough_text].</span>")
-	M.maxHealth -= 10
-	M.health = min(M.health - 10, M.maxHealth) //This can indeed crit you if you're alive solely based on alchol ingestion
 
 /datum/reagent/consumable/ethanol/tequila_sunrise
 	name = "Tequila Sunrise"
@@ -613,13 +601,6 @@ All effects don't start immediately, but rather get worse over time; the rate is
 	glass_icon_state = "beepskysmashglass"
 	glass_name = "Beepsky Smash"
 	glass_desc = "Heavy, hot and strong. Just like the Iron fist of the LAW."
-
-/datum/reagent/consumable/ethanol/beepsky_smash/on_mob_life(mob/living/M)
-	if(M.has_trait(TRAIT_ALCOHOL_TOLERANCE))
-		M.Stun(30, 0) //this realistically does nothing to prevent chainstunning but will cause them to recover faster once it's out of their system
-	else
-		M.Stun(40, 0)
-	return ..()
 
 /datum/reagent/consumable/ethanol/irish_cream
 	name = "Irish Cream"
@@ -1174,15 +1155,6 @@ All effects don't start immediately, but rather get worse over time; the rate is
 	glass_name = "Hearty Punch"
 	glass_desc = "Aromatic beverage served piping hot. According to folk tales it can almost wake the dead."
 
-/datum/reagent/consumable/ethanol/hearty_punch/on_mob_life(mob/living/M)
-	if(M.health <= 0)
-		M.adjustBruteLoss(-3, 0)
-		M.adjustFireLoss(-3, 0)
-		M.adjustCloneLoss(-5, 0)
-		M.adjustOxyLoss(-4, 0)
-		M.adjustToxLoss(-3, 0)
-		. = 1
-	return ..() || .
 
 /datum/reagent/consumable/ethanol/bacchus_blessing //An EXTREMELY powerful drink. Smashed in seconds, dead in minutes.
 	name = "Bacchus' Blessing"
@@ -1257,31 +1229,13 @@ All effects don't start immediately, but rather get worse over time; the rate is
 /datum/reagent/consumable/ethanol/neurotoxin
 	name = "Neurotoxin"
 	id = "neurotoxin"
-	description = "A strong neurotoxin that puts the subject into a death-like state."
+	description = "A strong neurotoxin that induces effects similar to extremely potent alcohol."
 	color = "#2E2E61" // rgb: 46, 46, 97
-	boozepwr = 0 //custom drunk effect
+	boozepwr = 150 //very powerful to compensate for losing its instant KO
 	taste_description = "a numbing sensation"
 	glass_icon_state = "neurotoxinglass"
 	glass_name = "Neurotoxin"
 	glass_desc = "A drink that is guaranteed to knock you silly."
-
-/datum/reagent/consumable/ethanol/neurotoxin/on_mob_life(mob/living/carbon/M)
-	M.Knockdown(60, 1, 0)
-	M.dizziness +=2
-	switch(current_cycle)
-		if(15 to 45)
-			if(!M.slurring)
-				M.slurring = 1
-			M.slurring += 3
-		if(45 to 55)
-			if(prob(50))
-				M.confused = max(M.confused+3,0)
-		if(55 to 200)
-			M.set_drugginess(55)
-		if(200 to INFINITY)
-			M.adjustToxLoss(2, 0)
-	..()
-	. = 1
 
 /datum/reagent/consumable/ethanol/hippies_delight
 	name = "Hippie's Delight"


### PR DESCRIPTION
Chem combat is detrimental to FO13 as a whole but who cares for the most part because let people shoot each other with stupid shit instead of ballistics if they want, whatever.

The issue is that neurotoxin and beepsky smash are both instant stuns that last as long as the chem is in your body, and, accordingly, are the reason that chem deathmixes are so lethal-the person cannot respond in any way or save themselves, and you can kill them at your lesiure-or the mix will do it for you.

Given that FO13 is virtually devoid of instant stuns as compared to regular SS13, this makes neuro a serious problem. Shotgun darts have proved that several times-it's not very difficult to immediately make neurotoxin, load it into a shotgun dart, and blast someone with neuro + any pyrotechnic chem.

I'll see if pyrotechnic chems still need a nerf after this, but honestly their main issue and the issue with chem fighting in general is just the stunlock that comes from this shit instantly being complete BS and leaving you unable to fight back at all.

Otherwise, brave bull giving you an extra +10 health pairs too well with the lifegiver perk-that's an extra +25 health total and that's sort of insane.

Hearty Punch is basically an atropine that can be made in the bar and combined with atropine, and given the previous chemistry nerfs, shouldn't be as a result.

Other bar drinks are untouched-i'm fine with people healing from alcohols. Just not the insane level that Hearty Punch obliges.