### PR TITLE
AMR v2

### DIFF
--- a/code/modules/jobs/job_types/ncr.dm
+++ b/code/modules/jobs/job_types/ncr.dm
@@ -257,7 +257,7 @@ Veteran Ranger
 	suit = 			/obj/item/clothing/suit/armor/f13/rangercombat
 	head = 			/obj/item/clothing/head/helmet/f13/ncr/rangercombat
 	gloves =		/obj/item/clothing/gloves/fingerless
-	suit_store = 	/obj/item/gun/ballistic/shotgun/automatic/antimateriel
+	suit_store = 	/obj/item/gun/ballistic/shotgun/antimateriel
 	backpack_contents = list(
 		/obj/item/gun/ballistic/revolver/sequoia=1, \
 		/obj/item/ammo_box/c4570=2, \

--- a/code/modules/projectiles/boxes_magazines/internal/rifle.dm
+++ b/code/modules/projectiles/boxes_magazines/internal/rifle.dm
@@ -29,5 +29,5 @@
 /obj/item/ammo_box/magazine/internal/boltaction/antimateriel
 	ammo_type = /obj/item/ammo_casing/a50MG
 	caliber = "a50MG"
-	max_ammo = 5
+	max_ammo = 4
 	multiload = 0 //one bullet at a time

--- a/code/modules/projectiles/boxes_magazines/internal/rifle.dm
+++ b/code/modules/projectiles/boxes_magazines/internal/rifle.dm
@@ -26,8 +26,8 @@
 	max_ammo = 5
 	multiload = 1
 
-/obj/item/ammo_box/magazine/internal/antimateriel
+/obj/item/ammo_box/magazine/internal/boltaction/antimateriel
 	ammo_type = /obj/item/ammo_casing/a50MG
 	caliber = "a50MG"
-	max_ammo = 4
+	max_ammo = 5
 	multiload = 0 //one bullet at a time

--- a/code/modules/projectiles/guns/ballistic/shotgun.dm
+++ b/code/modules/projectiles/guns/ballistic/shotgun.dm
@@ -294,12 +294,12 @@
 	zoom_out_amt = 13
 
 //Anti-Materiel Rifle (NCR)
-/obj/item/gun/ballistic/shotgun/automatic/antimateriel
+/obj/item/gun/ballistic/shotgun/antimateriel
 	name = "anti-materiel rifle"
 	desc = "A heavy, high-powered sniper rifle chambered in .50 caliber ammunition, custom-made for use by the New California Republic Rangers. Although relatively austere, you're still pretty sure it could take the head off a deathclaw."
 	icon_state = "sniper"
 	item_state = "sniper"
-	mag_type = /obj/item/ammo_box/magazine/internal/antimateriel
+	mag_type = /obj/item/ammo_box/magazine/internal/boltaction/antimateriel
 	fire_sound = 'sound/f13weapons/antimaterielfire.ogg'
 	pump_sound = 'sound/f13weapons/antimaterielreload.ogg'
 	zoomable = TRUE
@@ -309,7 +309,6 @@
 	w_class = WEIGHT_CLASS_BULKY
 	weapon_weight = WEAPON_HEAVY
 	recoil = 1 //have fun
-	fire_delay = 10 //but not too much fun
 
 //Colt Rangemaster
 /obj/item/gun/ballistic/shotgun/automatic/hunting

--- a/code/modules/projectiles/guns/ballistic/shotgun.dm
+++ b/code/modules/projectiles/guns/ballistic/shotgun.dm
@@ -309,6 +309,7 @@
 	w_class = WEIGHT_CLASS_BULKY
 	weapon_weight = WEAPON_HEAVY
 	recoil = 1 //have fun
+	fire_delay = 3
 
 //Colt Rangemaster
 /obj/item/gun/ballistic/shotgun/automatic/hunting

--- a/code/modules/research/designs/autolathe_designs.dm
+++ b/code/modules/research/designs/autolathe_designs.dm
@@ -805,6 +805,14 @@
 	build_path = /obj/item/ammo_box/a762/doublestacked
 	category = list("initial", "Security")
 
+/datum/design/c4570SP
+	name = ".45 LC speed loader (NCR)"
+	id = "c4570SP"
+	build_type = AUTOLATHE
+	materials = list(MAT_METAL = 8000)
+	build_path = /obj/item/ammo_box/c4570SP
+	category = list("initial", "Security")
+
 /datum/design/a50MG
 	name = "Anti-Materiel Ammo Rack (.50MG)"
 	id = "a50MG"


### PR DESCRIPTION
## Description
Instead of a semi-automatic rifle with a fire delay, the anti-materiel rifle is now a bolt-action rifle (requires cycling of the bolt between each shot) like the Remington. To compensate, the capacity has been increased by 1, from 4+1 to 5+1. Additionally, the .45 LC recipe has been added to the autolathe for 8000 metal.

## Motivation and Context
Per request on discord, and because the AMR is just a scoped Rangemaster with fancy ammo right now. Bolt-action is lore accurate, feels better, and disallows magdumping unless bolt is operated between shots. .45 LC is in anticipation of brush guns, and because it's a weaker variant of .45-70.

## How Has This Been Tested?
Eeeeyup.

## Screenshots (if appropriate):

## Changelog (neccesary)
:cl:
balance: The anti-materiel rifle now has a capacity of 5+1 and is bolt-action, like the Remington.
add: .45 LC rounds can now be printed at an autolathe.
/:cl:
