### PR TITLE
removes food from spawning on the map

### DIFF
--- a/code/game/objects/effects/spawners/f13lootdrop.dm
+++ b/code/game/objects/effects/spawners/f13lootdrop.dm
@@ -1024,51 +1024,8 @@
 	fan_out_items = TRUE
 
 	loot = list(
-				/obj/item/storage/box/ingredients/american,
-				/obj/item/storage/box/ingredients/carnivore,
-				/obj/item/storage/box/ingredients/delights,
-				/obj/item/storage/box/ingredients/exotic,
-				/obj/item/storage/box/ingredients/fiesta,
-				/obj/item/storage/box/ingredients/fruity,
-				/obj/item/storage/box/ingredients/grains,
-				/obj/item/storage/box/ingredients/italian,
-				/obj/item/storage/box/ingredients/sweets,
-				/obj/item/storage/box/ingredients/vegetarian,
-				/obj/item/storage/box/ingredients/wildcard,
-				/obj/item/storage/box/donkpockets,
-				/obj/item/reagent_containers/food/condiment/flour,
-				/obj/item/reagent_containers/food/condiment/rice,
-				/obj/item/reagent_containers/food/condiment/enzyme,
-				/obj/item/reagent_containers/food/condiment/soymilk,
-				/obj/item/reagent_containers/food/condiment/milk,
-				/obj/item/reagent_containers/food/condiment/saltshaker,
-				/obj/item/reagent_containers/food/condiment/peppermill,
-				/obj/item/reagent_containers/food/condiment/mayonnaise,
-				/obj/item/reagent_containers/food/condiment/soysauce,
-				/obj/item/reagent_containers/food/snacks/beans,
-				/obj/item/reagent_containers/food/snacks/baguette,
-				/obj/item/reagent_containers/food/snacks/bun,
-				/obj/item/reagent_containers/food/snacks/butter,
-				/obj/item/reagent_containers/food/snacks/cheesewedge,
-				/obj/item/reagent_containers/food/snacks/chips,
-				/obj/item/reagent_containers/food/snacks/chocolatebar,
-				/obj/item/reagent_containers/food/snacks/cracker,
-				/obj/item/reagent_containers/food/snacks/icecream,
-				/obj/item/reagent_containers/food/snacks/lollipop,
-				/obj/item/reagent_containers/food/snacks/meat/rawbacon,
-				/obj/item/reagent_containers/food/snacks/meat/slab/human,
-				/obj/item/reagent_containers/food/snacks/meat/slab/pug,
-				/obj/item/reagent_containers/food/snacks/meat/slab/meatproduct,
-				/obj/item/reagent_containers/food/snacks/muffin/berry,
-				/obj/item/reagent_containers/food/snacks/muffin,
-				/obj/item/reagent_containers/food/snacks/no_raisin,
-				/obj/item/reagent_containers/food/snacks/popcorn,
-				/obj/item/reagent_containers/food/snacks/raisincookie,
-				/obj/item/reagent_containers/food/snacks/sosjerky,
-				/obj/item/reagent_containers/food/snacks/sausage,
-				/obj/item/reagent_containers/food/snacks/store/cheesewheel,
 				"" // a chance to spawn nothing
-				)
+				) // scarcity PR - BD
 
 
 /obj/effect/spawner/lootdrop/f13/foodspawner/Initialize(mapload) //on mapload, pick how many shit to spawn

--- a/code/game/objects/structures/crates_lockers/closets/secure/freezer.dm
+++ b/code/game/objects/structures/crates_lockers/closets/secure/freezer.dm
@@ -24,15 +24,6 @@
 	desc = "This refrigerator looks quite dusty, is there anything edible still inside?"
 	req_access = list()
 
-/obj/structure/closet/secure_closet/freezer/kitchen/maintenance/PopulateContents()
-	..()
-	for(var/i = 0, i < 5, i++)
-		new /obj/item/reagent_containers/food/condiment/milk(src)
-	for(var/i = 0, i < 5, i++)
-		new /obj/item/reagent_containers/food/condiment/soymilk(src)
-	for(var/i = 0, i < 2, i++)
-		new /obj/item/storage/fancy/egg_box(src)
-
 /obj/structure/closet/secure_closet/freezer/kitchen/mining
 	req_access = list()
 

--- a/code/modules/mob/living/simple_animal/friendly/farm_animals.dm
+++ b/code/modules/mob/living/simple_animal/friendly/farm_animals.dm
@@ -21,8 +21,8 @@
 	attack_same = 1
 	attacktext = "kicks"
 	attack_sound = 'sound/weapons/punch1.ogg'
-	health = 40
-	maxHealth = 40
+	health = 150
+	maxHealth = 150
 	melee_damage_lower = 1
 	melee_damage_upper = 2
 	environment_smash = ENVIRONMENT_SMASH_NONE
@@ -124,8 +124,8 @@
 	response_harm   = "kicks"
 	attacktext = "kicks"
 	attack_sound = 'sound/weapons/punch1.ogg'
-	health = 50
-	maxHealth = 50
+	health = 100
+	maxHealth = 100
 	var/is_calf = 0
 	var/food_type = /obj/item/reagent_containers/food/snacks/grown/wheat
 	var/has_calf = 0
@@ -234,8 +234,8 @@
 	response_disarm = "gently pushes aside"
 	response_harm   = "kicks"
 	attacktext = "kicks"
-	health = 3
-	maxHealth = 3
+	health = 15
+	maxHealth = 15
 	ventcrawler = VENTCRAWLER_ALWAYS
 	var/amount_grown = 0
 	pass_flags = PASSTABLE | PASSGRILLE | PASSMOB
@@ -284,8 +284,8 @@
 	response_disarm = "gently pushes aside"
 	response_harm   = "kicks"
 	attacktext = "kicks"
-	health = 15
-	maxHealth = 15
+	health = 50
+	maxHealth = 50
 	ventcrawler = VENTCRAWLER_ALWAYS
 	var/eggsleft = 0
 	var/eggsFertile = TRUE


### PR DESCRIPTION
again, a temporary change to prevent map edits in lieu of other individuals making significant contributions to the map

this removes food from spawning randomly, working towards the scarcity issue found here (making a new one)

other ways to get food 
- butchering simple mobs
 - cazadors/ghouls/radscorpions/deathclaws/brahmin/bighorners/raiders/raiderboss
- butchering humans
 - everyone playing the game (on average around 40-60 oppourtunities to do this at any given time, not including people who have already died/ghosted)
- farming
 - you can create new soil mounds by digging up sand
 - every faction base has farming areas with tools/wells
 - every faction base has seeds/ability to farm
 - legion has a role who's job is basically to farm (slave/follower)

this also removes eggs and milk from spawning in freezers (legion can now no longer eat eggs to be alive)

this also means none of the factions start with food in their base now. (they do however start with a means to butcher stuff)