### PR TITLE
Moves technophreak trait to mind datums

### DIFF
--- a/code/__DEFINES/traits.dm
+++ b/code/__DEFINES/traits.dm
@@ -49,7 +49,6 @@
 #define TRAIT_NODEATH			"nodeath"
 #define TRAIT_NOHARDCRIT		"nohardcrit"
 #define TRAIT_NOSOFTCRIT		"nosoftcrit"
-#define TRAIT_TECHNOPHREAK		"technophreak" // Sets is_super_advanced_tool_user to TRUE
 
 #define TRAIT_ALCOHOL_TOLERANCE	"alcohol_tolerance"
 #define TRAIT_AGEUSIA			"ageusia"

--- a/code/datums/mind.dm
+++ b/code/datums/mind.dm
@@ -50,7 +50,7 @@
 	var/datum/faction/faction 			//associated faction
 	var/datum/changeling/changeling		//changeling holder
 	var/linglink
-	var/datum/martial_art/martial_art
+	var/datum/martial_art/martial_art // Why are there two sets of martial arts? Look into later.
 	var/static/default_martial_art = new/datum/martial_art
 	var/miming = 0 // Mime's vow of silence
 	var/list/antag_datums
@@ -60,7 +60,7 @@
 	var/datum/mind/soulOwner //who owns the soul.  Under normal circumstances, this will point to src
 	var/hasSoul = TRUE // If false, renders the character unable to sell their soul.
 	var/isholy = FALSE //is this person a chaplain or admin role allowed to use bibles
-
+	var/istechnophreak = FALSE // Sets the mind to knowing how to use super advanced technology and the like.
 	var/mob/living/enslaved_to //If this mind's master is another mob (i.e. adamantine golems)
 	var/datum/language_holder/language_holder
 	var/unconvertable = FALSE

--- a/code/game/objects/items/devices/flashlight.dm
+++ b/code/game/objects/items/devices/flashlight.dm
@@ -52,10 +52,6 @@
 		if((user.has_trait(TRAIT_CLUMSY) || user.has_trait(TRAIT_DUMB)) && prob(50))	//too dumb to use flashlight properly
 			return ..()	//just hit them in the head
 
-		if(!user.IsAdvancedToolUser())
-			to_chat(user, "<span class='warning'>You don't have the dexterity to do this!</span>")
-			return
-
 		if(!M.get_bodypart(BODY_ZONE_HEAD))
 			to_chat(user, "<span class='warning'>[M] doesn't have a head!</span>")
 			return
@@ -535,6 +531,6 @@
 	desc = "This shouldn't exist outside of someone's head, how are you seeing this?"
 	brightness_on = 15
 	flashlight_power = 1
-	flags_1 = CONDUCT_1 
+	flags_1 = CONDUCT_1
 	item_flags = DROPDEL
 	actions_types = list()

--- a/code/game/objects/items/storage/book.dm
+++ b/code/game/objects/items/storage/book.dm
@@ -105,10 +105,6 @@ GLOBAL_LIST_INIT(bibleitemstates, list("bible", "koran", "scrapbook", "bible",  
 
 /obj/item/storage/book/bible/attack(mob/living/M, mob/living/carbon/human/user, heal_mode = TRUE)
 
-	if (!user.IsAdvancedToolUser())
-		to_chat(user, "<span class='warning'>You don't have the dexterity to do this!</span>")
-		return
-
 	if (user.has_trait(TRAIT_CLUMSY) && prob(50))
 		to_chat(user, "<span class='danger'>[src] slips out of your hand and hits your head.</span>")
 		user.take_bodypart_damage(10)

--- a/code/game/objects/items/toys.dm
+++ b/code/game/objects/items/toys.dm
@@ -178,9 +178,6 @@
 /obj/item/toy/gun/afterattack(atom/target as mob|obj|turf|area, mob/user, flag)
 	if (flag)
 		return
-	if (!user.IsAdvancedToolUser())
-		to_chat(user, "<span class='warning'>You don't have the dexterity to do this!</span>")
-		return
 	src.add_fingerprint(user)
 	if (src.bullets < 1)
 		user.show_message("<span class='warning'>*click*</span>", 2)

--- a/code/game/objects/objs.dm
+++ b/code/game/objects/objs.dm
@@ -249,7 +249,7 @@
 	if(!(isfloorturf(loc) || istype(loc, /turf/open/indestructible)) && !anchored)
 		to_chat(user, "<span class='warning'>[src] needs to be on the floor to be secured!</span>")
 		return FAILED_UNFASTEN
-	if(!user.mind.istechnophreak && src.super_advanced_technology && !isdead(user))
+	if(!user.mind.istechnophreak && src.super_advanced_technology)
 		to_chat(user, "<span class='warning'>You don't understand the technology well enough to do this!</span>")
 		return FAILED_UNFASTEN
 	return SUCCESSFUL_UNFASTEN

--- a/code/game/objects/objs.dm
+++ b/code/game/objects/objs.dm
@@ -249,7 +249,7 @@
 	if(!(isfloorturf(loc) || istype(loc, /turf/open/indestructible)) && !anchored)
 		to_chat(user, "<span class='warning'>[src] needs to be on the floor to be secured!</span>")
 		return FAILED_UNFASTEN
-	if(!user.is_super_advanced_tool_user() && src.super_advanced_technology)
+	if(!user.mind.istechnophreak && src.super_advanced_technology && !isdead(user))
 		to_chat(user, "<span class='warning'>You don't understand the technology well enough to do this!</span>")
 		return FAILED_UNFASTEN
 	return SUCCESSFUL_UNFASTEN

--- a/code/game/objects/structures/musician.dm
+++ b/code/game/objects/structures/musician.dm
@@ -369,10 +369,6 @@
 /obj/structure/piano/ui_interact(mob/user)
 	if(!user || !anchored)
 		return
-
-	if(!user.IsAdvancedToolUser())
-		to_chat(user, "<span class='warning'>You don't have the dexterity to do this!</span>")
-		return 1
 	user.set_machine(src)
 	song.interact(user)
 

--- a/code/game/turfs/simulated/minerals.dm
+++ b/code/game/turfs/simulated/minerals.dm
@@ -47,9 +47,6 @@
 
 
 /turf/closed/mineral/attackby(obj/item/I, mob/user, params)
-	if (!user.IsAdvancedToolUser())
-		to_chat(usr, "<span class='warning'>You don't have the dexterity to do this!</span>")
-		return
 
 	if(I.tool_behaviour == TOOL_MINING)
 		var/turf/T = user.loc

--- a/code/game/turfs/simulated/walls.dm
+++ b/code/game/turfs/simulated/walls.dm
@@ -158,9 +158,6 @@
 
 /turf/closed/wall/attackby(obj/item/W, mob/user, params)
 	user.changeNext_move(CLICK_CD_MELEE)
-	if (!user.IsAdvancedToolUser())
-		to_chat(user, "<span class='warning'>You don't have the dexterity to do this!</span>")
-		return
 
 	//get the user's location
 	if(!isturf(user.loc))

--- a/code/modules/clothing/head/helmet.dm
+++ b/code/modules/clothing/head/helmet.dm
@@ -573,15 +573,6 @@
 	dynamic_hair_suffix = ""
 	dynamic_fhair_suffix = ""
 
-/obj/item/clothing/head/helmet/power_armor/f13/mob_can_equip(mob/user, slot)
-	if (ishuman(user))
-		var/mob/living/carbon/human/H = user
-		if (!H.has_trait(TRAIT_TECHNOPHREAK) && slot == SLOT_HEAD)
-			H << "<span class='warning'>You don't have the proper training to operate the power armor!</span>"
-			return 0
-			..()
-	return ..()
-
 /obj/item/clothing/head/helmet/power_armor/t45b
 	name = "Salvaged T-45b helmet"
 	desc = "It's a pre-War power armor helmet, recovered and maintained by NCR engineers."

--- a/code/modules/clothing/suits/armor.dm
+++ b/code/modules/clothing/suits/armor.dm
@@ -399,7 +399,7 @@
 /obj/item/clothing/suit/armor/f13/power_armor/mob_can_equip(mob/user, slot)
 	if (ishuman(user))
 		var/mob/living/carbon/human/H = user
-		if (!H.has_trait(TRAIT_TECHNOPHREAK) && slot == SLOT_WEAR_SUIT)
+		if (!H.mind.istechnophreak && slot == SLOT_WEAR_SUIT)
 			H << "<span class='warning'>You don't have the proper training to operate the power armor!</span>"
 			return 0
 			..()

--- a/code/modules/jobs/job_types/bos.dm
+++ b/code/modules/jobs/job_types/bos.dm
@@ -27,7 +27,7 @@ Main doors: ACCESS_CAPTAIN 20
 	..()
 	if(visualsOnly)
 		return
-	H.add_trait(TRAIT_TECHNOPHREAK)
+	H.mind.istechnophreak = TRUE
 
 /*
 Elder

--- a/code/modules/jobs/job_types/enclave.dm
+++ b/code/modules/jobs/job_types/enclave.dm
@@ -2,7 +2,7 @@
 	..()
 	if(visualsOnly)
 		return
-	H.add_trait(TRAIT_TECHNOPHREAK)
+	H.mind.istechnophreak = TRUE
 
 /*
 Commander

--- a/code/modules/jobs/job_types/silicon.dm
+++ b/code/modules/jobs/job_types/silicon.dm
@@ -35,6 +35,7 @@ AI
 			qdel(lateJoinCore)
 	var/mob/living/silicon/ai/AI = H
 	AI.rename_self("ai", M.client)			//If this runtimes oh well jobcode is fucked.
+	H.mind.istechnophreak = TRUE
 
 	//we may have been created after our borg
 	if(SSticker.current_state == GAME_STATE_SETTING_UP)

--- a/code/modules/jobs/job_types/vault.dm
+++ b/code/modules/jobs/job_types/vault.dm
@@ -16,7 +16,7 @@ here's a tip, go search DEFINES/access.dm
 	..()
 	if(visualsOnly)
 		return
-	H.add_trait(TRAIT_TECHNOPHREAK)
+	H.mind.istechnophreak = TRUE
 
 /*
 Overseer

--- a/code/modules/mob/dead/observer/observer.dm
+++ b/code/modules/mob/dead/observer/observer.dm
@@ -518,9 +518,6 @@ This is the proc mobs get to turn into a ghost. Forked from ghostize due to comp
 /mob/dead/observer/IsAdvancedToolUser()
 	return TRUE
 
-/mob/dead/observer/is_super_advanced_tool_user()
-	return TRUE
-
 /mob/dead/observer/verb/toggle_ghostsee()
 	set name = "Toggle Ghost Vision"
 	set desc = "Toggles your ability to see things only ghosts can see, like other ghosts"

--- a/code/modules/mob/living/carbon/human/human_helpers.dm
+++ b/code/modules/mob/living/carbon/human/human_helpers.dm
@@ -96,11 +96,6 @@
 		return FALSE
 	return TRUE//Humans can use guns and such
 
-/mob/living/carbon/human/is_super_advanced_tool_user()
-	if(has_trait(TRAIT_TECHNOPHREAK))
-		return TRUE
-	return FALSE // You're not a technophreak without training!
-
 /mob/living/carbon/human/reagent_check(datum/reagent/R)
 	return dna.species.handle_chemicals(R,src)
 	// if it returns 0, it will run the usual on_mob_life for that reagent. otherwise, it will stop after running handle_chemicals for the species.

--- a/code/modules/mob/mob.dm
+++ b/code/modules/mob/mob.dm
@@ -660,9 +660,6 @@
 /mob/proc/IsAdvancedToolUser()//This might need a rename but it should replace the can this mob use things check
 	return 0
 
-/mob/proc/is_super_advanced_tool_user()
-	return 0
-
 /mob/proc/swap_hand()
 	return
 

--- a/code/modules/paperwork/contract.dm
+++ b/code/modules/paperwork/contract.dm
@@ -187,7 +187,7 @@
 		return ..()
 
 /obj/item/paper/contract/infernal/proc/attempt_signature(mob/living/carbon/human/user, blood = 0)
-	if(!user.IsAdvancedToolUser() || !user.is_literate())
+	if(!user.is_literate())
 		to_chat(user, "<span class='notice'>You don't know how to read or write.</span>")
 		return 0
 	if(user.mind != target)

--- a/code/modules/paperwork/handlabeler.dm
+++ b/code/modules/paperwork/handlabeler.dm
@@ -61,9 +61,6 @@
 
 
 /obj/item/hand_labeler/attack_self(mob/user)
-	if(!user.IsAdvancedToolUser())
-		to_chat(user, "<span class='warning'>You don't have the dexterity to use [src]!</span>")
-		return
 	mode = !mode
 	icon_state = "labeler[mode]"
 	if(mode)

--- a/code/modules/research/rdconsole.dm
+++ b/code/modules/research/rdconsole.dm
@@ -1025,7 +1025,7 @@ Nothing else in the console has ID requirements.
 
 /obj/machinery/computer/rdconsole/ui_interact(mob/user)
 	. = ..()
-	if(!user.is_super_advanced_tool_user())
+	if(!user.mind.istechnophreak && !isdead(user))
 		return to_chat(user, "<span class='warning'>The array of simplistic button pressing confuses you. Besides, did you really want to spend all day staring at a screen?</span>")
 	var/datum/browser/popup = new(user, "rndconsole", name, 900, 600)
 	popup.add_stylesheet("techwebs", 'html/browser/techwebs.css')


### PR DESCRIPTION
**Description of changes:**
- Moves technophreak trait from a proc/trait to a var in mind datum. This transfers it from ghost, to dead bodies, to different critters, to an MMI - whatever. Point is, it'll work across everything.
- Adds a sanity check for ghosts for interactions.
- Fixes legion being unable to do a number of things and, by extension, monkeys and a few other critters. Don't worry, ishuman(user) is a proc. As is isdead(user).
- Positronic brains will be unable to use the console. I am not convinced to change it.

**Checklist before we merge your thing:**
- [x] The author is ready to merge
- [x] All changes are described above
- [x] 24 hours for comment have passed, or this is a bugfix
- [x] Hosted and tested; it compiles and works