### PR TITLE
Removes some additional bad slime reactions

### DIFF
--- a/code/modules/reagents/chemistry/recipes/slime_extracts.dm
+++ b/code/modules/reagents/chemistry/recipes/slime_extracts.dm
@@ -99,6 +99,8 @@
 	..()
 
 //Gold
+
+/*
 /datum/chemical_reaction/slime/slimemobspawn
 	name = "Slime Crit"
 	id = "m_tele"
@@ -127,6 +129,7 @@
 /datum/chemical_reaction/slime/slimemobspawn/lesser/summon_mobs(datum/reagents/holder, turf/T)
 	T.visible_message("<span class='danger'>The slime extract begins to vibrate violently!</span>")
 	addtimer(CALLBACK(src, .proc/chemical_mob_spawn, holder, 3, "Lesser Gold Slime", HOSTILE_SPAWN, "neutral"), 50)
+*/
 
 /datum/chemical_reaction/slime/slimemobspawn/friendly
 	name = "Slime Crit Friendly"
@@ -470,6 +473,8 @@
 	new /obj/item/slimepotion/slime/sentience(get_turf(holder.my_atom))
 	..()
 */
+
+/*
 //Adamantine
 /datum/chemical_reaction/slime/adamantine
 	name = "Adamantine"
@@ -481,6 +486,8 @@
 /datum/chemical_reaction/slime/adamantine/on_reaction(datum/reagents/holder)
 	new /obj/item/stack/sheet/mineral/adamantine(get_turf(holder.my_atom))
 	..()
+*/
+
 
 //Bluespace
 /datum/chemical_reaction/slime/slimefloor2

--- a/code/modules/reagents/chemistry/recipes/slime_extracts.dm
+++ b/code/modules/reagents/chemistry/recipes/slime_extracts.dm
@@ -129,7 +129,7 @@
 /datum/chemical_reaction/slime/slimemobspawn/lesser/summon_mobs(datum/reagents/holder, turf/T)
 	T.visible_message("<span class='danger'>The slime extract begins to vibrate violently!</span>")
 	addtimer(CALLBACK(src, .proc/chemical_mob_spawn, holder, 3, "Lesser Gold Slime", HOSTILE_SPAWN, "neutral"), 50)
-*/
+
 
 /datum/chemical_reaction/slime/slimemobspawn/friendly
 	name = "Slime Crit Friendly"
@@ -139,6 +139,7 @@
 /datum/chemical_reaction/slime/slimemobspawn/friendly/summon_mobs(datum/reagents/holder, turf/T)
 	T.visible_message("<span class='danger'>The slime extract begins to vibrate adorably!</span>")
 	addtimer(CALLBACK(src, .proc/chemical_mob_spawn, holder, 1, "Friendly Gold Slime", FRIENDLY_SPAWN, "neutral"), 50)
+*/
 
 //Silver
 /datum/chemical_reaction/slime/slimebork

--- a/code/modules/reagents/chemistry/recipes/slime_extracts.dm
+++ b/code/modules/reagents/chemistry/recipes/slime_extracts.dm
@@ -207,6 +207,7 @@
 	required_other = 1
 
 //Dark Blue
+/*
 /datum/chemical_reaction/slime/slimefreeze
 	name = "Slime Freeze"
 	id = "m_freeze"
@@ -229,7 +230,7 @@
 		var/turf/open/T = get_turf(holder.my_atom)
 		if(istype(T))
 			T.atmos_spawn_air("nitrogen=50;TEMP=2.7")
-
+*/
 /datum/chemical_reaction/slime/slimefireproof
 	name = "Slime Fireproof"
 	id = "m_fireproof"
@@ -493,7 +494,7 @@
 	new /obj/item/stack/tile/bluespace(get_turf(holder.my_atom), 25)
 	..()
 
-
+/*
 /datum/chemical_reaction/slime/slimecrystal
 	name = "Slime Crystal"
 	id = "m_crystal"
@@ -505,7 +506,7 @@
 	var/obj/item/stack/ore/bluespace_crystal/BC = new (get_turf(holder.my_atom))
 	BC.visible_message("<span class='notice'>The [BC.name] appears out of thin air!</span>")
 	..()
-
+*/
 /datum/chemical_reaction/slime/slimeradio
 	name = "Slime Radio"
 	id = "m_radio"
@@ -648,7 +649,7 @@
 
 /datum/chemical_reaction/slime/slime_transfer/on_reaction(datum/reagents/holder)
 	new /obj/item/slimepotion/transference(get_turf(holder.my_atom))
-	..() */
+	..()
 
 /datum/chemical_reaction/slime/flight_potion
 	name = "Flight Potion"
@@ -659,4 +660,4 @@
 
 /datum/chemical_reaction/slime/flight_potion/on_reaction(datum/reagents/holder)
 	new /obj/item/reagent_containers/glass/bottle/potion/flight(get_turf(holder.my_atom))
-	..()
+	..() */


### PR DESCRIPTION
Dark blue freezing air has the same issues as pyroclastic fire slime bombs and causes atmos issues. Bye.

Bluespace slime crystal generation is used exclusively to teleport out of the vault and onto centcomm. Bye. Todo: Removing BS crystals entirely.

Flight potions give you permanent methspeed. Bye.

Gold slimes are gone for reasons mentioned below and adamantine slimes are gone because golems.

I'll probably remove crossbreeds entirely later. Almost everything in there is a nightmare.