### PR TITLE
 Fixes shuttle vote being disabled the round after a no-admin shuttle call

### DIFF
--- a/code/__DEFINES/tgs.dm
+++ b/code/__DEFINES/tgs.dm
@@ -63,6 +63,9 @@
 
 //Call this at the beginning of world/Reboot(reason)
 /world/proc/TgsReboot()
+	//re-enable voting if it was disabled during shuttle call
+	if(!CONFIG_GET(flag/allow_vote_restart))
+		CONFIG_SET(flag/allow_vote_restart, TRUE)
 	return
 
 //DATUM DEFINITIONS

--- a/code/controllers/subsystem/vote.dm
+++ b/code/controllers/subsystem/vote.dm
@@ -131,7 +131,8 @@ SUBSYSTEM_DEF(vote)
 				active_admins = 1
 				break
 		if(!active_admins)
-			SSticker.Reboot("Restart vote successful.", "restart vote")
+			SSshuttle.emergency.request()
+			//SSticker.Reboot("Restart vote successful.", "restart vote")
 		else
 			to_chat(world, "<span style='boldannounce'>Notice:Restart vote will not restart the server automatically because there are active admins on.</span>")
 			message_admins("A restart vote has passed, but there are active admins on with +ban, so it has been canceled. If you wish, you may restart the server.")

--- a/code/controllers/subsystem/vote.dm
+++ b/code/controllers/subsystem/vote.dm
@@ -281,6 +281,7 @@ SUBSYSTEM_DEF(vote)
 			if(CONFIG_GET(flag/allow_vote_restart) || usr.client.holder)
 				if(min_restart_time < world.time)
 					initiate_vote("restart",usr.key)
+					CONFIG_SET(flag/allow_vote_restart, FALSE)
 				else
 					to_chat(usr.client, "<span style='boldannounce'>Restart can only initiate after [DisplayTimeText(min_restart_time)].</span>")
 		if("gamemode")


### PR DESCRIPTION
<!-- Thanks for choosing to take the time to contribute to our project! We have a few things below that we'd like you to fill out -->
<!-- The more detail you can give us, the faster we can code review, test, and merge your changes -->

<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
Hotfix for #794 to re-enable the shuttle vote on restart
## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
https://github.com/BadDeathclaw/TG-Claw/pull/794#issuecomment-481981059
## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- This helps us replicate your tests, to speed up review. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->

## Screenshots (if appropriate):

## Changelog (neccesary)
:cl:
fix:  Fixes shuttle vote being disabled the round after a no-admin shuttle call
/:cl:
