### PR TITLE
Minor Bugfixes 2.0

### DIFF
--- a/code/modules/jobs/jobs.dm
+++ b/code/modules/jobs/jobs.dm
@@ -1,13 +1,14 @@
 GLOBAL_LIST_INIT(command_positions, list(
-	"Elder",
-	"Head Scribe",
-	"Paladin",
-	"Centurion",
-	"NCR Captain",
-	"NCR Veteran Ranger",
-	"Overseer",
-	"Chief of Security",
-	"Sheriff"
+    "Elder",
+    "Head Scribe",
+    "Paladin",
+    "Centurion",
+    "Legion Centurion",
+    "NCR Captain",
+    "NCR Veteran Ranger",
+    "Overseer",
+    "Chief of Security",
+    "Sheriff"
 ))
 
 GLOBAL_LIST_INIT(brotherhood_positions, list(

--- a/code/modules/jobs/jobs.dm
+++ b/code/modules/jobs/jobs.dm
@@ -37,6 +37,13 @@ GLOBAL_LIST_INIT(legion_positions, list(
 	"Legion Vexillarius",
 	"Legion Explorer",
 	"Legion Scout",
+	"Centurion",
+	"Veteran Decanus",
+	"Decanus",
+	"Legionary",
+	"Vexillarius",
+	"Explorer",
+	"Scout",
 	"Camp Follower"
 ))
 

--- a/code/modules/reagents/chemistry/machinery/chem_dispenser.dm
+++ b/code/modules/reagents/chemistry/machinery/chem_dispenser.dm
@@ -141,9 +141,6 @@
 	if(!user.IsAdvancedToolUser())
 		to_chat(user, "<span class='warning'>The legion has no use for drugs! Better to destroy it.</span>")
 		return
-	if(!user.mind.ischemwhiz==TRUE)
-		to_chat(user, "<span class='warning'>Try as you might, you have no clue how to work this thing.</span>")
-		return
 	if(!ui)
 		ui = new(user, src, ui_key, "chem_dispenser", name, 550, 550, master_ui, state)
 		if(user.hallucinating())


### PR DESCRIPTION
## Description
Adds back in the previous job titles of Legion, this _should_ preserve everyone's hours while also keeping the new naming conventions and making sure the manifest works properly. Tracked playtime will look really ugly as a result, unfortunately. This is not a final fix but more of a placeholder. 

## Motivation and Context
People need their hours back but the crew manifest also needs to be fixed.

## How Has This Been Tested?
Booted up a test run to make sure that jobs properly appear in the crew manifest, I have literally no way of testing the hours thing but I'm 99% sure this should fix the issue. If not, I'll take full blame for it and will try to work towards a different fix. Without a proper test server, this is pretty difficult to deal with. 

## Screenshots (if appropriate):

## Changelog (neccesary)
:cl:

tweak: Adds the old Legion names back to the Legion jobs.dm roster.

/:cl:
