### PR TITLE
Anti-Materiel Rifle

### DIFF
--- a/code/modules/jobs/job_types/ncr.dm
+++ b/code/modules/jobs/job_types/ncr.dm
@@ -257,11 +257,11 @@ Veteran Ranger
 	suit = 			/obj/item/clothing/suit/armor/f13/rangercombat
 	head = 			/obj/item/clothing/head/helmet/f13/ncr/rangercombat
 	gloves =		/obj/item/clothing/gloves/fingerless
-	suit_store = 	/obj/item/gun/ballistic/shotgun/remington/scoped
+	suit_store = 	/obj/item/gun/ballistic/shotgun/antimateriel
 	backpack_contents = list(
 		/obj/item/gun/ballistic/revolver/sequoia=1, \
 		/obj/item/ammo_box/magazine/internal/cylinder/rev4570=2, \
-		/obj/item/ammo_box/a762/doublestacked=2, \
+		/obj/item/ammo_box/a50MG=2, \
 		/obj/item/kitchen/knife/combat/survival=1, \
 		/obj/item/reagent_containers/hypospray/medipen/stimpak=1, \
 		/obj/item/storage/bag/money/small/ncrofficers)

--- a/code/modules/jobs/job_types/ncr.dm
+++ b/code/modules/jobs/job_types/ncr.dm
@@ -257,7 +257,7 @@ Veteran Ranger
 	suit = 			/obj/item/clothing/suit/armor/f13/rangercombat
 	head = 			/obj/item/clothing/head/helmet/f13/ncr/rangercombat
 	gloves =		/obj/item/clothing/gloves/fingerless
-	suit_store = 	/obj/item/gun/ballistic/shotgun/antimateriel
+	suit_store = 	/obj/item/gun/ballistic/shotgun/automatic/antimateriel
 	backpack_contents = list(
 		/obj/item/gun/ballistic/revolver/sequoia=1, \
 		/obj/item/ammo_box/magazine/internal/cylinder/rev4570=2, \

--- a/code/modules/projectiles/boxes_magazines/ammo_boxes.dm
+++ b/code/modules/projectiles/boxes_magazines/ammo_boxes.dm
@@ -106,8 +106,8 @@
 	materials = list(MAT_METAL = 10000)
 
 /obj/item/ammo_box/a50MG
-	name = "anti-materiel stripper clip (.50MG)"
-	desc = "A .50 MG stripper clip, for when you really need something dead."
+	name = "anti-materiel ammo rack (.50MG)"
+	desc = "A rack of .50 MG ammo, for when you really need something dead."
 	icon_state = "762"
 	ammo_type = /obj/item/ammo_casing/a50MG
 	max_ammo = 5
@@ -115,8 +115,8 @@
 	materials = list(MAT_METAL = 14000)
 
 /obj/item/ammo_box/a50MG/incendiary
-	name = "anti-materiel incendiary stripper clip (.50MG)"
-	desc = "A .50 MG stripper clip, for when you really need something dead... and also on fire."
+	name = "anti-materiel incendiary ammo rack (.50MG)"
+	desc = "A rack of .50 MG ammo, for when you really need something dead... and also on fire."
 	icon_state = "762"
 	ammo_type = /obj/item/ammo_casing/a50MG/incendiary
 	max_ammo = 5
@@ -124,8 +124,8 @@
 	materials = list(MAT_METAL = 20000)
 
 /obj/item/ammo_box/a50MG/AP
-	name = "anti-materiel stripper clip (.50MG)"
-	desc = "A .50 MG stripper clip, for when you really need (a very big) something dead."
+	name = "anti-materiel ammo rack (.50MG)"
+	desc = "A .rack of .50 MG ammo, for when you really need (a very big) something dead."
 	icon_state = "762"
 	ammo_type = /obj/item/ammo_casing/a50MG/AP
 	max_ammo = 5

--- a/code/modules/projectiles/boxes_magazines/ammo_boxes.dm
+++ b/code/modules/projectiles/boxes_magazines/ammo_boxes.dm
@@ -105,6 +105,33 @@
 	multiple_sprites = 1
 	materials = list(MAT_METAL = 10000)
 
+/obj/item/ammo_box/a50MG
+	name = "anti-materiel stripper clip (.50MG)"
+	desc = "A .50 MG stripper clip, for when you really need something dead."
+	icon_state = "762"
+	ammo_type = /obj/item/ammo_casing/a50MG
+	max_ammo = 5
+	multiple_sprites = 1
+	materials = list(MAT_METAL = 14000)
+
+/obj/item/ammo_box/a50MG/incendiary
+	name = "anti-materiel incendiary stripper clip (.50MG)"
+	desc = "A .50 MG stripper clip, for when you really need something dead... and also on fire."
+	icon_state = "762"
+	ammo_type = /obj/item/ammo_casing/a50MG/incendiary
+	max_ammo = 5
+	multiple_sprites = 1
+	materials = list(MAT_METAL = 20000)
+
+/obj/item/ammo_box/a50MG/AP
+	name = "anti-materiel stripper clip (.50MG)"
+	desc = "A .50 MG stripper clip, for when you really need (a very big) something dead."
+	icon_state = "762"
+	ammo_type = /obj/item/ammo_casing/a50MG/AP
+	max_ammo = 5
+	multiple_sprites = 1
+	materials = list(MAT_METAL = 18000)
+
 /obj/item/ammo_box/n762
 	name = "ammo box (7.62x38mmR)"
 	icon_state = "10mmbox"

--- a/code/modules/projectiles/boxes_magazines/internal/rifle.dm
+++ b/code/modules/projectiles/boxes_magazines/internal/rifle.dm
@@ -26,8 +26,8 @@
 	max_ammo = 5
 	multiload = 1
 
-/obj/item/ammo_box/magazine/internal/boltaction/antimateriel
+/obj/item/ammo_box/magazine/internal/antimateriel
 	ammo_type = /obj/item/ammo_casing/a50MG
 	caliber = "a50MG"
 	max_ammo = 4
-	multiload = 1
+	multiload = 0 //one bullet at a time

--- a/code/modules/projectiles/boxes_magazines/internal/rifle.dm
+++ b/code/modules/projectiles/boxes_magazines/internal/rifle.dm
@@ -25,3 +25,9 @@
 	caliber = "a762"
 	max_ammo = 5
 	multiload = 1
+
+/obj/item/ammo_box/magazine/internal/boltaction/antimateriel
+	ammo_type = /obj/item/ammo_casing/a50MG
+	caliber = "a50MG"
+	max_ammo = 5
+	multiload = 1

--- a/code/modules/projectiles/boxes_magazines/internal/rifle.dm
+++ b/code/modules/projectiles/boxes_magazines/internal/rifle.dm
@@ -29,5 +29,5 @@
 /obj/item/ammo_box/magazine/internal/boltaction/antimateriel
 	ammo_type = /obj/item/ammo_casing/a50MG
 	caliber = "a50MG"
-	max_ammo = 5
+	max_ammo = 4
 	multiload = 1

--- a/code/modules/projectiles/guns/ballistic/automatic.dm
+++ b/code/modules/projectiles/guns/ballistic/automatic.dm
@@ -738,6 +738,25 @@
 	caliber = "2mm"
 	projectile_type = /obj/item/projectile/bullet/c2mm
 
+/obj/item/ammo_casing/a50MG
+	name = ".50MG bullet casing"
+	desc = "A .50MG bullet casing."
+	caliber = "a50MG"
+	icon_state = ".50"
+	projectile_type = /obj/item/projectile/bullet/a50MG
+
+/obj/item/ammo_casing/a50MG/incendiary
+	name = ".50 MG incendiary bullet casing"
+	desc = "A .50 MG incendiary bullet casing."
+	caliber = "a50MG"
+	projectile_type = /obj/item/projectile/bullet/a50MG/incendiary
+
+/obj/item/ammo_casing/a50MG/AP
+	name = ".50 MG AP bullet casing"
+	desc = "A .50 MG armor-piercing bullet casing."
+	caliber = "a50MG"
+	projectile_type = /obj/item/projectile/bullet/a50MG/AP
+
 //Projectiles
 /obj/item/projectile/bullet/c45
 	damage = 30
@@ -796,6 +815,26 @@
 /obj/item/projectile/bullet/a50AE
 	damage = 50
 	armour_penetration = 0
+
+/obj/item/projectile/bullet/a50MG
+	damage = 50
+	armour_penetration = 20
+
+/obj/item/projectile/bullet/a50MG/incendiary
+	damage = 30
+	armour_penetration = 0
+	var/fire_stacks = 4
+
+/obj/item/projectile/bullet/a50MG/incendiary/on_hit(atom/target, blocked = FALSE)
+	. = ..()
+	if(iscarbon(target))
+		var/mob/living/carbon/M = target
+		M.adjust_fire_stacks(fire_stacks)
+		M.IgniteMob()
+
+/obj/item/projectile/bullet/a50MG/AP
+	damage = 35
+	armour_penetration = 65 //will punch through anything short of Enclave power armor
 
 /obj/item/projectile/bullet/c2mm
 	damage = 60

--- a/code/modules/projectiles/guns/ballistic/shotgun.dm
+++ b/code/modules/projectiles/guns/ballistic/shotgun.dm
@@ -306,6 +306,7 @@
 	w_class = WEIGHT_CLASS_BULKY
 	weapon_weight = WEAPON_HEAVY
 	recoil = 1 //have fun
+	fire_delay = 4 //but not too much fun
 
 //Colt Rangemaster
 /obj/item/gun/ballistic/shotgun/automatic/hunting

--- a/code/modules/projectiles/guns/ballistic/shotgun.dm
+++ b/code/modules/projectiles/guns/ballistic/shotgun.dm
@@ -292,6 +292,21 @@
 	zoom_amt = 10
 	zoom_out_amt = 13
 
+//Anti-Materiel Rifle (NCR)
+/obj/item/gun/ballistic/shotgun/antimateriel
+	name = "anti-materiel rifle"
+	desc = "A heavy, high-powered sniper rifle chambered in .50 caliber ammunition, custom-made for use by the New California Republic Rangers. Although relatively austere, you're still pretty sure it could take the head off a deathclaw."
+	icon_state = "sniper"
+	item_state = "sniper"
+	mag_type = /obj/item/ammo_box/magazine/internal/boltaction/antimateriel
+	fire_sound = 'sound/f13weapons/hunting_rifle.ogg'
+	zoomable = TRUE
+	zoom_amt = 10
+	zoom_out_amt = 13
+	w_class = WEIGHT_CLASS_BULKY
+	weapon_weight = WEAPON_HEAVY
+	recoil = 1 //have fun
+
 //Colt Rangemaster
 /obj/item/gun/ballistic/shotgun/automatic/hunting
 	name = "Colt Rangemaster"

--- a/code/modules/projectiles/guns/ballistic/shotgun.dm
+++ b/code/modules/projectiles/guns/ballistic/shotgun.dm
@@ -11,6 +11,7 @@
 	casing_ejector = FALSE
 	var/recentpump = 0 // to prevent spammage
 	weapon_weight = WEAPON_HEAVY
+	var/pump_sound = 'sound/weapons/shotgunpump.ogg'
 
 /obj/item/gun/ballistic/shotgun/attackby(obj/item/A, mob/user, params)
 	. = ..()
@@ -48,7 +49,7 @@
 		. = 1
 
 /obj/item/gun/ballistic/shotgun/proc/pump(mob/M)
-	playsound(M, 'sound/weapons/shotgunpump.ogg', 60, 1)
+	playsound(M, pump_sound, 60, 1)
 	pump_unload(M)
 	pump_reload(M)
 	update_icon()	//I.E. fix the desc
@@ -293,20 +294,22 @@
 	zoom_out_amt = 13
 
 //Anti-Materiel Rifle (NCR)
-/obj/item/gun/ballistic/shotgun/antimateriel
+/obj/item/gun/ballistic/shotgun/automatic/antimateriel
 	name = "anti-materiel rifle"
 	desc = "A heavy, high-powered sniper rifle chambered in .50 caliber ammunition, custom-made for use by the New California Republic Rangers. Although relatively austere, you're still pretty sure it could take the head off a deathclaw."
 	icon_state = "sniper"
 	item_state = "sniper"
-	mag_type = /obj/item/ammo_box/magazine/internal/boltaction/antimateriel
-	fire_sound = 'sound/f13weapons/hunting_rifle.ogg'
+	mag_type = /obj/item/ammo_box/magazine/internal/antimateriel
+	fire_sound = 'sound/f13weapons/antimaterielfire.ogg'
+	pump_sound = 'sound/weapons/antimaterielreload.ogg'
 	zoomable = TRUE
 	zoom_amt = 10
 	zoom_out_amt = 13
+	force = 35
 	w_class = WEIGHT_CLASS_BULKY
 	weapon_weight = WEAPON_HEAVY
 	recoil = 1 //have fun
-	fire_delay = 4 //but not too much fun
+	fire_delay = 10 //but not too much fun
 
 //Colt Rangemaster
 /obj/item/gun/ballistic/shotgun/automatic/hunting

--- a/code/modules/projectiles/guns/ballistic/shotgun.dm
+++ b/code/modules/projectiles/guns/ballistic/shotgun.dm
@@ -301,7 +301,7 @@
 	item_state = "sniper"
 	mag_type = /obj/item/ammo_box/magazine/internal/antimateriel
 	fire_sound = 'sound/f13weapons/antimaterielfire.ogg'
-	pump_sound = 'sound/weapons/antimaterielreload.ogg'
+	pump_sound = 'sound/f13weapons/antimaterielreload.ogg'
 	zoomable = TRUE
 	zoom_amt = 10
 	zoom_out_amt = 13

--- a/code/modules/research/designs/autolathe_designs.dm
+++ b/code/modules/research/designs/autolathe_designs.dm
@@ -806,7 +806,7 @@
 	category = list("initial", "Security")
 
 /datum/design/a50MG
-	name = "Anti-Materiel Stripper Clip (.50MG)"
+	name = "Anti-Materiel Ammo Rack (.50MG)"
 	id = "a50MG"
 	build_type = AUTOLATHE
 	materials = list(MAT_METAL = 14000)
@@ -814,7 +814,7 @@
 	category = list("initial", "Security")
 
 /datum/design/a50MGincendiary
-	name = "Anti-Materiel Incendiary Stripper Clip (.50MG)"
+	name = "Anti-Materiel Incendiary Ammo Rack (.50MG)"
 	id = "a50MGincendiary"
 	build_type = AUTOLATHE
 	materials = list(MAT_METAL = 20000)
@@ -822,7 +822,7 @@
 	category = list("initial", "Security")
 
 /datum/design/a50MGAP
-	name = "Anti-Materiel Armor-Piercing Stripper Clip (.50MG)"
+	name = "Anti-Materiel Armor-Piercing Ammo Rack (.50MG)"
 	id = "a50MGAP"
 	build_type = AUTOLATHE
 	materials = list(MAT_METAL = 16000)

--- a/code/modules/research/designs/autolathe_designs.dm
+++ b/code/modules/research/designs/autolathe_designs.dm
@@ -805,6 +805,30 @@
 	build_path = /obj/item/ammo_box/a762/doublestacked
 	category = list("initial", "Security")
 
+/datum/design/a50MG
+	name = "Anti-Materiel Stripper Clip (.50MG)"
+	id = "a50MG"
+	build_type = AUTOLATHE
+	materials = list(MAT_METAL = 14000)
+	build_path = /obj/item/ammo_box/a50MG
+	category = list("initial", "Security")
+
+/datum/design/a50MGincendiary
+	name = "Anti-Materiel Incendiary Stripper Clip (.50MG)"
+	id = "a50MGincendiary"
+	build_type = AUTOLATHE
+	materials = list(MAT_METAL = 20000)
+	build_path = /obj/item/ammo_box/a50MG/incendiary
+	category = list("initial", "Security")
+
+/datum/design/a50MGAP
+	name = "Anti-Materiel Armor-Piercing Stripper Clip (.50MG)"
+	id = "a50MGAP"
+	build_type = AUTOLATHE
+	materials = list(MAT_METAL = 16000)
+	build_path = /obj/item/ammo_box/a50MG/AP
+	category = list("initial", "Security")
+
 /datum/design/cleaver
 	name = "Butcher's Cleaver"
 	id = "cleaver"


### PR DESCRIPTION
**This is not the syndicate anti-materiel rifle. That one's hilariously OP. I'm not touching it.**

## Description
Adds the .50 MG anti-materiel rifle from Fallout: New Vegas, chambered in a new .50 MG round (not to be confused with .50 AE, used for deagles). NCR Veteran Rangers spawn with this gun, and ammo is available in autolathes.

4+1 shots, and recoil and a substantial fire delay. Shots must be loaded one bullet at a time.

.308 ammo (scoped Remington, Rangemaster, etc): 40 damage, 20 AP. 7,000 metal cost.
.50 MG ammo: 50 damage, 20 AP. 14,000 metal cost.
.50 MG/Incendiary: 30 damage, 0 AP, buuuut it sets them on fire, so... 20,000 metal cost.
.50 MG/AP: 35 damage, 65 AP. Will punch through any armor like wet tissue paper. 18,000 metal cost.

So what does this mean for typical conflicts? Short version, it means it's more effective than the .308's at taking down lightly-armored targets with standard rounds (Recruit Legionaries, Raiders) or extremely heavily-armored targets with AP rounds (BOS power armor).

It does kick like a mule, though, so if you're hoping to snap off rapid shots like with the Remington, you better have good aim.

Compared to a scoped Remington:
+ More damage! You can now two-shot Recruit Legionaries.
- Slower rate of fire, which means your TTK is slower, but who cares? You've got...
+ Incendiary bullets! Which set fire to whoever they hit.
- They don't do much damage, though, especially against armored targets...
+ ... which is fine, because you have AP ammo for cracking the big nuts.
- Or you would, if you could get some, because all this costs a fortune in metal from the lathe.
+ But hey, it's worth it, 'cause you get the prestige of having a cool gun.
- And the lower ammo count, and the recoil..

## Motivation and Context
You know how Veteran Rangers spawn with a scoped Remington, an alarmingly common gun that really doesn't match their prestige at all? Well, now they get something cool. It's a little stronger, a lot rarer, and it's shiny as hell. Ammo is hard to come by and expensive, but you can scope in and drop some deathclaws like nobody's business. Oh, and you look dope as hell doing it.

The Vet Ranger's gun is currently *less cool* than the Patrol Ranger's gun. This fixes that. It's the Sequoia of rifles- the Veteran Ranger can now go toe-to-toe against the BOS Paladin and stand a chance. (You know how much damage a Sequoia does to T-51b power armor? **10.8**. Go get some AP rounds if you're taking on the Brotherhood.)

## How Has This Been Tested?
Fully tested, including autolathe spawning and different ammunition types.

[Balance, 24h hold] [Feature, 24h hold]

## Changelog
 :cl: Light-Weave
add: Adds the anti-materiel rifle, along with regular, AP and incendiary ammo for it.
add: NCR Veteran Rangers spawn with the AMR, and more ammo can be made in autolathes.
/:cl:
