### PR TITLE
Simplemob Armor Framework

### DIFF
--- a/code/modules/mob/living/simple_animal/animal_defense.dm
+++ b/code/modules/mob/living/simple_animal/animal_defense.dm
@@ -107,7 +107,7 @@
 /mob/living/simple_animal/bullet_act(obj/item/projectile/Proj)
 	if(!Proj)
 		return
-	apply_damage(Proj.damage, Proj.damage_type)
+	apply_damage(Proj.damage, Proj.damage_type, Proj.armour_penetration)
 	Proj.on_hit(src)
 	return 0
 

--- a/code/modules/mob/living/simple_animal/damage_procs.dm
+++ b/code/modules/mob/living/simple_animal/damage_procs.dm
@@ -33,7 +33,7 @@
 	else if(damage_coeff[BRUTE])
 		if(ap > armor[BRUTE])
 			. = adjustHealth(amount * CONFIG_GET(number/damage_multiplier), updating_health, forced)
-		else if(100-armor[BRUTE]+ap)/100 > 0)
+		else if((100-armor[BRUTE]+ap)/100 > 0)
 			. = adjustHealth(((100-armor[BRUTE]+ap)/100) * damage_coeff[BRUTE] * amount * CONFIG_GET(number/damage_multiplier), updating_health, forced)
 		else
 			. = adjustHealth(0, updating_health, forced)
@@ -44,7 +44,7 @@
 	else if(damage_coeff[BURN])
 		if(ap > armor[BURN])
 			. = adjustHealth(amount * CONFIG_GET(number/damage_multiplier), updating_health, forced)
-		else if(100-armor[BURN]+ap)/100 > 0)
+		else if((100-armor[BURN]+ap)/100 > 0)
 			. = adjustHealth(((100-armor[BURN]+ap)/100) * damage_coeff[BURN] * amount * CONFIG_GET(number/damage_multiplier), updating_health, forced)
 		else
 			. = adjustHealth(0, updating_health, forced)

--- a/code/modules/mob/living/simple_animal/damage_procs.dm
+++ b/code/modules/mob/living/simple_animal/damage_procs.dm
@@ -1,3 +1,23 @@
+/mob/living/simple_animal/apply_damage(damage = 0,damagetype = BRUTE,ap=0, def_zone = null, blocked = FALSE)
+	var/hit_percent = (100-blocked)/100
+	if(!damage || (hit_percent <= 0))
+		return 0
+	switch(damagetype)
+		if(BRUTE)
+			adjustBruteLoss(damage * hit_percent, ap)
+		if(BURN)
+			adjustFireLoss(damage * hit_percent, ap)
+		if(TOX)
+			adjustToxLoss(damage * hit_percent)
+		if(OXY)
+			adjustOxyLoss(damage * hit_percent)
+		if(CLONE)
+			adjustCloneLoss(damage * hit_percent)
+		if(STAMINA)
+			adjustStaminaLoss(damage * hit_percent)
+		if(BRAIN)
+			adjustBrainLoss(damage * hit_percent)
+	return 1
 
 /mob/living/simple_animal/proc/adjustHealth(amount, updating_health = TRUE, forced = FALSE)
 	if(!forced && (status_flags & GODMODE))
@@ -7,17 +27,27 @@
 		updatehealth()
 	return amount
 
-/mob/living/simple_animal/adjustBruteLoss(amount, updating_health = TRUE, forced = FALSE)
+/mob/living/simple_animal/adjustBruteLoss(amount, ap, updating_health = TRUE, forced = FALSE)
 	if(forced)
 		. = adjustHealth(amount * CONFIG_GET(number/damage_multiplier), updating_health, forced)
 	else if(damage_coeff[BRUTE])
-		. = adjustHealth(amount * damage_coeff[BRUTE] * CONFIG_GET(number/damage_multiplier), updating_health, forced)
+		if(ap > armor[BRUTE])
+			. = adjustHealth(amount * CONFIG_GET(number/damage_multiplier), updating_health, forced)
+		else if(100-armor[BRUTE]+ap)/100 > 0)
+			. = adjustHealth(((100-armor[BRUTE]+ap)/100) * damage_coeff[BRUTE] * amount * CONFIG_GET(number/damage_multiplier), updating_health, forced)
+		else
+			. = adjustHealth(0, updating_health, forced)
 
-/mob/living/simple_animal/adjustFireLoss(amount, updating_health = TRUE, forced = FALSE)
+/mob/living/simple_animal/adjustFireLoss(amount, ap, updating_health = TRUE, forced = FALSE)
 	if(forced)
 		. = adjustHealth(amount * CONFIG_GET(number/damage_multiplier), updating_health, forced)
 	else if(damage_coeff[BURN])
-		. = adjustHealth(amount * damage_coeff[BURN] * CONFIG_GET(number/damage_multiplier), updating_health, forced)
+		if(ap > armor[BURN])
+			. = adjustHealth(amount * CONFIG_GET(number/damage_multiplier), updating_health, forced)
+		else if(100-armor[BURN]+ap)/100 > 0)
+			. = adjustHealth(((100-armor[BURN]+ap)/100) * damage_coeff[BURN] * amount * CONFIG_GET(number/damage_multiplier), updating_health, forced)
+		else
+			. = adjustHealth(0, updating_health, forced)
 
 /mob/living/simple_animal/adjustOxyLoss(amount, updating_health = TRUE, forced = FALSE)
 	if(forced)

--- a/code/modules/mob/living/simple_animal/simple_animal.dm
+++ b/code/modules/mob/living/simple_animal/simple_animal.dm
@@ -48,6 +48,7 @@
 	var/armour_penetration = 0 //How much armour they ignore, as a flat reduction from the targets armour value
 	var/melee_damage_type = BRUTE //Damage type of a simple mob's melee attack, should it do damage.
 	var/list/damage_coeff = list(BRUTE = 1, BURN = 1, TOX = 1, CLONE = 1, STAMINA = 0, OXY = 1) // 1 for full damage , 0 for none , -1 for 1:1 heal from that source
+	var/list/armor = list(BRUTE = 0, BURN = 0, TOX = 0, CLONE = 0, STAMINA = 0, OXY = 0)
 	var/attacktext = "attacks"
 	var/attack_sound = null
 	var/friendly = "nuzzles" //If the mob does no damage with it's attack


### PR DESCRIPTION
Name says it all, adds armor values to simplemobs that will handle
incoming damage in addition to the existing damage_coefficient

:cl:
add: Adds armor values for simplemobs, default is 0 to not make existing mobs OP
/:cl: