### PR TITLE
Changes to Stimpaks and Healing Powder

### DIFF
--- a/code/game/machinery/deployable.dm
+++ b/code/game/machinery/deployable.dm
@@ -52,9 +52,9 @@
 	else if(istype(mover, /obj/item/projectile))
 		if(!anchored)
 			return 1
-		//var/obj/item/projectile/proj = mover
-		//if(proj.firer && Adjacent(proj.firer))
-			//return 1
+		var/obj/item/projectile/proj = mover
+		if(proj.firer && Adjacent(proj.firer))
+			return 1
 		if(prob(proj_pass_rate))
 			return 1
 		/* /obj/item/restraints/legcuffs/bola/energy/throw_impact(atom/hit_atom)

--- a/code/modules/reagents/chemistry/reagents/medicine_reagents.dm
+++ b/code/modules/reagents/chemistry/reagents/medicine_reagents.dm
@@ -1304,7 +1304,7 @@
 	reagent_state = LIQUID
 	color = "#C8A5DC"
 	taste_description = "grossness"
-	metabolization_rate = REAGENTS_METABOLISM
+	metabolization_rate = 0.75 * REAGENTS_METABOLISM
 	overdose_threshold = 18
 
 /datum/reagent/medicine/stimpak_b/reaction_mob(mob/living/M, method=TOUCH, reac_volume, show_message = 1)

--- a/code/modules/reagents/chemistry/reagents/medicine_reagents.dm
+++ b/code/modules/reagents/chemistry/reagents/medicine_reagents.dm
@@ -1261,17 +1261,17 @@
 	..()
 	return TRUE
 
-/datum/reagent/medicine/stimpak
+/datum/reagent/medicine/stimpak_a
 	name = "Stimpak Fluid"
-	id = "stimpak"
-	description = "Rapidly heals damage when injected. Deals minor toxin damage if injested."
+	id = "stimpak_a"
+	description = "Rapidly heals damage when injected. Deals minor toxin damage if ingested."
 	reagent_state = LIQUID
 	color = "#C8A5DC"
 	taste_description = "grossness"
-	metabolization_rate = 3 * REAGENTS_METABOLISM
+	metabolization_rate = 5 * REAGENTS_METABOLISM
 	overdose_threshold = 20
 
-/datum/reagent/medicine/stimpak/reaction_mob(mob/living/M, method=TOUCH, reac_volume, show_message = 1)
+/datum/reagent/medicine/stimpak_a/reaction_mob(mob/living/M, method=TOUCH, reac_volume, show_message = 1)
 	if(iscarbon(M) && M.stat != DEAD)
 		if(method in list(INGEST, VAPOR))
 			M.adjustToxLoss(0.5*reac_volume)
@@ -1279,16 +1279,52 @@
 				to_chat(M, "<span class='warning'>You don't feel so good...</span>")
 	..()
 
-/datum/reagent/medicine/stimpak/on_mob_life(mob/living/carbon/M)
-	M.adjustBruteLoss(-4*REM, 0)
-	M.adjustFireLoss(-4*REM, 0)
-	M.adjustOxyLoss(-3*REM, 0)
+/datum/reagent/medicine/stimpak_a/on_mob_life(mob/living/carbon/M)
+	M.adjustBruteLoss(-6*REM, 0)
+	M.adjustFireLoss(-6*REM, 0)
+	M.adjustOxyLoss(-6*REM, 0)
+	M.adjustToxLoss(-0.5*REM, 0)
+	M.AdjustStun(-10, 0)
+	M.AdjustKnockdown(-10, 0)
+	M.AdjustUnconscious(-10, 0)
+	M.adjustStaminaLoss(-4*REM, 0)
 	. = 1
 	..()
 
-/datum/reagent/medicine/stimpak/overdose_process(mob/living/M)
+/datum/reagent/medicine/stimpak_a/overdose_process(mob/living/M)
+	M.adjustToxLoss(5*REM, 0)
+	M.adjustOxyLoss(8*REM, 0)
+	..()
+	. = 1
+
+/datum/reagent/medicine/stimpak_b
+	name = "Stimpak Fluid"
+	id = "stimpak_b"
+	description = "The slowly healing secondary fluid in a stimpak. Deals minor toxin damage if ingested."
+	reagent_state = LIQUID
+	color = "#C8A5DC"
+	taste_description = "grossness"
+	metabolization_rate = REAGENTS_METABOLISM
+	overdose_threshold = 18
+
+/datum/reagent/medicine/stimpak_b/reaction_mob(mob/living/M, method=TOUCH, reac_volume, show_message = 1)
+	if(iscarbon(M) && M.stat != DEAD)
+		if(method in list(INGEST, VAPOR))
+			M.adjustToxLoss(0.5*reac_volume)
+			if(show_message)
+				to_chat(M, "<span class='warning'>You don't feel so good...</span>")
+	..()
+
+/datum/reagent/medicine/stimpak_b/on_mob_life(mob/living/carbon/M)
+	M.adjustBruteLoss(-0.7*REM, 0)
+	M.adjustFireLoss(-0.7*REM, 0)
+	M.adjustOxyLoss(-0.7*REM, 0)
+	. = 1
+	..()
+
+/datum/reagent/medicine/stimpak_b/overdose_process(mob/living/M)
 	M.adjustToxLoss(2.5*REM, 0)
-	M.adjustOxyLoss(7*REM, 0)
+	M.adjustOxyLoss(6*REM, 0)
 	..()
 	. = 1
 
@@ -1299,7 +1335,7 @@
 	reagent_state = SOLID
 	color = "#A9FBFB"
 	taste_description = "bitterness"
-	metabolization_rate = 0.25 * REAGENTS_METABOLISM
+	metabolization_rate = 0.4 * REAGENTS_METABOLISM
 	overdose_threshold = 30
 
 /datum/reagent/medicine/healing_powder/on_mob_life(mob/living/carbon/M)

--- a/code/modules/reagents/chemistry/recipes/medicine.dm
+++ b/code/modules/reagents/chemistry/recipes/medicine.dm
@@ -256,6 +256,6 @@
 /datum/chemical_reaction/stimpak
 	name = "Stimpak Fluid"
 	id = "stimpak"
-	results = list("stimpak" = 2)
+	results = list("stimpak_b" = 2)
 	required_reagents = list("blood" = 2, "spaceacillin" = 3)
 	required_temp = 300

--- a/code/modules/reagents/reagent_containers/hypospray.dm
+++ b/code/modules/reagents/reagent_containers/hypospray.dm
@@ -179,10 +179,10 @@
 	name = "stimpak"
 	desc = "A handheld delivery system for medicine, used to rapidly heal physical damage to the body."
 	icon_state = "stimpakpen"
-	volume = 10
-	amount_per_transfer_from_this = 10
-	list_reagents = list("stimpak" = 10)
-	
+	volume = 20
+	amount_per_transfer_from_this = 20
+	list_reagents = list("stimpak_a" = 10, "stimpak_b" = 10)
+
 /*
 /obj/item/reagent_containers/hypospray/medipen/psycho
 	name = "Psycho"


### PR DESCRIPTION
<!-- Thanks for choosing to take the time to contribute to our project! We have a few things below that we'd like you to fill out -->
<!-- The more detail you can give us, the faster we can code review, test, and merge your changes -->

<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
Buffs stimpacks, nerfs healing powder, differentiates the two to create distinct classes of healing compared to the current state of "stimpaks bad, healing powder good"

Before:
Stimpaks healed 40 burn/brute/oxy over 10 game ticks
Healing Powder healed 300 burn/brute over 100 game ticks

After:
Stimpaks initially heal 33.5 burn/brute/oxy (and 2.5 tox) over 5 game ticks, and reduce stuns during those 5 game ticks 
Stimpaks then heal about an additional 20 burn/brute/oxy over 28 game ticks (for a total of 53.5 brute/burn/oxy)
Healing Powder heals 186 burn/brute over about 62 game ticks (Heal at the same speed, around 2/3 total healing/duration so they don't last forever anymore)

Results:
Stimpaks heal very fast up front and then a little extra afterwards, and reduce stuns for a few seconds
Healing powder doesn't last a ridiculous amount of time anymore but is still good

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Healing powder is far, far better than stimpaks at the moment and is not very different. This change makes stimpaks (the harder to make healing source) more viable and differentiates the two in an interesting way.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- This helps us replicate your tests, to speed up review. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->
Tested on a private server, everything worked fine.
## Screenshots (if appropriate):

## Changelog (neccesary)

🆑 ChronicPwnage
balance: Stimpaks now heal you a fair amount very quickly, then a little bit afterwards 
balance: Healing Powder total duration reduced by about 1/3
 /🆑
