### PR TITLE
Remove ERP Verbs 2: Electric Boogaloo

### DIFF
--- a/code/game/objects/effects/spawners/f13lootdrop.dm
+++ b/code/game/objects/effects/spawners/f13lootdrop.dm
@@ -986,7 +986,6 @@
 				/obj/item/storage/box/snappops,
 				/obj/item/bikehorn/rubberducky,
 				/obj/item/stack/packageWrap,
-				/obj/item/dildo,
 				/obj/item/storage/box/matches,
 				/obj/item/toner,
 				/obj/item/tank/internals/oxygen,

--- a/code/game/objects/effects/spawners/ss13.dm
+++ b/code/game/objects/effects/spawners/ss13.dm
@@ -1250,7 +1250,6 @@ obj
 								lb2.loc=src.loc
 								del src
 							if(15)
-								var/obj/item/dildo/lb = new
 								var/obj/item/storage/box/matches/lb2 = new
 								lb.loc=src.loc
 								lb2.loc=src.loc

--- a/tgstation.dme
+++ b/tgstation.dme
@@ -2678,9 +2678,4 @@
 #include "interface\menu.dm"
 #include "interface\stylesheet.dm"
 #include "interface\skin.dmf"
-#include "lewd\_lewd.dm"
-#include "lewd\lewd_datums.dm"
-#include "lewd\lewd_interactions.dm"
-#include "lewd\lewd_species.dm"
-#include "lewd\objects.dm"
 // END_INCLUDE


### PR DESCRIPTION
We've been over this a lot. Rhicora's attempted PR got shot down by people whining, so I'm going to lay out a few reasons off the bat why removing the verbs is a good change.

**ERP verbs aren't conductive at all to a good server.**
First off the bat, it draws a bad crowd from Citadel and other sub-par servers. These people and their attitudes towards others tend to push people who might be interested in roleplay in a Fallout universe away, as well as creating a bad reputation for the server in general. Removing ERP would remove this stigma making BD citadel-tier, thereby making it more likely to attract and retain prospective players.
One common response to this is "But the server will die without ERP!". My response to that is: If it dies without ERP, then let it die. However, the population dropoff as a result of removing ERP - with the Citadel players and people who only come here to ERP verb leaving - will be negated by the actual interest of roleplayers and average SS13 players with an interest in the subject and a change of pace in gameplay.

**Removing ERP verbs will result in a net improvement in server quality.**
When you remove ERP verbs, as per the above, you remove the players who are soley interested in it and their attitudes towards others. This results in an increase in player quality, from the retained players who are here for the Fallout atmosphere and roleplay, and the new players with the same interests. As a result of this, staff quality will increase as there's a better quality pool of players to draw from. This results in rules getting enforced more uniformly, a better role model for newer players, and a higher quality of community management. Together, these factors will draw more players in and create a looping effect of better players = better staff = better server.

If you like ERP verbs and want them to stay, I'd ask you to respond to a few questions instead of just getting whiny and downvoting:
1. Why do ERP verbs contribute to making BD a good/quality server?
2. In what way do they contribute?
3. Do you also play on other servers with ERP verbs enabled?

Happily answer other questions if they're posed as to why ERP should be removed. Exactly the same changes Rhicora made.

![ahurepm](https://user-images.githubusercontent.com/44979174/53127941-80295800-355b-11e9-896c-0151927fb6f6.gif)

