### PR TITLE
Revert "Make ghouls hostile to ghoul players"

### DIFF
--- a/code/modules/mob/living/carbon/human/species_types/ghoul.dm
+++ b/code/modules/mob/living/carbon/human/species_types/ghoul.dm
@@ -20,10 +20,10 @@
 	..()
 	for(var/obj/item/bodypart/b in C.bodyparts)
 		b.max_damage -= 10
-	C.faction |= "pghoul"
+	C.faction |= "ghoul"
 /datum/species/ghoul/on_species_loss(mob/living/carbon/C)
 	..()
-	C.faction -= "pghoul"
+	C.faction -= "ghoul"
 	for(var/obj/item/bodypart/b in C.bodyparts)
 		b.max_damage = initial(b.max_damage)
 


### PR DESCRIPTION
This got spedmerge in 3 hours with no actual discussion on it and what other solutions there are

I'll post my comments on the previous PR here

Discussing with Jt in general a bit on this, it's not as severe as it seems at first glance, as the only area where this is really an issue is the prison due to the good weapons and armor that can spawn there, however that area is easily dealt with already with even just a pistol, so ultimately being able to bypass ghouls isnt an issue.

A better solution would be to replace the ghouls in the armory of the prison with some protectrons which will attack ghoul chars and are ultimately a better defense for a loot stockpile on par with the east enclave bunker