### PR TITLE
Ejecting power cells from energy weapons now requires alt-click

### DIFF
--- a/code/modules/projectiles/guns/energy.dm
+++ b/code/modules/projectiles/guns/energy.dm
@@ -227,7 +227,7 @@
 			. = "<span class='danger'>[user] casually lights their [A.name] with [src]. Damn.</span>"
 
 
-/obj/item/gun/energy/attack_self(mob/living/user)
+/obj/item/gun/energy/AltClick(mob/living/user)
 	if(cell)
 		cell.forceMove(drop_location())
 		user.put_in_hands(cell)
@@ -236,6 +236,10 @@
 		to_chat(user, "<span class='notice'>You pull the cell out of \the [src].</span>")
 	else
 		to_chat(user, "<span class='notice'>There's no cell in \the [src].</span>")
+	return
+
+/obj/item/gun/energy/examine(mob/user)
+	to_chat(user, "<span class='notice'>Alt-click to eject the cell.</span>")
 	return
 
 

--- a/code/modules/projectiles/guns/energy.dm
+++ b/code/modules/projectiles/guns/energy.dm
@@ -238,11 +238,6 @@
 		to_chat(user, "<span class='notice'>There's no cell in \the [src].</span>")
 	return
 
-/obj/item/gun/energy/examine(mob/user)
-	to_chat(user, "<span class='notice'>Alt-click to eject the cell.</span>")
-	return
-
-
 /obj/item/gun/energy/attackby(obj/item/A, mob/user, params)
 	..()
 	if (istype(A, /obj/item/stock_parts/cell/ammo))

--- a/code/modules/projectiles/guns/energy.dm
+++ b/code/modules/projectiles/guns/energy.dm
@@ -254,3 +254,7 @@
 				return
 		else if (cell)
 			to_chat(user, "<span class='notice'>There's already a cell in \the [src].</span>")
+
+/obj/item/gun/energy/examine(mob/user)
+	..()
+	to_chat(user, "<span class='notice'>Alt-click to eject the battery.</span>")

--- a/code/modules/projectiles/guns/energy/special.dm
+++ b/code/modules/projectiles/guns/energy/special.dm
@@ -293,7 +293,7 @@
 
 /obj/item/gun/energy/gravity_gun
 	name = "one-point gravitational manipulator"
-	desc = "An experimental, multi-mode device that fires bolts of Zero-Point Energy, causing local distortions in gravity."
+	desc = "An experimental, multi-mode device that fires bolts of Zero-Point Energy, causing local distortions in gravity./ <span class='notice'>Alt-click to eject the cell.</span>"
 	ammo_type = list(/obj/item/ammo_casing/energy/gravity/repulse, /obj/item/ammo_casing/energy/gravity/attract, /obj/item/ammo_casing/energy/gravity/chaos)
 	item_state = "gravity_gun"
 	icon_state = "gravity_gun"

--- a/code/modules/projectiles/guns/energy/special.dm
+++ b/code/modules/projectiles/guns/energy/special.dm
@@ -293,7 +293,7 @@
 
 /obj/item/gun/energy/gravity_gun
 	name = "one-point gravitational manipulator"
-	desc = "An experimental, multi-mode device that fires bolts of Zero-Point Energy, causing local distortions in gravity./ <span class='notice'>Alt-click to eject the cell.</span>"
+	desc = "An experimental, multi-mode device that fires bolts of Zero-Point Energy, causing local distortions in gravity."
 	ammo_type = list(/obj/item/ammo_casing/energy/gravity/repulse, /obj/item/ammo_casing/energy/gravity/attract, /obj/item/ammo_casing/energy/gravity/chaos)
 	item_state = "gravity_gun"
 	icon_state = "gravity_gun"


### PR DESCRIPTION
So yknow... you can use the modes for the guns

## Screenshots (if appropriate):

## Changelog (neccesary)
:cl: Improvedname
tweak: Ejecting batteries now require an alt click
/:cl:
