### PR TITLE
Chem Whiz

### DIFF
--- a/code/__DEFINES/traits.dm
+++ b/code/__DEFINES/traits.dm
@@ -67,6 +67,7 @@
 #define TRAIT_BIG_LEAGUES		"big_leagues"
 #define TRAIT_IRONFIST			"iron_fist"
 #define	TRAIT_LIFEGIVER			"lifegiver"
+#define	TRAIT_CHEMWHIZ			"chemwhiz"
 
 // common trait sources
 #define TRAIT_GENERIC "generic"

--- a/code/datums/mind.dm
+++ b/code/datums/mind.dm
@@ -57,6 +57,7 @@
 	var/hasSoul = TRUE // If false, renders the character unable to sell their soul.
 	var/isholy = FALSE //is this person a chaplain or admin role allowed to use bibles
 	var/istechnophreak = FALSE // Sets the mind to knowing how to use super advanced technology and the like.
+	var/ischemwhiz = FALSE //The above, but specifically for chemistry machinery
 	var/mob/living/enslaved_to //If this mind's master is another mob (i.e. adamantine golems)
 	var/datum/language_holder/language_holder
 	var/unconvertable = FALSE

--- a/code/datums/traits/good.dm
+++ b/code/datums/traits/good.dm
@@ -34,6 +34,18 @@
 	gain_text = "<span class='notice'>You feel like swinging for the fences!</span>"
 	lose_text = "<span class='danger'>You feel like bunting.</span>"
 
+/datum/quirk/chemwhiz
+	name = "Chem Whiz"
+	desc = "You've been playing around with chemicals all your life. You know how to use chemistry machinery."
+	value = 2
+	mob_trait = TRAIT_CHEMWHIZ
+	gain_text = "<span class='notice'>The mysteries of chemistry are revealed to you.</span>"
+	lose_text = "<span class='danger'>You forget how the periodic table works.</span>"
+
+/datum/quirk/chemwhiz/on_spawn()
+	var/mob/living/carbon/human/mob_tar = quirk_holder
+	mob_tar.mind.ischemwhiz = TRUE
+
 /datum/quirk/drunkhealing
 	name = "Drunken Resilience"
 	desc = "Nothing like a good drink to make you feel on top of the world. Whenever you're drunk, you slowly recover from injuries."

--- a/code/datums/traits/good.dm
+++ b/code/datums/traits/good.dm
@@ -33,7 +33,7 @@
 	mob_trait = TRAIT_BIG_LEAGUES
 	gain_text = "<span class='notice'>You feel like swinging for the fences!</span>"
 	lose_text = "<span class='danger'>You feel like bunting.</span>"
-
+/*
 /datum/quirk/chemwhiz
 	name = "Chem Whiz"
 	desc = "You've been playing around with chemicals all your life. You know how to use chemistry machinery."
@@ -45,7 +45,7 @@
 /datum/quirk/chemwhiz/on_spawn()
 	var/mob/living/carbon/human/mob_tar = quirk_holder
 	mob_tar.mind.ischemwhiz = TRUE
-
+*/
 /datum/quirk/drunkhealing
 	name = "Drunken Resilience"
 	desc = "Nothing like a good drink to make you feel on top of the world. Whenever you're drunk, you slowly recover from injuries."

--- a/code/modules/jobs/job_types/bos.dm
+++ b/code/modules/jobs/job_types/bos.dm
@@ -22,7 +22,8 @@ Main doors: ACCESS_CAPTAIN 20
 	belt = 			/obj/item/storage/belt/military
 	glasses =		/obj/item/clothing/glasses/night
 	id = 			/obj/item/card/id/dogtag
-
+	technophreak = TRUE
+/*
 /datum/outfit/job/bos/pre_equip(mob/living/carbon/human/H, visualsOnly = FALSE)
 	..()
 	if(visualsOnly)
@@ -34,7 +35,7 @@ Main doors: ACCESS_CAPTAIN 20
 	if(visualsOnly)
 		return
 	H.mind.istechnophreak = TRUE
-
+*/
 /*
 Elder
 */
@@ -132,6 +133,7 @@ Paladin
 	belt = 			/obj/item/storage/belt/utility/full/engi
 	backpack_contents = list(
 		/obj/item/kitchen/knife/combat=1)
+	chemwhiz = TRUE
 
 
 /*
@@ -185,7 +187,6 @@ Scribe
 	selection_color = "#95a5a6"
 	exp_requirements = 600
 
-
 	outfit = /datum/outfit/job/bos/f13scribe
 
 	access = list(ACCESS_ROBOTICS, ACCESS_BOS, ACCESS_ENGINE_EQUIP, ACCESS_ENGINE, ACCESS_HYDROPONICS, ACCESS_KITCHEN, ACCESS_BAR)
@@ -205,6 +206,7 @@ Scribe
 		/obj/item/gun/energy/laser/pistol=1, \
 		/obj/item/reagent_containers/hypospray/medipen/stimpak=2) //super paks not in yet
 	//PA training not in yet
+	chemwhiz = TRUE
 
 /*
 Initiate Knight
@@ -253,7 +255,6 @@ Initiate Scribe
 	supervisors = "the scribes"
 	selection_color = "#95a5a6"
 
-
 	outfit = /datum/outfit/job/bos/f13initiatescribe
 
 	access = list(ACCESS_BOS, ACCESS_ENGINE_EQUIP, ACCESS_ENGINE, ACCESS_HYDROPONICS)
@@ -271,3 +272,4 @@ Initiate Scribe
 	id = 			/obj/item/card/id/dogtag
 	backpack_contents = list(
 		/obj/item/gun/energy/laser/pistol=1)
+	chemwhiz = TRUE

--- a/code/modules/jobs/job_types/bos.dm
+++ b/code/modules/jobs/job_types/bos.dm
@@ -23,7 +23,7 @@ Main doors: ACCESS_CAPTAIN 20
 	glasses =		/obj/item/clothing/glasses/night
 	id = 			/obj/item/card/id/dogtag
 	technophreak = TRUE
-/*
+
 /datum/outfit/job/bos/pre_equip(mob/living/carbon/human/H, visualsOnly = FALSE)
 	..()
 	if(visualsOnly)
@@ -35,7 +35,7 @@ Main doors: ACCESS_CAPTAIN 20
 	if(visualsOnly)
 		return
 	H.mind.istechnophreak = TRUE
-*/
+
 /*
 Elder
 */

--- a/code/modules/jobs/job_types/enclave.dm
+++ b/code/modules/jobs/job_types/enclave.dm
@@ -57,6 +57,7 @@ Medic
 /datum/outfit/job/enclave/f13usmedic
 	name = "US Medic"
 	jobtype = /datum/job/enclave/f13usmedic
+	chemwhiz = TRUE
 
 	id = /obj/item/card/id/gold
 	uniform =  /obj/item/clothing/under/rank/captain

--- a/code/modules/jobs/job_types/job.dm
+++ b/code/modules/jobs/job_types/job.dm
@@ -177,6 +177,10 @@
 
 	var/pda_slot = SLOT_BELT
 
+	var/technophreak = FALSE //F13 Technophreak, for super advanced tech (e.g. power armor, R&D)
+	var/chemwhiz = FALSE //F13 Chemwhiz, for chemistry machines
+
+
 /datum/outfit/job/pre_equip(mob/living/carbon/human/H, visualsOnly = FALSE)
 	switch(H.backbag)
 		if(GBACKPACK)
@@ -199,6 +203,11 @@
 			backpack_contents = list()
 		backpack_contents.Insert(1, box) // Box always takes a first slot in backpack
 		backpack_contents[box] = 1
+
+	if(technophreak==TRUE)
+		H.mind.istechnophreak = TRUE
+	if(chemwhiz == TRUE)
+		H.mind.ischemwhiz = TRUE
 
 /datum/outfit/job/post_equip(mob/living/carbon/human/H, visualsOnly = FALSE)
 	if(visualsOnly)
@@ -232,6 +241,11 @@
 		PDA.owner = H.real_name
 		PDA.ownjob = J.title
 		PDA.update_label()
+
+	if(technophreak==TRUE)
+		H.mind.istechnophreak = TRUE
+	if(chemwhiz == TRUE)
+		H.mind.ischemwhiz = TRUE
 
 /datum/outfit/job/get_chameleon_disguise_info()
 	var/list/types = ..()

--- a/code/modules/jobs/job_types/vault.dm
+++ b/code/modules/jobs/job_types/vault.dm
@@ -159,6 +159,7 @@ Medical Doctor
 /datum/outfit/job/vault/f13doctor
 	name = "Medical Doctor"
 	jobtype = /datum/job/vault/f13doctor
+	chemwhiz = TRUE
 
 	//pda
 	uniform = 		/obj/item/clothing/under/f13/vault13
@@ -197,6 +198,7 @@ Scientist
 /datum/outfit/job/vault/f13vaultscientist
 	name = "Scientist"
 	jobtype = /datum/job/vault/f13vaultscientist
+	chemwhiz = TRUE
 
 	//pda
 	uniform = 		/obj/item/clothing/under/f13/vault13

--- a/code/modules/jobs/job_types/wasteland.dm
+++ b/code/modules/jobs/job_types/wasteland.dm
@@ -234,17 +234,13 @@ Pusher
 	backpack = /obj/item/storage/backpack/satchel/explorer
 	satchel = /obj/item/storage/backpack/satchel/explorer
 
-	suit = /obj/item/clothing/suit/f13/duster
+	suit = /obj/item/clothing/suit/armor/khan
+	uniform = /obj/item/clothing/under/f13/khan
+
+	chemwhiz = TRUE
 
 /datum/outfit/job/wasteland/f13pusher/pre_equip(mob/living/carbon/human/H)
 	..()
-	uniform = pick(
-		/obj/item/clothing/under/f13/merca, \
-		/obj/item/clothing/under/f13/mercc, \
-		/obj/item/clothing/under/f13/caravaneer, \
-		/obj/item/clothing/under/f13/roving, \
-		/obj/item/clothing/under/f13/doctorm, \
-		/obj/item/clothing/under/jabroni)
 	r_pocket = pick(
 		/obj/item/flashlight/flare/torch, \
 		/obj/item/flashlight/flare)

--- a/code/modules/jobs/jobs.dm
+++ b/code/modules/jobs/jobs.dm
@@ -1,4 +1,3 @@
-
 GLOBAL_LIST_INIT(command_positions, list(
 	"Elder",
 	"Centurion",

--- a/code/modules/reagents/chemistry/machinery/chem_dispenser.dm
+++ b/code/modules/reagents/chemistry/machinery/chem_dispenser.dm
@@ -141,6 +141,9 @@
 	if(!user.IsAdvancedToolUser())
 		to_chat(user, "<span class='warning'>The legion has no use for drugs! Better to destroy it.</span>")
 		return
+	if(!user.mind.ischemwhiz==TRUE)
+		to_chat(user, "<span class='warning'>Try as you might, you have no clue how to work this thing.</span>")
+		return
 	if(!ui)
 		ui = new(user, src, ui_key, "chem_dispenser", name, 550, 550, master_ui, state)
 		if(user.hallucinating())


### PR DESCRIPTION
## Description
Chemistry machines now require the Chem Whiz perk to use, given only to certain jobs (Pusher, Scribes, Vault Doctor - and soon, the NCR Medical Officer and Den Doctor).

(Note: NCR Med/Den Doc are in the changelog 'cause we're updating them all at the same time)

## Motivation and Context
If you want to be a super cool chemist who can make medicine, you have to sacrifice something for that ability, by being a job that would reasonably know how Discussed in staff channels.

## How Has This Been Tested?
Fully tested.

## Screenshots (if appropriate):

## Changelog (neccesary)
:cl:
balance: Only certain roles can use the chem dispenser now - NCR Medical Officer, Den Doctor, Vault Doctor, Scribes and Pushers.
/:cl:
