### PR TITLE
Minor Bugfixes

### DIFF
--- a/code/datums/traits/negative.dm
+++ b/code/datums/traits/negative.dm
@@ -128,7 +128,7 @@
 	var/mob/living/carbon/human/H = quirk_holder
 	var/obj/item/clothing/glasses/regular/glasses = new(get_turf(H))
 	H.put_in_hands(glasses)
-	H.equip_to_slot(glasses, SLOT_GLASSES)
+	H.equip_to_slot_if_possible(glasses, SLOT_GLASSES)
 	H.regenerate_icons() //this is to remove the inhand icon, which persists even if it's not in their hands
 
 

--- a/code/modules/jobs/jobs.dm
+++ b/code/modules/jobs/jobs.dm
@@ -1,8 +1,12 @@
 GLOBAL_LIST_INIT(command_positions, list(
 	"Elder",
+	"Head Scribe",
+	"Paladin",
 	"Centurion",
 	"NCR Captain",
+	"NCR Veteran Ranger",
 	"Overseer",
+	"Chief of Security",
 	"Sheriff"
 ))
 
@@ -18,18 +22,21 @@ GLOBAL_LIST_INIT(brotherhood_positions, list(
 
 GLOBAL_LIST_INIT(den_positions, list(
 	"Sheriff",
+	"Den Doctor",
 	"Settler"
 ))
 
 GLOBAL_LIST_INIT(legion_positions, list(
-	"Centurion",
-	"Veteran Decanus",
-	"Vexillarius",
-	"Decanus",
-	"Explorer",
-	"Scout",
+	"Legion Centurion",
+	"Legion Veteran Decanus",
 	"Veteran Legionnaire",
-	"Legionary",
+	"Legion Prime Decanus",
+	"Prime Legionnaire",
+	"Legion Recruit Decanus",
+	"Recruit Legionnaire",
+	"Legion Vexillarius",
+	"Legion Explorer",
+	"Legion Scout",
 	"Camp Follower"
 ))
 
@@ -37,6 +44,9 @@ GLOBAL_LIST_INIT(ncr_positions, list(
 	"NCR Captain",
 	"NCR Lieutenant",
 	"NCR Sergeant",
+	"NCR Medical Officer",
+	"NCR Engineer",
+	"NCR Heavy Trooper",
 	"NCR Trooper",
 	"NCR Recruit",
 	"NCR Veteran Ranger",
@@ -55,10 +65,10 @@ GLOBAL_LIST_INIT(vault_positions, list(
 ))
 
 GLOBAL_LIST_INIT(wasteland_positions, list(
-	"Wastelander",
 	"Raider",
 	"Pusher",
-	"Preacher"
+	"Preacher",
+	"Wastelander"
 ))
 GLOBAL_LIST_INIT(security_positions, list(
 	"Chief of Security",


### PR DESCRIPTION
## Description
If you spawn with prescription glasses and your job already has glasses equipped, those glasses are deleted, but never officially removed- so if it's something like a medHUD or NVGs, you still get the benefits of both. Now you start with prescription glasses in your hands if your eyes are already full.

The job select screen and manifest screen has been rearranged slightly to accommodate for the new roles.

## Motivation and Context
Bugfixes.

## How Has This Been Tested?
Yup.

## Screenshots (if appropriate):

## Changelog (neccesary)
:cl:
fix: Fixes job select screen and manifest screen.
fix: Fixes minor prescription glasses exploit.
/:cl:
