### PR TITLE
.45-70 cost increase (ammo bench)

### DIFF
--- a/code/modules/crafting/recipes.dm
+++ b/code/modules/crafting/recipes.dm
@@ -300,7 +300,7 @@
 /datum/crafting_recipe/c4570
 	name = ".45-70 speed loader (NCR)"
 	result = /obj/item/ammo_box/c4570
-	reqs = list(/obj/item/stack/sheet/metal = 6)
+	reqs = list(/obj/item/stack/sheet/metal = 10)
 	tools = list(TOOL_SCREWDRIVER,
 				TOOL_NCR)
 	time = 10

--- a/code/modules/crafting/recipes.dm
+++ b/code/modules/crafting/recipes.dm
@@ -300,7 +300,7 @@
 /datum/crafting_recipe/c4570
 	name = ".45-70 speed loader (NCR)"
 	result = /obj/item/ammo_box/c4570
-	reqs = list(/obj/item/stack/sheet/metal = 10)
+	reqs = list(/obj/item/stack/sheet/metal = 20)
 	tools = list(TOOL_SCREWDRIVER,
 				TOOL_NCR)
 	time = 10


### PR DESCRIPTION
## Description
Increases the cost of .45-70 speedloaders by a further 233%, from 6 metal sheets to 20.
Alternative to #759, which breaks shit and won't compile.

## Motivation and Context
Before the ammobench PR, the Ranger Sequoia was almost worthless, because of the ammunition's terrible AP (-20, meaning that anyone with armor gets 20% more armor) and extreme scarcity (with no way to reproduce more). This means that they were only viable against completely unarmored targets (i.e. civilians and noncombatants) and strong, dangerous hostile mobs (i.e. deathclaws). And since Veteran Rangers aren't supposed to be gunning down unarmored civvies, it was really only useful for deathclaws compared to a scoped S&W, a 9mm/10mm SMG, or some other powerful backup weapon.

After the ammobench PR, the .45-70 speedloaders were too cheap and easy to produce, requiring six metal sheets (one per bullet). So we're increasing the cost to **20** metal sheets - 3.33 sheets per bullet. You can now make more ammo, but it's going to cost you, and since you only get six shots per craft? Still have to make 'em count.

## How Has This Been Tested?
It's a one-number change, but I tested it anyway.

## Screenshots (if appropriate):

## Changelog (neccesary)
:cl:
fix: .45-70 recipe is now 20 sheets at the ammobench. Make it count.
/:cl:
