### PR TITLE
fixes /job/ncr/f13vetranger

### DIFF
--- a/code/modules/jobs/job_types/ncr.dm
+++ b/code/modules/jobs/job_types/ncr.dm
@@ -260,7 +260,7 @@ Veteran Ranger
 	suit_store = 	/obj/item/gun/ballistic/shotgun/automatic/antimateriel
 	backpack_contents = list(
 		/obj/item/gun/ballistic/revolver/sequoia=1, \
-		/obj/item/ammo_box/magazine/internal/cylinder/rev4570=2, \
+		/obj/item/ammo_box/c4570=2, \
 		/obj/item/ammo_box/a50MG=2, \
 		/obj/item/kitchen/knife/combat/survival=1, \
 		/obj/item/reagent_containers/hypospray/medipen/stimpak=1, \


### PR DESCRIPTION
It's supposed to spawn with two speedloaders of .45-70 but doesn't due
to dipshits and syntax errors

🆑
fix: fixes the loadout for veteran rangers
/🆑