### PR TITLE
.45 Long Colt

### DIFF
--- a/code/modules/crafting/recipes.dm
+++ b/code/modules/crafting/recipes.dm
@@ -298,7 +298,7 @@
 	subcategory = CAT_AMMO
 
 /datum/crafting_recipe/c4570SP
-	name = ".45-70 special speed loader (NCR)"
+	name = ".45 LC speed loader (NCR)"
 	result = /obj/item/ammo_box/c4570SP
 	reqs = list(/obj/item/stack/sheet/metal = 8)
 	tools = list(TOOL_SCREWDRIVER,

--- a/code/modules/crafting/recipes.dm
+++ b/code/modules/crafting/recipes.dm
@@ -297,10 +297,10 @@
 	category = CAT_WEAPONRY
 	subcategory = CAT_AMMO
 
-/datum/crafting_recipe/c4570
-	name = ".45-70 speed loader (NCR)"
-	result = /obj/item/ammo_box/c4570
-	reqs = list(/obj/item/stack/sheet/metal = 20)
+/datum/crafting_recipe/c4570SP
+	name = ".45-70 special speed loader (NCR)"
+	result = /obj/item/ammo_box/c4570SP
+	reqs = list(/obj/item/stack/sheet/metal = 8)
 	tools = list(TOOL_SCREWDRIVER,
 				TOOL_NCR)
 	time = 10

--- a/code/modules/crafting/recipes.dm
+++ b/code/modules/crafting/recipes.dm
@@ -300,7 +300,7 @@
 /datum/crafting_recipe/c4570
 	name = ".45-70 speed loader (NCR)"
 	result = /obj/item/ammo_box/c4570
-	reqs = list(/obj/item/stack/sheet/metal = 6)
+	reqs = list(/obj/item/stack/sheet/metal = 10)
 	tools = list(TOOL_SCREWDRIVER,
 				TOOL_NCR)
 	time = 10

--- a/code/modules/crafting/recipes.dm
+++ b/code/modules/crafting/recipes.dm
@@ -300,7 +300,7 @@
 /datum/crafting_recipe/c4570
 	name = ".45-70 speed loader (NCR)"
 	result = /obj/item/ammo_box/c4570
-	reqs = list(/obj/item/stack/sheet/metal = 10)
+	reqs = list(/obj/item/stack/sheet/metal = 20)
 	tools = list(TOOL_SCREWDRIVER,
 				TOOL_NCR)
 	time = 10

--- a/code/modules/projectiles/boxes_magazines/ammo_boxes.dm
+++ b/code/modules/projectiles/boxes_magazines/ammo_boxes.dm
@@ -34,6 +34,16 @@
 	multiple_sprites = 1
 	materials = list(MAT_METAL = 8000)
 
+
+/obj/item/ammo_box/c4570SP
+	name = "speed loader (.45-70 special)"
+	desc = "Designed to quickly reload revolvers."
+	icon_state = "4570"
+	ammo_type = /obj/item/ammo_casing/c4570SP
+	max_ammo = 6
+	multiple_sprites = 1
+	materials = list(MAT_METAL = 4000)
+
 /obj/item/ammo_box/c9mm
 	name = "ammo box (9mm)"
 	icon_state = "9mmbox"

--- a/code/modules/projectiles/boxes_magazines/ammo_boxes.dm
+++ b/code/modules/projectiles/boxes_magazines/ammo_boxes.dm
@@ -36,7 +36,7 @@
 
 
 /obj/item/ammo_box/c4570SP
-	name = "speed loader (.45-70 special)"
+	name = "speed loader (.45 LC)"
 	desc = "Designed to quickly reload revolvers."
 	icon_state = "4570"
 	ammo_type = /obj/item/ammo_casing/c4570SP

--- a/code/modules/projectiles/guns/ballistic/automatic.dm
+++ b/code/modules/projectiles/guns/ballistic/automatic.dm
@@ -725,6 +725,10 @@
 	caliber = "4570"
 	projectile_type = /obj/item/projectile/bullet/c4570
 
+/obj/item/ammo_casing/c4570SP
+	caliber = "4570"
+	projectile_type = /obj/item/projectile/bullet/c4570SP
+
 //Heavy
 /obj/item/ammo_casing/a50AE
 	name = ".50AE bullet casing"
@@ -807,6 +811,10 @@
 /obj/item/projectile/bullet/c4570
 	damage = 60
 	armour_penetration = -20
+
+/obj/item/projectile/bullet/c4570SP
+	damage = 45
+	armour_penetration = 20
 
 /obj/item/projectile/bullet/a357
 	damage = 35

--- a/code/modules/projectiles/guns/ballistic/automatic.dm
+++ b/code/modules/projectiles/guns/ballistic/automatic.dm
@@ -722,10 +722,14 @@
 
 //HeavySP
 /obj/item/ammo_casing/c4570
+	name = ".45-70 bullet casing"
+	desc = "A .45-70 bullet casing."
 	caliber = "4570"
 	projectile_type = /obj/item/projectile/bullet/c4570
 
 /obj/item/ammo_casing/c4570SP
+	name = ".45 LC bullet casing"
+	desc = "A .45 Long Colt bullet casing."
 	caliber = "4570"
 	projectile_type = /obj/item/projectile/bullet/c4570SP
 


### PR DESCRIPTION
## Description
Adds the .45 Long Colt round to the ammo bench crafting lists as an alternative to .45-70 Govt. Requires 8 sheets of metal per speedloader, and is less powerful than standard .45-70 rounds (but penetrates armor better), having a damage and AP comparable to .308 rounds. Note that the .45 LC cannot currently be loaded into standard .45 ACP pistols (e.g. M1911).

.45 LC: 45 damage, 20 AP
.45-70: 60 damage, -20 AP
.308: 40 damage, 20 AP

## Motivation and Context
Alternative to giving VRs the ability to make their own .45-70, which can two-shot someone by aiming at the arm or leg (or other unarmored place). .45 LC can never twoshot someone on full health regardless of circumstance.

## How Has This Been Tested?
All tested.

## Screenshots (if appropriate):

## Changelog (neccesary)
:cl:
add: Adds .45-70 Special rounds for the Ranger Sequoia and BFR, doing 45 damage with 20 AP. Produceable at an ammo bench.
/:cl:
