### PR TITLE
Offroad

### DIFF
--- a/code/__DEFINES/traits.dm
+++ b/code/__DEFINES/traits.dm
@@ -68,6 +68,7 @@
 #define TRAIT_IRONFIST			"iron_fist"
 #define	TRAIT_LIFEGIVER			"lifegiver"
 #define	TRAIT_CHEMWHIZ			"chemwhiz"
+#define	TRAIT_OFFROAD			"offroad"
 
 // common trait sources
 #define TRAIT_GENERIC "generic"

--- a/code/datums/mind.dm
+++ b/code/datums/mind.dm
@@ -58,6 +58,7 @@
 	var/isholy = FALSE //is this person a chaplain or admin role allowed to use bibles
 	var/istechnophreak = FALSE // Sets the mind to knowing how to use super advanced technology and the like.
 	var/ischemwhiz = FALSE //The above, but specifically for chemistry machinery
+	var/isoffroad = FALSE //The above, but knowing how to move around in the wastes faster
 	var/mob/living/enslaved_to //If this mind's master is another mob (i.e. adamantine golems)
 	var/datum/language_holder/language_holder
 	var/unconvertable = FALSE

--- a/code/modules/jobs/job_types/job.dm
+++ b/code/modules/jobs/job_types/job.dm
@@ -179,6 +179,7 @@
 
 	var/technophreak = FALSE //F13 Technophreak, for super advanced tech (e.g. power armor, R&D)
 	var/chemwhiz = FALSE //F13 Chemwhiz, for chemistry machines
+	var/offroad = FALSE //F13 Offroad, for travelling offroad
 
 
 /datum/outfit/job/pre_equip(mob/living/carbon/human/H, visualsOnly = FALSE)
@@ -208,6 +209,8 @@
 		H.mind.istechnophreak = TRUE
 	if(chemwhiz == TRUE)
 		H.mind.ischemwhiz = TRUE
+	if(offroad == TRUE)
+		H.mind.isoffroad = TRUE
 
 /datum/outfit/job/post_equip(mob/living/carbon/human/H, visualsOnly = FALSE)
 	if(visualsOnly)

--- a/code/modules/jobs/job_types/ncr.dm
+++ b/code/modules/jobs/job_types/ncr.dm
@@ -253,7 +253,7 @@ Veteran Ranger
 /datum/outfit/job/ncr/f13vetranger
 	name = "NCR Veteran Ranger"
 	jobtype = /datum/job/ncr/f13vetranger
-	offroad = TRUE
+//	offroad = TRUE
 	uniform =  		/obj/item/clothing/under/f13/cowboyb
 	suit = 			/obj/item/clothing/suit/armor/f13/rangercombat
 	head = 			/obj/item/clothing/head/helmet/f13/ncr/rangercombat
@@ -288,7 +288,7 @@ Ranger
 /datum/outfit/job/ncr/f13ranger
 	name = "NCR Ranger"
 	jobtype = /datum/job/ncr/f13ranger
-	offroad = TRUE
+//	offroad = TRUE
 	uniform =  		/obj/item/clothing/under/f13/ranger
 	suit = 			/obj/item/clothing/suit/armor/f13/combat/ncr
 	head = 			/obj/item/clothing/head/f13/ranger
@@ -327,7 +327,7 @@ Recon Ranger
 /datum/outfit/job/ncr/f13recranger
 	name = "NCR Recon Ranger"
 	jobtype = /datum/job/ncr/f13recranger
-	offroad = TRUE
+//	offroad = TRUE
 	uniform =  		/obj/item/clothing/under/f13/ranger
 	suit = 			/obj/item/clothing/suit/f13/duster
 	head = 			/obj/item/clothing/head/fluff/cowboy

--- a/code/modules/jobs/job_types/ncr.dm
+++ b/code/modules/jobs/job_types/ncr.dm
@@ -253,6 +253,7 @@ Veteran Ranger
 /datum/outfit/job/ncr/f13vetranger
 	name = "NCR Veteran Ranger"
 	jobtype = /datum/job/ncr/f13vetranger
+	offroad = TRUE
 	uniform =  		/obj/item/clothing/under/f13/cowboyb
 	suit = 			/obj/item/clothing/suit/armor/f13/rangercombat
 	head = 			/obj/item/clothing/head/helmet/f13/ncr/rangercombat
@@ -287,6 +288,7 @@ Ranger
 /datum/outfit/job/ncr/f13ranger
 	name = "NCR Ranger"
 	jobtype = /datum/job/ncr/f13ranger
+	offroad = TRUE
 	uniform =  		/obj/item/clothing/under/f13/ranger
 	suit = 			/obj/item/clothing/suit/armor/f13/combat/ncr
 	head = 			/obj/item/clothing/head/f13/ranger
@@ -325,6 +327,7 @@ Recon Ranger
 /datum/outfit/job/ncr/f13recranger
 	name = "NCR Recon Ranger"
 	jobtype = /datum/job/ncr/f13recranger
+	offroad = TRUE
 	uniform =  		/obj/item/clothing/under/f13/ranger
 	suit = 			/obj/item/clothing/suit/f13/duster
 	head = 			/obj/item/clothing/head/fluff/cowboy

--- a/code/modules/mob/living/living.dm
+++ b/code/modules/mob/living/living.dm
@@ -484,7 +484,7 @@
 
 /mob/living/movement_delay(ignorewalk = 0)
 	. = 0
-	if(isopenturf(loc) && !is_flying())
+	if(isopenturf(loc) && !is_flying() && mind.isoffroad==FALSE)
 		var/turf/open/T = loc
 		. += T.slowdown
 	var/static/datum/config_entry/number/run_delay/config_run_delay


### PR DESCRIPTION
## Description
Adds the Offroad trait, which ignores slowdown from offroad turfs (e.g. desert). Only exists in the code currently.

## Motivation and Context
We can use it in the perk rework later and/or give to Rangers.

## How Has This Been Tested?
Yep, all tested.

## Screenshots (if appropriate):

## Changelog (neccesary)
:cl:
add: Adds the Offroad perk to the code for later use.
/:cl:
