### PR TITLE
Prime armors for Ghost

### DIFF
--- a/code/modules/clothing/head/helmet.dm
+++ b/code/modules/clothing/head/helmet.dm
@@ -365,6 +365,11 @@
 	dynamic_hair_suffix = ""
 	dynamic_fhair_suffix = ""
 
+/obj/item/clothing/head/helmet/f13/legion/legrecruit/legprime
+	name = "legion prime helmet"
+	item_state = "legprime"
+	armor = list("melee" = 25, "bullet" = 25, "laser" = 16, "energy" = 16, "bomb" = 25, "bio" = 0, "rad" = 0, "fire" = 0, "acid" = 0)
+
 /obj/item/clothing/head/helmet/f13/legion/scout
 	name = "legion scout hood"
 	desc = "It's a leather hood worn by legion scouts."
@@ -384,7 +389,7 @@
 	desc = "It's a metal legion veteran helmet, looks pretty sturdy."
 	icon_state = "legvet"
 	item_state = "legvet"
-	armor = list("melee" = 25, "bullet" = 25, "laser" = 16, "energy" = 16, "bomb" = 25, "bio" = 0, "rad" = 0, "fire" = 0, "acid" = 0)
+	armor = list("melee" = 35, "bullet" = 30, "laser" = 20, "energy" = 20, "bomb" = 25, "bio" = 0, "rad" = 0, "fire" = 0, "acid" = 0)
 	flags_inv = HIDEEARS|HIDEHAIR
 	strip_delay = 50
 	resistance_flags = LAVA_PROOF | FIRE_PROOF
@@ -407,19 +412,24 @@
 	desc = "It's leather legion decan helmet."
 	icon_state = "legdecan"
 	item_state = "legdecan"
-	armor = list("melee" = 25, "bullet" = 25, "laser" = 16, "energy" = 16, "bomb" = 25, "bio" = 0, "rad" = 0, "fire" = 0, "acid" = 0)
+	armor = list("melee" = 10, "bullet" = 16, "laser" = 0, "energy" = 0, "bomb" = 16, "bio" = 0, "rad" = 0, "fire" = 0, "acid" = 0)
 	flags_inv = HIDEEARS|HIDEHAIR
 	strip_delay = 50
 	resistance_flags = LAVA_PROOF | FIRE_PROOF
 	dynamic_hair_suffix = ""
 	dynamic_fhair_suffix = ""
 
+/obj/item/clothing/head/helmet/f13/legion/legdecan/vet/prime
+	name = "legion prime decanus helmet"
+	item_state = "legdecanprime"
+	armor = list("melee" = 25, "bullet" = 25, "laser" = 16, "energy" = 16, "bomb" = 25, "bio" = 0, "rad" = 0, "fire" = 0, "acid" = 0)
+
 /obj/item/clothing/head/helmet/f13/legion/legdecan/vet
 	name = "legion veteran decanus helmet"
 	desc = "It's leather legion veteran decan helmet."
 	icon_state = "legdecanvet"
 	item_state = "legdecanvet"
-	armor = list("melee" = 30, "bullet" = 30, "laser" = 20, "energy" = 20, "bomb" = 30, "bio" = 0, "rad" = 0, "fire" = 0, "acid" = 0)
+	armor = list("melee" = 35, "bullet" = 30, "laser" = 20, "energy" = 20, "bomb" = 25, "bio" = 0, "rad" = 0, "fire" = 0, "acid" = 0)
 	flags_inv = HIDEEARS|HIDEHAIR
 	strip_delay = 50
 	resistance_flags = LAVA_PROOF | FIRE_PROOF

--- a/code/modules/clothing/suits/armor.dm
+++ b/code/modules/clothing/suits/armor.dm
@@ -458,10 +458,15 @@
 	armor = list("melee" = 10, "bullet" = 16, "laser" = 0, "energy" = 0, "bomb" = 16, "bio" = 0, "rad" = 0, "fire" = 0, "acid" = 0)
 	strip_delay = 60
 
+/obj/item/clothing/suit/armor/f13/legrecruit/prime
+	name= "legion prime armor"
+	item_state = "legprime"
+	armor = list("melee" = 25, "bullet" = 25, "laser" = 16, "energy" = 16, "bomb" = 25, "bio" = 0, "rad" = 0, "fire" = 0, "acid" = 0)
+
 /obj/item/clothing/suit/armor/f13/legrecruit/vet
 	name = "legion veteran armor"
 	item_state = "legveteran"
-	armor = list("melee" = 25, "bullet" = 25, "laser" = 16, "energy" = 16, "bomb" = 25, "bio" = 0, "rad" = 0, "fire" = 0, "acid" = 0)
+	armor = list("melee" = 35, "bullet" = 30, "laser" = 20, "energy" = 20, "bomb" = 25, "bio" = 0, "rad" = 0, "fire" = 0, "acid" = 0)
 
 /obj/item/clothing/suit/armor/f13/legvexil
 	name = "legion vexillarius armor"


### PR DESCRIPTION
Prime Armor code for Ghost to use when it comes the armor rework

## Description
Literally just the code for Prime Armors and Helmets, along with their Decanus variants. For now this is not actually functional due to the lack of actual Primes and the armor not being used for anyone else. Purely just to help Ghost get the armor rework done in one go. 

## Motivation and Context
This change was motivated by Ghost telling me to post my armors so that they can be adjusted in one sweep by the armor rework they'll be doing. This is also in preparation for the arrival of Prime Legionaries and a Prime Decanus soon. 

## How Has This Been Tested?
Primes spawn with this as intended and the code itself has worked fine throughout my testing. 

## Screenshots (if appropriate):

## Changelog (neccesary)
:cl:
add: Legion Prime Armor and Helmets, for the Decanus variant as well.
tweak: Some armor values are adjusted compared to live numbers but this was due to my early stages of the rework and my intent to buff Veteran armors and nerf some others, Ghost will fix the values as needed to bring them up to speed with the armor rework. 
/:cl:
