### PR TITLE
Improve lewdcode quality

### DIFF
--- a/code/modules/mob/living/carbon/human/human.dm
+++ b/code/modules/mob/living/carbon/human/human.dm
@@ -5,6 +5,10 @@
 	icon_state = "caucasian_m"
 	appearance_flags = KEEP_TOGETHER|TILE_BOUND|PIXEL_SCALE
 	var/obj/item/rig/wearing_rig
+	var/has_penis = 0
+	var/has_vagina = 0
+	var/has_breasts = 0
+	
 //lewd
 	var/last_partner
 	var/last_orifice
@@ -36,6 +40,13 @@
 	physiology = new()
 
 	handcrafting = new()
+
+	if(gender == MALE)
+		has_penis = TRUE
+	if(gender == FEMALE)
+		has_vagina = TRUE
+		has_breasts = TRUE
+
 //lewd
 	sexual_potency = (prob(80) ? rand(9, 14) : pick(rand(5, 13), rand(15, 20)))
 	lust_tolerance = (prob(80) ? rand(150, 300) : pick(rand(10, 100), rand(350,600)))

--- a/code/modules/surgery/gender_reassignment.dm
+++ b/code/modules/surgery/gender_reassignment.dm
@@ -158,14 +158,14 @@
 	if(H.gender == FEMALE)
 		user.visible_message("[user] surgically masculinized [target]'s face.", "<span class='notice'>You finished surgically masculinizing [target]'s face.</span>")
 		H.gender = MALE
-		if (!H.has_breasts)
+		if (H.has_breasts)
 			H.gender_ambiguous = 1
 		else
 			H.gender_ambiguous = 0
 	else
 		user.visible_message("[user] surgically feminized [target]'s face.", "<span class='notice'>You finished surgically feminizing [target]'s face.</span>")
 		H.gender = FEMALE
-		if (H.has_breasts)
+		if (!H.has_breasts)
 			H.gender_ambiguous = 1
 		else
 			H.gender_ambiguous = 0

--- a/code/modules/surgery/gender_reassignment.dm
+++ b/code/modules/surgery/gender_reassignment.dm
@@ -1,42 +1,180 @@
-/datum/surgery/gender_reassignment
-	name = "gender reassignment"
+/datum/surgery/gender_reassignment_lower
+	name = "gender reassignment - lower surgery"
 	species = list(/mob/living/carbon/human)
 	possible_locs = list(BODY_ZONE_PRECISE_GROIN)
 	steps = list(
 		/datum/surgery_step/incise,
 		/datum/surgery_step/clamp_bleeders,
-		/datum/surgery_step/reshape_genitals,
+		/datum/surgery_step/lower_surgery,
 		/datum/surgery_step/close
 		)
 
-//reshape_genitals
-/datum/surgery_step/reshape_genitals
-	name = "reshape genitals"
+/datum/surgery_step/lower_surgery
+	name = "lower surgery"
 	implements = list(/obj/item/scalpel = 100, /obj/item/hatchet = 50, /obj/item/wirecutters = 35)
-	time = 64
+	time = 32
 
-/datum/surgery_step/reshape_genitals/preop(mob/user, mob/living/carbon/target, target_zone, obj/item/tool, datum/surgery/surgery)
-	if(target.gender == FEMALE)
-		user.visible_message("[user] begins to reshape [target]'s genitals to look more masculine.", "<span class='notice'>You begin to reshape [target]'s genitals to look more masculine...</span>")
-	else
-		user.visible_message("[user] begins to reshape [target]'s genitals to look more feminine.", "<span class='notice'>You begin to reshape [target]'s genitals to look more feminine...</span>")
-
-/datum/surgery_step/reshape_genitals/success(mob/user, mob/living/carbon/target, target_zone, obj/item/tool, datum/surgery/surgery)
+/datum/surgery_step/lower_surgery/preop(mob/user, mob/living/carbon/target, target_zone, obj/item/tool, datum/surgery/surgery)
 	var/mob/living/carbon/human/H = target	//no type check, as that should be handled by the surgery
-	H.gender_ambiguous = 0
-	if(target.gender == FEMALE)
-		user.visible_message("[user] has made a man of [target]!", "<span class='notice'>You made [target] a man.</span>")
-		target.gender = MALE
+	if(H.has_penis == TRUE)
+		user.visible_message("[user] begins to reshape [target]'s genitals to look more feminine.", "<span class='notice'>You begin to reshape [target]'s genitals to look more feminine...</span>")
 	else
-		user.visible_message("[user] has made a woman of [target]!", "<span class='notice'>You made [target] a woman.</span>")
-		target.gender = FEMALE
+		user.visible_message("[user] begins to reshape [target]'s genitals to look more masculine.", "<span class='notice'>You begin to reshape [target]'s genitals to look more masculine...</span>")
+
+/datum/surgery_step/lower_surgery/success(mob/user, mob/living/carbon/target, target_zone, obj/item/tool, datum/surgery/surgery)
+	var/mob/living/carbon/human/H = target	//no type check, as that should be handled by the surgery
+	if(H.has_penis)
+		user.visible_message("[user] surgically constructed [target]'s vagina.", "<span class='notice'>You finished surgically constructing [target]'s vagina.</span>")
+		H.has_penis = FALSE
+		H.has_vagina = TRUE
+	else
+		user.visible_message("[user] surgically constructed [target]'s penis.", "<span class='notice'>You finished surgically constructing [target]'s penis.</span>")
+		H.has_penis = TRUE
+		H.has_vagina = FALSE
 	target.regenerate_icons()
 	return 1
 
-/datum/surgery_step/reshape_genitals/failure(mob/user, mob/living/carbon/target, target_zone, obj/item/tool, datum/surgery/surgery)
+/datum/surgery_step/lower_surgery/failure(mob/user, mob/living/carbon/target, target_zone, obj/item/tool, datum/surgery/surgery)
 	var/mob/living/carbon/human/H = target
+	user.visible_message("<span class='warning'>[user] accidentally mutilates [target]'s genitals.</span>", "<span class='warning'>You accidentally mutilate [target]'s genitals!</span>")
+	H.has_penis = FALSE
+	H.has_vagina = FALSE
+	target.regenerate_icons()
+	return 1
+
+/datum/surgery/castration
+	name = "castration"
+	species = list(/mob/living/carbon/human)
+	possible_locs = list(BODY_ZONE_PRECISE_GROIN)
+	steps = list(
+		/datum/surgery_step/incise,
+		/datum/surgery_step/clamp_bleeders,
+		/datum/surgery_step/lower_surgery,
+		/datum/surgery_step/close
+		)
+
+/datum/surgery_step/castration
+	name = "castration"
+	implements = list(/obj/item/scalpel = 100, /obj/item/hatchet = 50, /obj/item/wirecutters = 35)
+	time = 32
+
+/datum/surgery_step/castration/preop(mob/user, mob/living/carbon/target, target_zone, obj/item/tool, datum/surgery/surgery)
+	var/mob/living/carbon/human/H = target	//no type check, as that should be handled by the surgery
+	if(H.has_penis == TRUE)
+		user.visible_message("[user] begins to slice away at [target]'s penis.", "<span class='notice'>You begin to slice away at [target]'s penis.</span>")
+	else
+		return 0
+
+/datum/surgery_step/castration/success(mob/user, mob/living/carbon/target, target_zone, obj/item/tool, datum/surgery/surgery)
+	var/mob/living/carbon/human/H = target	//no type check, as that should be handled by the surgery
+	if(H.has_penis)
+		user.visible_message("[user] castrated [target].", "<span class='notice'>You finished castrating [target].</span>")
+		H.has_penis = FALSE
+	return 1
+
+/datum/surgery_step/castration/failure(mob/user, mob/living/carbon/target, target_zone, obj/item/tool, datum/surgery/surgery)
+	var/mob/living/carbon/human/H = target
+	user.visible_message("<span class='warning'>[user] accidentally sinks the [tool] deep into the remnants of [target]'s penis.</span>", "<span class='warning'>You accidentally sink the [tool] deep into the remnants of [target]'s penis!</span>")
+	H.has_vagina = TRUE
+	target.regenerate_icons()
+	return 1
+
+
+/datum/surgery/gender_reassignment_top
+	name = "gender reassignment - top surgery"
+	species = list(/mob/living/carbon/human)
+	possible_locs = list(BODY_ZONE_CHEST)
+	steps = list(
+		/datum/surgery_step/incise,
+		/datum/surgery_step/clamp_bleeders,
+		/datum/surgery_step/top_surgery,
+		/datum/surgery_step/close
+		)
+
+/datum/surgery_step/top_surgery
+	name = "top surgery"
+	implements = list(/obj/item/scalpel = 100, /obj/item/hatchet = 50, /obj/item/wirecutters = 35)
+	time = 32
+
+/datum/surgery_step/top_surgery/preop(mob/user, mob/living/carbon/target, target_zone, obj/item/tool, datum/surgery/surgery)
+	var/mob/living/carbon/human/H = target
+	if(H.has_breasts == FALSE)
+		user.visible_message("[user] begins to reshape [target]'s chest to look more feminine.", "<span class='notice'>You begin to reshape [target]'s chest to look more feminine...</span>")
+	else
+		user.visible_message("[user] begins to reshape [target]'s chest to look more masculine.", "<span class='notice'>You begin to reshape [target]'s chest to look more masculine...</span>")
+
+/datum/surgery_step/top_surgery/success(mob/user, mob/living/carbon/target, target_zone, obj/item/tool, datum/surgery/surgery)
+	var/mob/living/carbon/human/H = target	//no type check, as that should be handled by the surgery
+	if(H.has_breasts)
+		user.visible_message("[user] surgically removed [target]'s breasts.", "<span class='notice'>You finished surgically removing [target]'s breasts.</span>")
+		H.has_breasts = FALSE
+		if (H.gender == FEMALE)
+			H.gender_ambiguous = 1
+		else
+			H.gender_ambiguous = 0
+	else
+		user.visible_message("[user] surgically constructed [target]'s breasts.", "<span class='notice'>You finished surgically constructing [target]'s breasts.</span>")
+		H.has_breasts = TRUE
+		if (H.gender == MALE)
+			H.gender_ambiguous = 1
+		else
+			H.gender_ambiguous = 0
+	target.regenerate_icons()
+	return 1
+
+/datum/surgery_step/top_surgery/failure(mob/user, mob/living/carbon/target, target_zone, obj/item/tool, datum/surgery/surgery)
+	var/mob/living/carbon/human/H = target
+	user.visible_message("<span class='warning'>[user] accidentally mutilates [target]'s breasts.</span>", "<span class='warning'>You accidentally mutilate [target]'s breasts!</span>")
+	H.has_breasts = FALSE
 	H.gender_ambiguous = 1
-	user.visible_message("<span class='warning'>[user] accidentally mutilates [target]'s genitals beyond the point of recognition!</span>", "<span class='warning'>You accidentally mutilate [target]'s genitals beyond the point of recognition!</span>")
-	target.gender = pick(MALE, FEMALE)
+	target.regenerate_icons()
+	return 1
+
+/datum/surgery/gender_reassignment_face
+	name = "gender reassignment - facial surgery"
+	species = list(/mob/living/carbon/human)
+	possible_locs = list(BODY_ZONE_HEAD)
+	steps = list(
+		/datum/surgery_step/incise,
+		/datum/surgery_step/clamp_bleeders,
+		/datum/surgery_step/facial_assignment,
+		/datum/surgery_step/close
+		)
+
+/datum/surgery_step/facial_assignment
+	name = "facial assignment surgery"
+	implements = list(/obj/item/scalpel = 100, /obj/item/hatchet = 50, /obj/item/wirecutters = 35)
+	time = 32
+
+/datum/surgery_step/facial_assignment/preop(mob/user, mob/living/carbon/target, target_zone, obj/item/tool, datum/surgery/surgery)
+	var/mob/living/carbon/human/H = target
+	if(H.has_breasts == FALSE)
+		user.visible_message("[user] begins to reshape [target]'s face to look more feminine.", "<span class='notice'>You begin to reshape [target]'s face to look more feminine...</span>")
+	else
+		user.visible_message("[user] begins to reshape [target]'s face to look more masculine.", "<span class='notice'>You begin to reshape [target]'s face to look more masculine...</span>")
+
+/datum/surgery_step/facial_assignment/success(mob/user, mob/living/carbon/target, target_zone, obj/item/tool, datum/surgery/surgery)
+	var/mob/living/carbon/human/H = target	//no type check, as that should be handled by the surgery
+	if(H.gender == FEMALE)
+		user.visible_message("[user] surgically masculinized [target]'s face.", "<span class='notice'>You finished surgically masculinizing [target]'s face.</span>")
+		H.gender = MALE
+		if (!H.has_breasts)
+			H.gender_ambiguous = 1
+		else
+			H.gender_ambiguous = 0
+	else
+		user.visible_message("[user] surgically feminized [target]'s face.", "<span class='notice'>You finished surgically feminizing [target]'s face.</span>")
+		H.gender = FEMALE
+		if (H.has_breasts)
+			H.gender_ambiguous = 1
+		else
+			H.gender_ambiguous = 0
+	target.regenerate_icons()
+	return 1
+
+/datum/surgery_step/facial_assignment/failure(mob/user, mob/living/carbon/target, target_zone, obj/item/tool, datum/surgery/surgery)
+	var/mob/living/carbon/human/H = target
+	user.visible_message("<span class='warning'>[user] accidentally mutilates [target]'s face.</span>", "<span class='warning'>You accidentally mutilate [target]'s face!</span>")
+	H.gender_ambiguous = 1
 	target.regenerate_icons()
 	return 1

--- a/interactions/lewd/_lewd.dm
+++ b/interactions/lewd/_lewd.dm
@@ -275,6 +275,7 @@
 
 /mob/living/carbon/human/proc/do_facefuck(mob/living/carbon/human/partner)
 	var/message
+	var/retaliation_message = FALSE
 
 	if(is_fucking(partner, CUM_TARGET_MOUTH))
 		if(has_vagina())
@@ -286,6 +287,14 @@
 				"looks \the [partner]'s in the eyes as their pussy presses into a waiting tongue.",
 				"sways their hips, pushing their sex into \the [partner]'s face.",
 				)
+			if(partner.a_intent == INTENT_HARM)
+				src.adjustBruteLoss(5)
+				retaliation_message = pick(
+					"bites furiously at \the [partner]'s legs.",
+					"tightens teeth against \the [partner]'s pussy.",
+					"looks deeply displeased to be there.",
+					"struggles to escape from between \the [partner]'s thighs.",
+				)
 		else if(has_penis())
 			message = pick(
 				"roughly fucks \the [partner]'s mouth.",
@@ -295,6 +304,22 @@
 				"looks \the [partner]'s in the eyes as their cock presses into a waiting tongue.",
 				"rolls their hips hard, sinking into \the [partner]'s mouth.",
 				)
+			if(partner.a_intent == INTENT_HARM)
+				src.adjustBruteLoss(5)
+				retaliation_message = pick(
+					"bites down hard on \the [partner]'s cock.",
+					"tightens teeth against \the [partner]'s dick until blood flows.",
+					"stares up from between \the [partner]'s knees, blood on their teeth.",
+					"struggles to escape from between \the [partner]'s legs.",
+				)
+				if(prob(5)) // dick crit
+					src.adjustBruteLoss(20)
+					retaliation_message = pick(
+						"tightens teeth onto \the [partner]'s cock, messily tearing it away!",
+						"bites down on \the [partner]'s cock and doesn't let go until it rips off!",
+						"bites \the [partner]'s cock off completely in the struggle!",
+					)
+					src.has_penis = FALSE
 		else
 			message = pick(
 				"grinds against \the [partner]'s face.",
@@ -303,6 +328,14 @@
 				"grips \the [partner]'s hair, drawing them into the strangely sexless spot between their legs.",
 				"looks \the [partner]'s in the eyes as they're caught beneath two thighs.",
 				"rolls their hips hard against \the [partner]'s face.",
+				)
+			if(partner.a_intent == INTENT_HARM)
+				src.adjustBruteLoss(5)
+				retaliation_message = pick(
+					"bites down hard on \the [partner]'s leg.",
+					"tightens teeth between \the [partner]'s legs.",
+					"stares up from between \the [partner]'s knees, blood on their teeth.",
+					"struggles to escape from between \the [partner]'s legs.",
 				)
 	else
 		if(has_vagina())
@@ -318,6 +351,8 @@
 
 	playsound(loc, "honk/sound/interactions/oral[rand(1, 2)].ogg", 70, 1, -1)
 	visible_message("<font color=purple><b>\The [src]</b> [message]</font>")
+	if(retaliation_message)
+		visible_message("<font color=red><b>\The [partner]</b> [message]</font>")
 	handle_post_sex(NORMAL_LUST, CUM_TARGET_MOUTH, partner)
 	partner.dir = get_dir(partner,src)
 	do_fucking_animation(get_dir(src, partner))

--- a/interactions/lewd/_lewd.dm
+++ b/interactions/lewd/_lewd.dm
@@ -20,16 +20,13 @@
 //I'm sorry, lewd should not have mob procs such as life() and such in it.
 
 /mob/living/carbon/human/proc/has_penis()
-	if(gender == MALE)
-		return TRUE
+	return has_penis
 
 /mob/living/carbon/human/proc/has_vagina()
-	if(gender == FEMALE)
-		return TRUE
+	return has_vagina
 
 /mob/living/carbon/human/proc/has_breasts()
-	if(gender == FEMALE)
-		return TRUE
+	return has_breasts
 
 /mob/living/carbon/human/proc/has_anus()
 	return TRUE
@@ -39,8 +36,12 @@
 		return FALSE
 	return TRUE
 
-/mob/living/carbon/human/proc/is_nude()
-	if((!(wear_suit) || !(wear_suit.body_parts_covered)) && (!(w_uniform) || !(w_uniform.body_parts_covered)))
+/mob/living/carbon/human/proc/is_topless()
+	if((!(wear_suit) || !(wear_suit.body_parts_covered & CHEST)) && (!(w_uniform) || !(w_uniform.body_parts_covered & CHEST)))
+		return TRUE
+
+/mob/living/carbon/human/proc/is_bottomless()
+	if((!(wear_suit) || !(wear_suit.body_parts_covered & GROIN)) && (!(w_uniform) || !(w_uniform.body_parts_covered & GROIN)))
 		return TRUE
 
 /proc/cum_splatter(target) // Like blood_splatter(), but much more questionable on a resume.
@@ -82,13 +83,13 @@
 				else
 					message = "cums on \the [partner]'s face."
 			if(CUM_TARGET_VAGINA)
-				if(partner.is_nude() && partner.has_vagina())
+				if(partner.is_bottomless() && partner.has_vagina())
 					message = "cums in \the [partner]'s pussy."
 					partner.reagents.add_reagent("cum", rand(8,12))
 				else
 					message = "cums on \the [partner]'s belly."
 			if(CUM_TARGET_ANUS)
-				if(partner.is_nude() && partner.has_anus())
+				if(partner.is_bottomless() && partner.has_anus())
 					message = "cums in \the [partner]'s asshole."
 					partner.reagents.add_reagent("cum", rand(8,12))
 				else
@@ -99,7 +100,7 @@
 				else
 					message = "cums on \the [partner]."
 			if(CUM_TARGET_BREASTS)
-				if(partner.is_nude() && partner.has_vagina())
+				if(partner.is_topless() && partner.has_vagina())
 					message = "cums onto \the [partner]'s breasts."
 				else
 					message = "cums on \the [partner]'s chest and neck."
@@ -207,18 +208,62 @@
 			lust_increase += 5
 		else
 			if(partner.has_vagina())
-				message = "licks \the [partner]'s pussy."
+				message = pick(
+					"licks \the [partner]'s pussy.",
+					"runs their tongue up the shape of \the [partner]'s pussy.",
+					"traces \the [partner]'s slit with their tongue.",
+					"darts the tip of their tongue around \the [partner]'s clit.",
+					"laps slowly at \the [partner].",
+					"kisses \the [partner]'s delicate folds.",
+					"tastes \the [partner].",
+				)
 			else if(partner.has_penis())
-				message = "sucks \the [partner] off."
+				message = pick(
+					"sucks \the [partner]'s off.",
+					"runs their tongue up the shape of \the [partner]'s cock.",
+					"traces \the [partner]'s cock with their tongue.",
+					"darts the tip of their tongue around tip of \the [partner]'s cock.",
+					"laps slowly at \the [partner]'s shaft.",
+					"kisses the base of \the [partner]'s shaft.",
+					"takes \the [partner] deeper into their mouth.",
+				)
 			else
-				message = "licks \the [partner]."
+				// get confused about how to do the sex
+				message = pick(
+					"licks \the [partner].",
+					"looks a little unsure of where to lick \the [partner].",
+					"runs their tongue between \the [partner]'s legs.",
+					"kisses \the [partner]'s thigh.",
+					"tries their best with \the [partner].",
+				)
 	else
 		if(partner.has_vagina())
-			message = "buries their face in \the [partner]'s pussy."
+			message = pick(
+				"buries their face in \the [partner]'s pussy.",
+				"nuzzles \the [partner]'s wet sex.",
+				"finds their face caught between \the [partner]'s thighs.",
+				"kneels down between \the [partner]'s legs.",
+				"grips \the [partner]'s legs, pushing them apart.",
+				"sinks their face in between \the [partner]'s thighs.",
+			)
 		else if(partner.has_penis())
-			message = "takes \the [partner]'s cock into their mouth."
+			message = pick(
+				"takes \the [partner]'s cock into their mouth.",
+				"wraps their lips around \the [partner]'s cock.",
+				"finds their face between \the [partner]'s thighs.",
+				"kneels down between \the [partner]'s legs.",
+				"grips \the [partner]'s legs, kissing at the tip of their cock.",
+				"goes down on \the [partner].",
+			)
 		else
-			message = "begins to lick \the [partner]."
+			message = pick(
+				"begins to lick \the [partner].",
+				"starts kissing \the [partner]'s thigh.",
+				"sinks down between \the [partner]'s thighs.",
+				"briefly flashes a puzzled look from between \the [partner]'s legs.",
+				"looks unsure of how to handle \the [partner]'s lack of genitalia.",
+				"seems like they were expecting \the [partner] to have a cock or a pussy or ... something.",
+			)
 		partner.set_is_fucking(src, CUM_TARGET_MOUTH)
 
 	playsound(get_turf(src), "honk/sound/interactions/bj[rand(1, 11)].ogg", 50, 1, -1)
@@ -233,19 +278,40 @@
 
 	if(is_fucking(partner, CUM_TARGET_MOUTH))
 		if(has_vagina())
-			message = "grinds their pussy into \the [partner]'s face."
+			message = pick(
+				"grinds their pussy into \the [partner]'s face.",
+				"grips the back of \the [partner]'s head, forcing them onto their pussy.",
+				"rolls their pussy against \the [partner]'s tongue.",
+				"slides \the [partner]'s mouth between their legs.",
+				"looks \the [partner]'s in the eyes as their pussy presses into a waiting tongue.",
+				"sways their hips, pushing their sex into \the [partner]'s face.",
+				)
 		else if(has_penis())
-			message = "roughly fucks \the [partner]'s mouth."
+			message = pick(
+				"roughly fucks \the [partner]'s mouth.",
+				"forces their cock down \the [partner]'s throat.",
+				"pushes in against \the [partner]'s tongue until a tight gagging sound comes.",
+				"grips \the [partner]'s hair and draws them to the base of the cock.",
+				"looks \the [partner]'s in the eyes as their cock presses into a waiting tongue.",
+				"rolls their hips hard, sinking into \the [partner]'s mouth.",
+				)
 		else
-			message = "grinds against \the [partner]\s face."
+			message = pick(
+				"grinds against \the [partner]'s face.",
+				"feels \the [partner]'s face between bare legs.",
+				"pushes in against \the [partner]'s tongue.",
+				"grips \the [partner]'s hair, drawing them into the strangely sexless spot between their legs.",
+				"looks \the [partner]'s in the eyes as they're caught beneath two thighs.",
+				"rolls their hips hard against \the [partner]'s face.",
+				)
 	else
 		if(has_vagina())
 			message = "forces \the [partner]'s face into their pussy."
 		else if(has_penis())
 			if(is_fucking(partner, CUM_TARGET_THROAT))
-				message = "retracts their dick from \the [partner]'s throat"
+				message = "retracts their cock from \the [partner]'s throat"
 			else
-				message = "shoves their dick deep into \the [partner]'s mouth"
+				message = "shoves their cock into \the [partner]'s mouth"
 		else
 			message = "shoves their crotch into \the [partner]'s face."
 		set_is_fucking(partner , CUM_TARGET_MOUTH)
@@ -264,10 +330,14 @@
 	if(is_fucking(partner, THIGH_SMOTHERING))
 
 		if(has_vagina())
-			message = pick(list("presses their weight down onto \the [partner]'s face, blocking their vision completely.", "rides \the [partner]'s face, grinding their wet pussy all over it."))
+			message = pick(list(
+				"presses their weight down onto \the [partner]'s face, blocking their vision completely.", 
+				"rides \the [partner]'s face, grinding their wet pussy all over it."))
 
 		else if(has_penis())
-			message = pick(list("presses their weight down onto \the [partner]'s face, blocking their vision completely.", "forces their dick and nutsack into \the [partner]'s face as they're stuck locked inbetween their thighs.", "slips their cock into \the [partner]'s helpless mouth, keeping their groin pressed hard into their face."))
+			message = pick(list("presses their weight down onto \the [partner]'s face, blocking their vision completely.", 
+				"forces their dick and nutsack into \the [partner]'s face as they're stuck locked in between their thighs.", 
+				"slips their cock into \the [partner]'s helpless mouth, keeping their shaft pressed hard into their face."))
 
 		else
 			message = "rubs their groin up and down \the [partner]'s face."
@@ -275,13 +345,17 @@
 	else
 
 		if(has_vagina())
-			message = pick(list("clambers over \the [partner]'s face and pins them down with their meaty thighs, their moist slit rubbing all over \the [partner]'s mouth and nose.", "locks their legs around \the [partner]'s head before pulling it into their taint."))
+			message = pick(list(
+				"clambers over \the [partner]'s face and pins them down with their thighs, their moist slit rubbing all over \the [partner]'s mouth and nose.", 
+				"locks their legs around \the [partner]'s head before pulling it into their mound."))
 
 		else if(has_penis())
-			message = pick(list("clambers over \the [partner]'s face and pins them down with their thick thighs, then slowly inching closer and covering their eyes and nose with their leaking erection.", "locks their legs around \the [partner]'s head before pulling it into their fat package, smothering them."))
+			message = pick(list(
+				"clambers over \the [partner]'s face and pins them down with their thighs, then slowly inching closer and covering their eyes and nose with their leaking erection.", 
+				"locks their legs around \the [partner]'s head before pulling it into their fat package, smothering them."))
 
 		else
-			message = "deviously locks their legs around \the [partner]'s head and smothers it in their thick meaty thighs."
+			message = "deviously locks their legs around \the [partner]'s head and smothers it in their thighs."
 
 		set_is_fucking(partner , THIGH_SMOTHERING)
 
@@ -317,7 +391,10 @@
 	var/message
 
 	if(is_fucking(partner, CUM_TARGET_THROAT))
-		message = "[pick("brutally fucks \the [partner]'s throat.", "chokes \the [partner] on their dick.", "brutally shoves their dick deep into \the [partner]'s mouth.")]"
+		message = "[pick(
+			"brutally fucks \the [partner]'s throat.", 
+			"chokes \the [partner] on their dick.", 
+			"brutally shoves their dick deep into \the [partner]'s mouth.")]"
 		if(rand(3))
 			partner.emote("chokes on \The [src]")
 			if(prob(1) && istype(partner, /mob/living/carbon/human))
@@ -343,7 +420,11 @@
 	var/lust_increase = 1
 
 	if(is_fucking(partner, NUTS_TO_FACE))
-		message = pick(list("grabs the back of [partner]'s head and pulls it into their crotch.", "jams their nutsack right into [partner]'s face.", "roughly grinds their fat nutsack into [partner]'s mouth.", "pulls out their saliva-covered nuts from [partner]'s violated mouth and then wipes off the slime onto their face."))
+		message = pick(list(
+			"grabs the back of [partner]'s head and pulls it into their crotch.", 
+			"jams their nutsack right into [partner]'s face.", 
+			"roughly grinds their fat nutsack into [partner]'s mouth.", 
+			"pulls out their saliva-covered nuts from [partner]'s violated mouth and then wipes off the slime onto their face."))
 	else
 		message = pick(list("wedges a digit into the side of [partner]'s jaw and pries it open before using their other hand to shove their whole nutsack inside!", "stands with their groin inches away from [partner]'s face, then thrusting their hips forward and smothering [partner]'s whole face with their heavy ballsack."))
 		set_is_fucking(partner , NUTS_TO_FACE)
@@ -374,7 +455,9 @@
 	var/message
 
 	if(is_fucking(partner, CUM_TARGET_VAGINA))
-		message = "[pick("pounds \the [partner]'s pussy.","shoves their dick deep into \the [partner]'s pussy")]"
+		message = "[pick(
+			"pounds \the [partner]'s pussy.",
+			"shoves their dick deep into \the [partner]'s pussy")]"
 	else
 		message = "slides their cock into \the [partner]'s pussy."
 		set_is_fucking(partner, CUM_TARGET_VAGINA)
@@ -390,7 +473,8 @@
 	var/message
 
 	if(partner.is_fucking(src, CUM_TARGET_VAGINA))
-		message = "[pick("rides \the [partner]'s dick.", "forces [partner]'s cock on their pussy")]"
+		message = "[pick("rides \the [partner]'s dick.", 
+			"forces [partner]'s cock on their pussy")]"
 	else
 		message = "slides their pussy onto \the [partner]'s cock."
 		partner.set_is_fucking(src, CUM_TARGET_VAGINA)
@@ -405,7 +489,8 @@
 	var/message
 
 	if(partner.is_fucking(src, CUM_TARGET_ANUS))
-		message = "[pick("rides \the [partner]'s dick.", "forces [partner]'s cock on their ass")]"
+		message = "[pick("rides \the [partner]'s dick.", 
+			"forces [partner]'s cock on their ass")]"
 	else
 		message = "lowers their ass onto \the [partner]'s cock."
 		partner.set_is_fucking(src, CUM_TARGET_ANUS)
@@ -417,14 +502,18 @@
 	do_fucking_animation(get_dir(src, partner))
 
 /mob/living/carbon/human/proc/do_fingering(mob/living/carbon/human/partner)
-	visible_message("<font color=purple><b>\The [src]</b> [pick("fingers \the [partner].", "fingers \the [partner]'s pussy.", "fingers \the [partner] hard.")]</font>")
+	visible_message("<font color=purple><b>\The [src]</b> [pick("fingers \the [partner].", 
+		"fingers \the [partner]'s pussy.", 
+		"fingers \the [partner] hard.")]</font>")
 	playsound(loc, "honk/sound/interactions/champ_fingering.ogg", 50, 1, -1)
 	partner.handle_post_sex(NORMAL_LUST, null, src)
 	partner.dir = get_dir(partner, src)
 	do_fucking_animation(get_dir(src, partner))
 
 /mob/living/carbon/human/proc/do_fingerass(mob/living/carbon/human/partner)
-	visible_message("<font color=purple><b>\The [src]</b> [pick("fingers \the [partner].", "fingers \the [partner]'s asshole.", "fingers \the [partner] hard.")]</font>")
+	visible_message("<font color=purple><b>\The [src]</b> [pick("fingers \the [partner].", 
+		"fingers \the [partner]'s asshole.", 
+		"fingers \the [partner] hard.")]</font>")
 	playsound(loc, "honk/sound/interactions/champ_fingering.ogg", 50, 1, -1)
 	partner.handle_post_sex(NORMAL_LUST, null, src)
 	partner.dir = get_dir(partner, src)
@@ -441,9 +530,12 @@
 	var/message
 
 	if(partner.is_fucking(src, CUM_TARGET_HAND))
-		message = "[pick("jerks \the [partner] off.", "works \the [partner]'s shaft.", "wanks \the [partner]'s cock hard.")]"
+		message = "[pick("jerks \the [partner] off.", 
+			"works \the [partner]'s shaft.", 
+			"wanks \the [partner]'s cock hard.")]"
 	else
-		message = "[pick("wraps their hand around \the [partner]'s cock.", "starts playing with \the [partner]'s cock")]"
+		message = "[pick("wraps their hand around \the [partner]'s cock.", 
+			"starts playing with \the [partner]'s cock")]"
 		partner.set_is_fucking(src, CUM_TARGET_HAND)
 
 	playsound(src, "honk/sound/interactions/bang[rand(1, 3)].ogg", 70, 1, -1)
@@ -456,9 +548,12 @@
 	var/message
 
 	if(is_fucking(partner, CUM_TARGET_BREASTS))
-		message = "[pick("fucks \the [partner]'s' breasts.", "grinds their cock between \the [partner]'s boobs.", "thrusts into \the [partner]'s tits.", "grabs \the [partner]'s breasts together and presses his dick between them.")]"
+		message = "[pick("fucks \the [partner]'s' breasts.", 
+			"grinds their cock between \the [partner]'s boobs.", 
+			"thrusts into \the [partner]'s tits.", 
+			"grabs \the [partner]'s breasts together and presses their dick between them.")]"
 	else
-		message = "pushes \the [partner]'s breasts together and presses his dick between them."
+		message = "pushes \the [partner]'s breasts together and presses their dick between them."
 		set_is_fucking(partner , CUM_TARGET_BREASTS)
 
 
@@ -472,9 +567,12 @@
 	var/message
 
 	if(is_fucking(partner, GRINDING_FACE_WITH_ANUS))
-		message = "[pick("grinds their ass into \the [partner]'s face.", "shoves their ass into \the [partner]'s face.")]"
+		message = "[pick("grinds their ass into \the [partner]'s face.", 
+			"shoves their ass into \the [partner]'s face.")]"
 	else
-		message = "[pick("grabs the back of \the [partner]'s head and forces it into their asscheeks.", "squats down and plants their ass right on \the [partner]'s face")]"
+		message = "[pick(
+			"grabs the back of \the [partner]'s head and forces it into their asscheeks.", 
+			"squats down and plants their ass right on \the [partner]'s face")]"
 		set_is_fucking(partner , GRINDING_FACE_WITH_ANUS)
 
 	playsound(loc, "honk/sound/interactions/squelch[rand(1, 3)].ogg", 70, 1, -1)
@@ -503,23 +601,33 @@
 
 	if(is_fucking(partner, GRINDING_FACE_WITH_FEET))
 		if(src.get_item_by_slot(SLOT_SHOES) != null)
-			message = "[pick(list("grinds their [get_shoes()] into [partner]'s face.", "presses their footwear down hard on [partner]'s face.", "rubs off the dirt from their [get_shoes()] onto [partner]'s face."))]</span>"
+			message = "[pick(list("grinds their [get_shoes()] into [partner]'s face.", 
+				"presses their footwear down hard on [partner]'s face.", 
+				"rubs off the dirt from their [get_shoes()] onto [partner]'s face."))]</span>"
 		else
-			message = "[pick(list("grinds their barefeet into [partner]'s face.", "deviously covers [partner]'s mouth and nose with their barefeet.", "runs the soles of their barefeet against [partner]'s lips."))]</span>"
+			message = "[pick(list("grinds their bare feet into [partner]'s face.", 
+				"deviously covers [partner]'s mouth and nose with their bare feet.", 
+				"runs the soles of their bare feet against [partner]'s lips."))]</span>"
 
 	else if(is_fucking(partner, GRINDING_MOUTH_WITH_FEET))
 		if(src.get_item_by_slot(SLOT_SHOES) != null)
-			message = "[pick(list("pulls their [get_shoes()] out of [partner]'s mouth and puts them on their face.", "slowly retracts their [get_shoes()] from [partner]'s mouth, putting them on their face instead."))]</span>"
+			message = "[pick(list("pulls their [get_shoes()] out of [partner]'s mouth and puts them on their face.", 
+				"slowly retracts their [get_shoes()] from [partner]'s mouth, putting them on their face instead."))]</span>"
 		else
-			message = "[pick(list("pulls their barefeet out of [partner]'s mouth and rests them on their face instead.", "retracts their barefeet from [partner]'s mouth and grinds them into their face instead."))]</span>"
+			message = "[pick(list("pulls their bare feet out of [partner]'s mouth and rests them on their face instead.", 
+				"retracts their bare feet from [partner]'s mouth and grinds them into their face instead."))]</span>"
 
 		set_is_fucking(partner , GRINDING_FACE_WITH_FEET)
 
 	else
 		if(src.get_item_by_slot(SLOT_SHOES) != null)
-			message = "[pick(list("plants their [get_shoes()] ontop of [partner]'s face.", "rests their [get_shoes()] on [partner]'s face and presses down hard.", "harshly places their [get_shoes()] atop [partner]'s face."))]</span>"
+			message = "[pick(list("plants their [get_shoes()] ontop of [partner]'s face.", 
+				"rests their [get_shoes()] on [partner]'s face and presses down hard.", 
+				"harshly places their [get_shoes()] atop [partner]'s face."))]</span>"
 		else
-			message = "[pick(list("plants their barefeet ontop of [partner]'s face.", "rests their massive feet on [partner]'s face, smothering them.", "positions their barefeet atop [partner]'s face."))]</span>"
+			message = "[pick(list("plants their bare feet ontop of [partner]'s face.", 
+				"rests their feet on [partner]'s face, smothering them.", 
+				"positions their bare feet atop [partner]'s face."))]</span>"
 
 		set_is_fucking(partner , GRINDING_FACE_WITH_FEET)
 
@@ -535,23 +643,32 @@
 
 	if(is_fucking(partner, GRINDING_MOUTH_WITH_FEET))
 		if(src.get_item_by_slot(SLOT_SHOES) != null)
-			message = "[pick(list("roughly shoves their [get_shoes()] deeper into [partner]'s mouth.", "harshly forces another inch of their [get_shoes()] into [partner]'s mouth.", "presses their weight down, their [get_shoes()] prying deeper into [partner]'s mouth."))]</span>"
+			message = "[pick(list("roughly shoves their [get_shoes()] deeper into [partner]'s mouth.", 
+				"harshly forces another inch of their [get_shoes()] into [partner]'s mouth.", 
+				"presses their weight down, their [get_shoes()] prying deeper into [partner]'s mouth."))]</span>"
 		else
-			message = "[pick(list("wiggles their toes deep inside [partner]'s mouth.", "crams their barefeet down deeper into [partner]'s mouth, making them gag.", "roughly grinds their feet on [partner]'s tongue."))]</span>"
+			message = "[pick(list("wiggles their toes deep inside [partner]'s mouth.", 
+				"crams their barefeet down deeper into [partner]'s mouth, making them gag.",
+				"roughly grinds their feet on [partner]'s tongue."))]</span>"
 
 	else if(is_fucking(partner, GRINDING_FACE_WITH_FEET))
 		if(src.get_item_by_slot(SLOT_SHOES) != null)
-			message = "[pick(list("decides to force their [get_shoes()] deep into [partner]'s mouth.", "pressed the tip of their [get_shoes()] against [partner]'s lips and shoves inwards."))]</span>"
+			message = "[pick(list("decides to force their [get_shoes()] deep into [partner]'s mouth.", 
+				"pressed the tip of their [get_shoes()] against [partner]'s lips and shoves inwards."))]</span>"
 		else
-			message = "[pick(list("pries open [partner]'s mouth with their toes and shoves their barefoot in.", "presses down their foot even harder, cramming their foot into [partner]'s mouth."))]</span>"
+			message = "[pick(list("pries open [partner]'s mouth with their toes and shoves their bare foot in.", 
+				"presses down their foot even harder, cramming their foot into [partner]'s mouth."))]</span>"
 
 		set_is_fucking(partner , GRINDING_MOUTH_WITH_FEET)
 
 	else
 		if(src.get_item_by_slot(SLOT_SHOES) != null)
-			message = "[pick(list("readies themselves and in one swift motion, shoves their [get_shoes()] into [partner]'s mouth.", "grinds the tip of their [get_shoes()] against [partner]'s mouth before pushing themselves in."))]</span>"
+			message = "[pick(list("readies themselves and in one swift motion, shoves their [get_shoes()] into [partner]'s mouth.", 
+				"grinds the tip of their [get_shoes()] against [partner]'s mouth before pushing themselves in."))]</span>"
 		else
-			message = "[pick(list("rubs their dirty barefeet across [partner]'s face before prying them into their muzzle.", "forces their barefeet into [partner]'s mouth.", "covers [partner]'s mouth and nose with their foot until they gasp for breath, then shoving both feet inside before they can react."))]</span>"
+			message = "[pick(list("rubs their dirty bare feet across [partner]'s face before prying them into their muzzle.", 
+				"forces their barefeet into [partner]'s mouth.", 
+				"covers [partner]'s mouth and nose with their foot until they gasp for breath, then shoves both feet inside before they can react."))]</span>"
 		set_is_fucking(partner , GRINDING_MOUTH_WITH_FEET)
 
 	playsound(loc, "honk/sound/interactions/foot_wet[rand(1, 3)].ogg", 70, 1, -1)

--- a/interactions/lewd/lewd_datums.dm
+++ b/interactions/lewd/lewd_datums.dm
@@ -32,16 +32,63 @@
 
 /datum/interaction/lewd/titgrope/post_interaction(mob/living/carbon/human/user, mob/living/carbon/human/target)
 	. = ..()
-	if(user.lust < 5)
-		user.lust = 5
 
 /datum/interaction/lewd/titgrope/display_interaction(mob/living/carbon/human/user, mob/living/carbon/human/target)
 	if(user.a_intent == INTENT_HELP)
-		user.visible_message("<span class='warning'>\The [user] gently gropes \the [target]'s breasts.</span>")
-	else if(user.a_intent == INTENT_HARM)
-		user.visible_message("<span class='warning'>\The [user] aggressively gropes \the [target]'s breasts.</span>")
-	else
-		return
+		user.visible_message(
+				pick("<span class='warning'>\The [user] gently gropes \the [target]'s breast.</span>",
+					 "<span class='warning'>\The [user] softly squeezes \the [target]'s breasts.</span>",
+					 "<span class='warning'>\The [user] grips \the [target]'s breasts.</span>",
+					 "<span class='warning'>\The [user] runs a few fingers over \the [target]'s breast.</span>",
+					 "<span class='warning'>\The [user] delicately teases \the [target]'s nipple.</span>",
+					 "<span class='warning'>\The [user] traces a touch across \the [target]'s breast.</span>"))
+	if(user.a_intent == INTENT_HARM)
+		user.visible_message(
+				pick("<span class='warning'>\The [user] aggressively gropes \the [target]'s breast.</span>",
+					 "<span class='warning'>\The [user] grabs \the [target]'s breasts.</span>",
+					 "<span class='warning'>\The [user] tightly squeezes \the [target]'s breasts.</span>",
+					 "<span class='warning'>\The [user] slaps at \the [target]'s breasts.</span>",
+					 "<span class='warning'>\The [user] gropes \the [target]'s breasts roughly.</span>"))
+	if(prob(5 + target.lust))
+		if(target.a_intent == INTENT_HELP)
+			user.visible_message(
+				pick("<span class='warning'>\The [target] shivers in arousal.</span>",
+					 "<span class='warning'>\The [target] moans quietly.</span>",
+					 "<span class='warning'>\The [target] breathes out a soft moan.</span>",
+					 "<span class='warning'>\The [target] gasps.</span>",
+					 "<span class='warning'>\The [target] shudders softly.</span>",
+					 "<span class='warning'>\The [target] trembles as hands run across bare skin.</span>"))
+			if(target.lust < 5)
+				target.lust = 5
+		if(target.a_intent == INTENT_DISARM)
+			if (target.restrained())
+				user.visible_message(
+					pick("<span class='warning'>\The [target] twists playfully against the restraints.</span>",
+						 "<span class='warning'>\The [target] squirms away from [user]'s hand.</span>",
+						 "<span class='warning'>\The [target] slides back from [user]'s roaming hand.</span>",
+						 "<span class='warning'>\The [target] thrusts bare breasts forward into [user]'s hands.</span>"))
+			else
+				user.visible_message(
+					pick("<span class='warning'>\The [target] playfully bats at [user]'s hand.</span>",
+						 "<span class='warning'>\The [target] squirms away from [user]'s hand.</span>",
+						 "<span class='warning'>\The [target] guides [user]'s hand across bare breasts.</span>",
+						 "<span class='warning'>\The [target] teasingly laces a few fingers over [user]'s knuckles.</span>"))
+			if(target.lust < 10)
+				target.lust += 1
+	if(target.a_intent == INTENT_GRAB)
+		user.visible_message(
+				pick("<span class='warning'>\The [target] grips [user]'s wrist tight.</span>",
+				 "<span class='warning'>\The [target] digs nails into [user]'s arm.</span>",
+				 "<span class='warning'>\The [target] grabs [user]'s wrist for a second.</span>"))
+	if(target.a_intent == INTENT_HARM)
+		user.adjustBruteLoss(1)
+		user.visible_message(
+				pick("<span class='warning'>\The [target] pushes [user] roughly away.</span>",
+				 "<span class='warning'>\The [target] digs nails angrily into [user]'s arm.</span>",
+				 "<span class='warning'>\The [target] fiercely struggles against [user].</span>",
+				 "<span class='warning'>\The [target] claws [user]'s forearm, drawing blood.</span>",
+				 "<span class='warning'>\The [target] slaps [user]'s hand away.</span>"))
+	return
 
 /datum/interaction/lewd/oral
 	command = "suckvag"
@@ -52,7 +99,7 @@
 	write_log_target = "was given head by"
 	interaction_sound = null
 	user_not_tired = TRUE
-	require_target_naked = TRUE
+	require_target_bottomless = TRUE
 	max_distance = 0
 
 /datum/interaction/lewd/oral/display_interaction(mob/living/carbon/human/user, mob/living/carbon/human/target)
@@ -74,8 +121,8 @@
 	write_log_target = "was fucked by"
 	interaction_sound = null
 	user_not_tired = TRUE
-	require_user_naked = TRUE
-	require_target_naked = TRUE
+	require_user_bottomless = TRUE
+	require_target_bottomless = TRUE
 	max_distance = 0
 
 /datum/interaction/lewd/fuck/display_interaction(mob/living/carbon/human/user, mob/living/carbon/human/target)
@@ -98,7 +145,7 @@
 	require_target_vagina = TRUE
 	interaction_sound = null
 	user_not_tired = TRUE
-	require_target_naked = TRUE
+	require_target_bottomless = TRUE
 	max_distance = 0
 
 /datum/interaction/lewd/finger/display_interaction(mob/living/carbon/human/user, mob/living/carbon/human/target)
@@ -111,7 +158,7 @@
 	require_user_hands = TRUE
 	require_target_anus = TRUE
 	user_not_tired = TRUE
-	require_target_naked = TRUE
+	require_target_bottomless = TRUE
 	max_distance = 0
 
 /datum/interaction/lewd/fingerass/display_interaction(mob/living/carbon/human/user, mob/living/carbon/human/target)
@@ -124,7 +171,7 @@
 	interaction_sound = null
 	require_target_mouth = TRUE
 	user_not_tired = TRUE
-	require_user_naked = TRUE
+	require_user_bottomless = TRUE
 	max_distance = 0
 
 /datum/interaction/lewd/facefuck/display_interaction(mob/living/carbon/human/user, mob/living/carbon/human/target)
@@ -137,7 +184,7 @@
 	require_user_penis = TRUE
 	require_target_mouth = TRUE
 	user_not_tired = TRUE
-	require_user_naked = TRUE
+	require_user_bottomless = TRUE
 	max_distance = 0
 
 /datum/interaction/lewd/throatfuck/display_interaction(mob/living/carbon/human/user, mob/living/carbon/human/target)
@@ -150,7 +197,7 @@
 	require_user_hands = TRUE
 	require_target_penis = TRUE
 	target_not_tired = TRUE
-	require_target_naked = TRUE
+	require_target_bottomless = TRUE
 	max_distance = 1
 
 /datum/interaction/lewd/handjob/display_interaction(mob/living/carbon/human/user, mob/living/carbon/human/target)
@@ -162,8 +209,8 @@
 	interaction_sound = null
 	require_user_penis = TRUE
 	user_not_tired = TRUE
-	require_user_naked = TRUE
-	require_target_naked = TRUE
+	require_user_bottomless = TRUE
+	require_target_topless = TRUE
 	require_target_vagina = TRUE
 	max_distance = 0
 
@@ -178,8 +225,8 @@
 	require_target_penis = TRUE
 	user_not_tired = TRUE
 	target_not_tired = TRUE
-	require_user_naked = TRUE
-	require_target_naked = TRUE
+	require_user_bottomless = TRUE
+	require_target_bottomless = TRUE
 	max_distance = 0
 
 /datum/interaction/lewd/mount/display_interaction(mob/living/carbon/human/user, mob/living/carbon/human/target)
@@ -194,8 +241,8 @@
 	require_target_penis = TRUE
 	user_not_tired = TRUE
 	target_not_tired = TRUE
-	require_user_naked = TRUE
-	require_target_naked = TRUE
+	require_user_bottomless = TRUE
+	require_target_bottomless = TRUE
 	max_distance = 0
 
 /datum/interaction/lewd/mountass/display_interaction(mob/living/carbon/human/user, mob/living/carbon/human/target)
@@ -208,7 +255,7 @@
 	require_user_mouth = TRUE
 	require_target_anus = TRUE
 	user_not_tired = TRUE
-	require_target_naked = TRUE
+	require_target_bottomless = TRUE
 	max_distance = 0
 
 /datum/interaction/lewd/rimjob/display_interaction(mob/living/carbon/human/user, mob/living/carbon/human/target)
@@ -221,7 +268,7 @@
 	require_target_mouth = TRUE
 	require_user_anus = TRUE
 	user_not_tired = TRUE
-	require_user_naked = TRUE
+	require_user_bottomless = TRUE
 	max_distance = 0
 
 /datum/interaction/lewd/mountface/display_interaction(mob/living/carbon/human/user, mob/living/carbon/human/target)
@@ -262,7 +309,7 @@
 	command = "thigh_smother"
 	description = "Smother them."
 	max_distance = 0
-	require_user_naked = TRUE
+	require_user_bottomless = TRUE
 	require_target_mouth = TRUE
 	interaction_sound = null
 	user_not_tired = TRUE
@@ -277,7 +324,7 @@
 	command = "nut_face"
 	description = "Nuts to face."
 	interaction_sound = null
-	require_user_naked = TRUE
+	require_user_bottomless = TRUE
 	require_user_penis = TRUE
 	require_target_mouth = TRUE
 	max_distance = 0

--- a/interactions/lewd/lewd_interactions.dm
+++ b/interactions/lewd/lewd_interactions.dm
@@ -14,8 +14,10 @@
 	var/user_not_tired
 	var/target_not_tired
 
-	var/require_user_naked
-	var/require_target_naked
+	var/require_user_topless
+	var/require_target_topless
+	var/require_user_bottomless
+	var/require_target_bottomless
 
 	var/require_user_penis
 	var/require_user_anus
@@ -37,9 +39,14 @@
 				to_chat(user, "<span class='warning'>You're still exhausted from the last time. You need to wait [DisplayTimeText(user.refactory_period * 10, TRUE)] until you can do that!</span>")
 			return FALSE
 
-		if(require_user_naked && !user.is_nude())
+		if(require_user_bottomless && !user.is_bottomless())
 			if(!silent)
-				to_chat(user, "<span class = 'warning'>Your clothes are in the way.</span>")
+				to_chat(user, "<span class = 'warning'>Your pants are in the way.</span>")
+			return FALSE
+
+		if(require_user_topless && !user.is_topless())
+			if(!silent)
+				to_chat(user, "<span class = 'warning'>Your top is in the way.</span>")
 			return FALSE
 
 		if(require_user_penis && !user.has_penis())
@@ -72,9 +79,14 @@
 				to_chat(user, "<span class='warning'>They're still exhausted from the last time. They need to wait [DisplayTimeText(target.refactory_period * 10, TRUE)] until you can do that!</span>")
 			return FALSE
 
-		if(require_target_naked && !target.is_nude())
+		if(require_target_bottomless && !target.is_bottomless())
 			if(!silent)
-				to_chat(user, "<span class = 'warning'>Their clothes are in the way.</span>")
+				to_chat(user, "<span class = 'warning'>Their pants are in the way.</span>")
+			return FALSE
+
+		if(require_target_topless && !target.is_topless())
+			if(!silent)
+				to_chat(user, "<span class = 'warning'>Their top is in the way.</span>")
 			return FALSE
 
 		if(require_target_penis && !target.has_penis())
@@ -115,10 +127,19 @@
 	var/dat = ..()
 	if(refactory_period)
 		dat += "<br>...are sexually exhausted for the time being."
-	if(is_nude())
-		dat += "<br>...are naked."
+	if(a_intent == INTENT_HELP)
+		dat += "<br>...are acting gentle."
+	else if (a_intent == INTENT_DISARM)
+		dat += "<br>...are acting playful."
+	else if (a_intent == INTENT_GRAB)
+		dat += "<br>...are acting rough."
+	else if(a_intent == INTENT_HARM)
+		dat += "<br>...are fighting anyone who comes near."
+	if(is_topless())
 		if(has_breasts())
 			dat += "<br>...have breasts."
+	if(is_bottomless())
+		dat += "<br>...are naked."
 		if(has_penis())
 			dat += "<br>...have a penis."
 		if(has_vagina())

--- a/interactions/lewd/lewd_species.dm
+++ b/interactions/lewd/lewd_species.dm
@@ -4,13 +4,13 @@
 	var/has_breasts = FALSE
 
 /datum/species/proc/has_penis(mob/living/carbon/human/H)
-	return has_genitals && (H.gender == MALE)
+	return has_genitals && H.has_penis
 
 /datum/species/proc/has_vagina(mob/living/carbon/human/H)
-	return has_genitals && (H.gender == FEMALE)
+	return has_genitals && H.has_vagina
 
 /datum/species/proc/has_anus(mob/living/carbon/human/H)
 	return has_anus
 
 /datum/species/proc/has_breasts(mob/living/carbon/human/H)
-	return has_breasts || (H.gender == FEMALE)
+	return has_breasts || (H.has_breasts)

--- a/interactions/lewd/objects.dm
+++ b/interactions/lewd/objects.dm
@@ -43,7 +43,7 @@
 
 /obj/item/dildo/attack(mob/living/carbon/human/M, mob/living/carbon/human/user)
 	var/message = ""
-	if(istype(M, /mob/living/carbon/human) && user.zone_selected == "groin" && M.is_nude())
+	if(istype(M, /mob/living/carbon/human) && user.zone_selected == "groin" && M.is_bottomless())
 		if(hole == CUM_TARGET_VAGINA && M.has_vagina())
 			message = (user == M) ? pick("fucks their own pussy with \the [src]","shoves the [src] into their pussy", "jams the [src] into their pussy") : pick("fucks [M] right in the pussy with \the [src]", "jams \the [src] right into [M]'s pussy")
 		else if(hole == CUM_TARGET_ANUS && M.has_anus())
@@ -121,7 +121,7 @@
 
 /obj/item/dildo/cyborg/attack(mob/living/carbon/human/M, mob/living/carbon/human/user)
 	var/message = ""
-	if(istype(M, /mob/living/carbon/human) && M.is_nude())
+	if(istype(M, /mob/living/carbon/human) && M.is_bottomless())
 		if(hole == CUM_TARGET_VAGINA && M.has_vagina())
 			message = (user == M) ? pick("fucks their own pussy with \the [src]","shoves the [src] into their pussy", "jams the [src] into their pussy") : pick("fucks [M] right in the pussy with \the [src]", "jams \the [src] right into [M]'s pussy")
 		else if(hole == CUM_TARGET_ANUS && M.has_anus())


### PR DESCRIPTION
If you can't beat 'em, join 'em. Substitute for removing ERP verbs (#332), makes them better and more varied in their description. 

The breast grope action offers an example of intent-based ERP, we can expand this to other verbs if need be. Other changes:

- Divorces sex organs from gender. 
- is_topless() and is_bottomless() are now separate concepts.
- Adds dickbiting / retaliatory damage against partner in Harm mode.
- Adds castration so you can remove Bear testicles.
- Applies gender_ambiguous only when breasts mismatch with gender presentation, or surgery was messed up.