### PR TITLE
Fixes ticklag/FPS

### DIFF
--- a/config/config.txt
+++ b/config/config.txt
@@ -275,10 +275,10 @@ TICK_LIMIT_MC_INIT 500
 
 ##Defines the ticklag for the world. Ticklag is the amount of time between game ticks (aka byond ticks) (in 1/10ths of a second).
 ##	This also controls the client network update rate, as well as the default client fps
-#TICKLAG 0.3
+#TICKLAG 0.5
 
 ##Can also be set as per-second value, the following value is identical to the above.
-FPS 0
+FPS 60
 
 ## Comment this out to disable automuting
 #AUTOMUTE_ON


### PR DESCRIPTION
This was tested, a visual comparison was made between 0 (syncs with tick rate) 40, 60, and 120 FPS. I posted this in the coding channel in the discord. 

What i imagine happened was setting the FPS to zero in the config file doesn't sync it to the tick rate, as opposed to setting it to zero in game preferences. 

