### PR TITLE
Bigger text input box for Me/Emote on IC menu.

### DIFF
--- a/code/modules/mob/living/emote.dm
+++ b/code/modules/mob/living/emote.dm
@@ -418,7 +418,7 @@
 		to_chat(user, "You cannot send IC messages (muted).")
 		return FALSE
 	else if(!params)
-		var/custom_emote = copytext(sanitize(input("Choose an emote to display.") as text|null), 1, MAX_MESSAGE_LEN)
+		var/custom_emote = copytext(sanitize(input("Choose an emote to display.") as message|null), 1, MAX_MESSAGE_LEN)
 		if(custom_emote && !check_invalid(user, custom_emote))
 			var/type = input("Is this a visible or hearable emote?") as null|anything in list("Visible", "Hearable")
 			switch(type)

--- a/code/modules/mob/say.dm
+++ b/code/modules/mob/say.dm
@@ -20,8 +20,8 @@
 /mob/proc/whisper(message, datum/language/language=null)
 	say(message, language) //only living mobs actually whisper, everything else just talks
 
-/mob/verb/me_verb(message as text)
-	set name = "Me"
+/mob/verb/me_verb(message as null|message)
+	set name = "Emote"
 	set category = "IC"
 
 	if(GLOB.say_disabled)	//This is here to try to identify lag problems
@@ -47,7 +47,7 @@
 	if(jb)
 		to_chat(src, "<span class='danger'>You have been banned from deadchat.</span>")
 		return
-	
+
 
 
 	if (src.client)

--- a/code/modules/mob/say.dm
+++ b/code/modules/mob/say.dm
@@ -20,11 +20,10 @@
 /mob/proc/whisper(message, datum/language/language=null)
 	say(message, language) //only living mobs actually whisper, everything else just talks
 
-/mob/verb/me_verb(message as null|message)
-	set name = "Emote"
+/mob/verb/me_verb(message as message) //messages give you bigger boxes on text inputs, null| can be set before them too.
+	set name = "Me"
 	set category = "IC"
-
-	if(GLOB.say_disabled)	//This is here to try to identify lag problems
+	if(GLOB.say_disabled)	//This is here to try to identify lag problem
 		to_chat(usr, "<span class='danger'>Speech is currently admin-disabled.</span>")
 		return
 


### PR DESCRIPTION
## Description
Gave the Me verb bigger input boxes to type into.

## Motivation and Context
Typing in a paragraph into the tiny byond text input kind of sucks for double checking what you put in.

## How Has This Been Tested?
Hosted and Tested

![untitled](https://user-images.githubusercontent.com/46565256/52909861-d006d700-325c-11e9-9a37-0ec22e6f6487.png)
