### PR TITLE
Admin Config Changes

### DIFF
--- a/config/admin_ranks.txt
+++ b/config/admin_ranks.txt
@@ -48,8 +48,6 @@ Three Dog		= -@ -ADMIN +DJ
 Scribe 			= +POSSESS +SERVER +REJUV +BUILD +DEBUG +VAREDIT +SOUND +SPAWN +DJ +POLL -AUTOLOGIN
 Head Scribe 		= +@ +RIGHTS -AUTOLOGIN
 
-Head Coder      = +EVERYTHING
-Coder			= +DEBUG +VAREDIT +SERVER +SPAWN +POLL -AUTOLOGIN
 Initiate		= +ADMIN
 Aspirant 		= +@ +BAN +REJUV
 Knight 			= +@ +SPAWN +FUN +VAREDIT +POSSESS +SOUND

--- a/config/admin_ranks.txt
+++ b/config/admin_ranks.txt
@@ -48,6 +48,8 @@ Three Dog		= -@ -ADMIN +DJ
 Scribe 			= +POSSESS +SERVER +REJUV +BUILD +DEBUG +VAREDIT +SOUND +SPAWN +DJ +POLL -AUTOLOGIN
 Head Scribe 		= +@ +RIGHTS -AUTOLOGIN
 
+Head Coder      = +EVERYTHING
+Coder			= +DEBUG +VAREDIT +SERVER +SPAWN +POLL -AUTOLOGIN
 Initiate		= +ADMIN
 Aspirant 		= +@ +BAN +REJUV
 Knight 			= +@ +SPAWN +FUN +VAREDIT +POSSESS +SOUND

--- a/config/admin_ranks.txt
+++ b/config/admin_ranks.txt
@@ -17,6 +17,7 @@
 # BEGIN_KEYWORDS
 # +ADMIN = general admin tools, verbs etc
 # +FUN = events, other event-orientated actions. Access to the fun secrets in the secrets panel.
+# +DJ = A tool that functions like +SOUND just with a couple changes and a volume selector.
 # +BAN = the ability to ban, jobban and fullban
 # +STEALTH = the ability to stealthmin (make yourself appear with a fake name to everyone but other admins
 # +POSSESS = the ability to possess objects
@@ -33,6 +34,7 @@
 # +EVERYTHING (or +HOST or +ALL) = Simply gives you everything without having to type every flag
 # END_KEYWORDS
 
+#Previous ranks on archive incase someone shits the proverbial bed. (once everyone has been switched over to the new ranks you're more than welcome to blitz these to reduce bloat)
 Admin Observer	= -AUTOLOGIN
 Moderator		= +ADMIN
 Admin Candidate	= +@
@@ -43,7 +45,13 @@ Game Master		= +EVERYTHING *EVERYTHING
 Lazy Master 	= +EVERYTHING -AUTOLOGIN *EVERYTHING
 Three Dog		= -@ -ADMIN +DJ
 
-Host			= +EVERYTHING *EVERYTHING
+Scribe 			= +POSSESS +SERVER +REJUV +BUILD +DEBUG +VAREDIT +SOUND +SPAWN +DJ +POLL -AUTOLOGIN
+Head Scribe 		= +@ +RIGHTS -AUTOLOGIN
 
-Head Coder      = +EVERYTHING
-Coder			= +DEBUG +VAREDIT +SERVER +SPAWN +POLL -AUTOLOGIN
+Initiate		= +ADMIN
+Aspirant 		= +@ +BAN +REJUV
+Knight 			= +@ +SPAWN +FUN +VAREDIT +POSSESS +SOUND
+Paladin			= +@ +STEALTH +BUILD +SERVER +DJ +POLL +RIGHTS
+Head Paladin		= +EVERYTHING *EVERYTHING
+Elder			= +EVERYTHING *EVERYTHING
+Host 			= +EVERYTHING *EVERYTHING


### PR DESCRIPTION
This addresses the following problems that were brought up with my original PR, discussed for six days, and then fixed, and then subsequently created again in the PR that changed admin ranks afterwards

From what i understand +@ gives the rank roles from the one above it, but if the one above it also has +@ that would additionally mean that it would get the roles from the one above that one.

- There is a acute distinction between people who need and understand debug verbs and people who don't need and don't understand debug verbs. Paladins have no use for them and the use they could possibly get out of them is already accomplished with +SERVER. If you can have the majority of paladins say in coding public what dynex is i'll change this immediately.

- Initiates can ban people, in cases of grief, they also need to be able to revive people. A simple situation that was brought up in the previous PR. You took the only joy they had away by removing +SOUND, so at minimum understand that they can at least seek joy by allowing other to finish their already hampered round.

- The majority of the admin team should be able to create polls, not only scribes and head paladins+. Problems requiring player base input affect all levels of leadership, not just senior leadership, allowing only a select group of the most senior members of the admin team to create player polls is essentially pocket democracy and you should feel ashamed for it.

- We had a LONG and LENGTHY discussion about specifically what verbs both developers and admins should get, i'll concede that +STEALTH isn't necessary for anyone but paladins, and that it isn't really necessary for anyone at all. All the permissions that both the Head Scribe and Scribe had originally, with the exception of +STEALTH, were discussed in painful detail among key members of the administration team and quite literally the entirety of the development team individually, where we argued from each side why we would need those verbs, and the verbs listed were the final product. The majority of the argument essentially boils down to "testing" and "fixing problems that arise during game play" and "making use of existing verbs that admins wouldn't be able to effectively use", like +DEBUG for example.

- Knights need possess and sound for obvious reasons, fundamentally normal admins make up the majority of the administration team and are primarily tasked with running events. Possess also gives the ability to immediately ( 30 seconds quicker ) stop grief / actions that would otherwise damage the server or its population by possessing the person and kicking their ckey out of their character. Additionally sound files are played for event moods, setting a round mood in general, lore related speeches/dialogues, or actions that are happening in the metagame that need to be referenced into the actual game.

- more points to be made, reviewing the previous PR-