### PR TITLE
Fixes armor and runtimes and cleans out chemwiz/technophreak code

### DIFF
--- a/code/modules/clothing/suits/armor.dm
+++ b/code/modules/clothing/suits/armor.dm
@@ -396,11 +396,16 @@
 	strip_delay = 200
 	resistance_flags = LAVA_PROOF | FIRE_PROOF | ACID_PROOF
 
-/obj/item/clothing/suit/armor/f13/power_armor/equipped(mob/user, slot)
-	if(user.mind && !user.mind.istechnophreak)
-		to_chat(user, "<span class='warning'>You don't have the proper training to operate the power armor!</span>")
-		return
-	else ..()
+/obj/item/clothing/suit/armor/f13/power_armor/mob_can_equip(mob/M, mob/equipper, slot)
+	if(!..() || !ishuman(M))
+		return FALSE
+	if(equipper && equipper.mind.istechnophreak)
+		return TRUE
+	var/mob/living/carbon/human/H = M
+	if(H.mind.istechnophreak)
+		return TRUE
+	else
+		return FALSE
 
 /obj/item/clothing/suit/armor/f13/power_armor/t45d
 	name = "T-45d power armor"

--- a/code/modules/clothing/suits/armor.dm
+++ b/code/modules/clothing/suits/armor.dm
@@ -385,8 +385,6 @@
 	item_state = "t45bpowerarmor"
 	armor = list("melee" = 75, "bullet" = 50, "laser" = 30, "energy" = 50, "bomb" = 48, "bio" = 60, "rad" = 50, "fire" = 75, "acid" = 0)
 
-// power armor
-
 /obj/item/clothing/suit/armor/f13/power_armor
 	w_class = WEIGHT_CLASS_HUGE
 	slowdown = 1
@@ -398,17 +396,11 @@
 	strip_delay = 200
 	resistance_flags = LAVA_PROOF | FIRE_PROOF | ACID_PROOF
 
-
-/obj/item/clothing/suit/armor/f13/power_armor/mob_can_equip(mob/user, slot)
-	if (ishuman(user))
-		var/mob/living/carbon/human/H = user
-		if (!H.mind.istechnophreak && slot == SLOT_WEAR_SUIT)
-			H << "<span class='warning'>You don't have the proper training to operate the power armor!</span>"
-			return 0
-			..()
-	return ..()
-
-
+/obj/item/clothing/suit/armor/f13/power_armor/equipped(mob/user, slot)
+	if(user.mind && !user.mind.istechnophreak)
+		to_chat(user, "<span class='warning'>You don't have the proper training to operate the power armor!</span>")
+		return
+	else ..()
 
 /obj/item/clothing/suit/armor/f13/power_armor/t45d
 	name = "T-45d power armor"

--- a/code/modules/jobs/job_types/bos.dm
+++ b/code/modules/jobs/job_types/bos.dm
@@ -22,7 +22,6 @@ Main doors: ACCESS_CAPTAIN 20
 	belt = 			/obj/item/storage/belt/military
 	glasses =		/obj/item/clothing/glasses/night
 	id = 			/obj/item/card/id/dogtag
-	technophreak = TRUE
 
 /datum/outfit/job/bos/pre_equip(mob/living/carbon/human/H, visualsOnly = FALSE)
 	..()
@@ -133,7 +132,6 @@ Paladin
 	belt = 			/obj/item/storage/belt/utility/full/engi
 	backpack_contents = list(
 		/obj/item/kitchen/knife/combat=1)
-	chemwhiz = TRUE
 
 
 /*
@@ -206,7 +204,6 @@ Scribe
 		/obj/item/gun/energy/laser/pistol=1, \
 		/obj/item/reagent_containers/hypospray/medipen/stimpak=2) //super paks not in yet
 	//PA training not in yet
-	chemwhiz = TRUE
 
 /*
 Initiate Knight
@@ -272,4 +269,3 @@ Initiate Scribe
 	id = 			/obj/item/card/id/dogtag
 	backpack_contents = list(
 		/obj/item/gun/energy/laser/pistol=1)
-	chemwhiz = TRUE

--- a/code/modules/jobs/job_types/bos.dm
+++ b/code/modules/jobs/job_types/bos.dm
@@ -29,12 +29,6 @@ Main doors: ACCESS_CAPTAIN 20
 		return
 	H.mind.istechnophreak = TRUE
 
-/datum/outfit/job/bos/post_equip(mob/living/carbon/human/H, visualsOnly = FALSE)
-	..()
-	if(visualsOnly)
-		return
-	H.mind.istechnophreak = TRUE
-
 /*
 Elder
 */

--- a/code/modules/jobs/job_types/den.dm
+++ b/code/modules/jobs/job_types/den.dm
@@ -220,7 +220,6 @@ Den Doctor
 	outfit = /datum/outfit/job/den/f13dendoc
 
 /datum/outfit/job/den/f13dendoc
-	chemwhiz = TRUE 
 	name = "Den Doctor"
 	jobtype = /datum/job/den/f13dendoc
 	uniform =  		/obj/item/clothing/under/f13/medic

--- a/code/modules/jobs/job_types/enclave.dm
+++ b/code/modules/jobs/job_types/enclave.dm
@@ -1,9 +1,3 @@
-/datum/outfit/job/enclave/post_equip(mob/living/carbon/human/H, visualsOnly = FALSE)
-	..()
-	if(visualsOnly)
-		return
-	H.mind.istechnophreak = TRUE
-
 /datum/outfit/job/enclave/pre_equip(mob/living/carbon/human/H, visualsOnly = FALSE)
 	..()
 	if(visualsOnly)

--- a/code/modules/jobs/job_types/enclave.dm
+++ b/code/modules/jobs/job_types/enclave.dm
@@ -57,8 +57,6 @@ Medic
 /datum/outfit/job/enclave/f13usmedic
 	name = "US Medic"
 	jobtype = /datum/job/enclave/f13usmedic
-	chemwhiz = TRUE
-
 	id = /obj/item/card/id/gold
 	uniform =  /obj/item/clothing/under/rank/captain
 

--- a/code/modules/jobs/job_types/job.dm
+++ b/code/modules/jobs/job_types/job.dm
@@ -177,10 +177,6 @@
 
 	var/pda_slot = SLOT_BELT
 
-	var/technophreak = FALSE //F13 Technophreak, for super advanced tech (e.g. power armor, R&D)
-	var/chemwhiz = FALSE //F13 Chemwhiz, for chemistry machines
-
-
 /datum/outfit/job/pre_equip(mob/living/carbon/human/H, visualsOnly = FALSE)
 	switch(H.backbag)
 		if(GBACKPACK)
@@ -203,11 +199,6 @@
 			backpack_contents = list()
 		backpack_contents.Insert(1, box) // Box always takes a first slot in backpack
 		backpack_contents[box] = 1
-
-	if(technophreak==TRUE)
-		H.mind.istechnophreak = TRUE
-	if(chemwhiz == TRUE)
-		H.mind.ischemwhiz = TRUE
 
 /datum/outfit/job/post_equip(mob/living/carbon/human/H, visualsOnly = FALSE)
 	if(visualsOnly)
@@ -241,11 +232,6 @@
 		PDA.owner = H.real_name
 		PDA.ownjob = J.title
 		PDA.update_label()
-
-	if(technophreak==TRUE)
-		H.mind.istechnophreak = TRUE
-	if(chemwhiz == TRUE)
-		H.mind.ischemwhiz = TRUE
 
 /datum/outfit/job/get_chameleon_disguise_info()
 	var/list/types = ..()

--- a/code/modules/jobs/job_types/ncr.dm
+++ b/code/modules/jobs/job_types/ncr.dm
@@ -140,7 +140,6 @@ Medic
 	outfit = /datum/outfit/job/ncr/f13medic
 
 /datum/outfit/job/ncr/f13medic
-	chemwhiz = TRUE
 	name = "NCR Medical Officer"
 	jobtype = /datum/job/ncr/f13medic
 	uniform =  		/obj/item/clothing/under/f13/ncr/officer

--- a/code/modules/jobs/job_types/vault.dm
+++ b/code/modules/jobs/job_types/vault.dm
@@ -15,13 +15,6 @@ here's a tip, go search DEFINES/access.dm
 /datum/outfit/job/vault
 	gloves = /obj/item/pda
 
-/datum/outfit/job/vault/post_equip(mob/living/carbon/human/H, visualsOnly = FALSE)
-	..()
-	if(visualsOnly)
-		return
-	H.mind.istechnophreak = TRUE
-
-
 /datum/outfit/job/vault/pre_equip(mob/living/carbon/human/H, visualsOnly = FALSE)
 	..()
 	if(visualsOnly)

--- a/code/modules/jobs/job_types/vault.dm
+++ b/code/modules/jobs/job_types/vault.dm
@@ -159,7 +159,6 @@ Medical Doctor
 /datum/outfit/job/vault/f13doctor
 	name = "Medical Doctor"
 	jobtype = /datum/job/vault/f13doctor
-	chemwhiz = TRUE
 
 	//pda
 	uniform = 		/obj/item/clothing/under/f13/vault13
@@ -198,7 +197,6 @@ Scientist
 /datum/outfit/job/vault/f13vaultscientist
 	name = "Scientist"
 	jobtype = /datum/job/vault/f13vaultscientist
-	chemwhiz = TRUE
 
 	//pda
 	uniform = 		/obj/item/clothing/under/f13/vault13

--- a/code/modules/jobs/job_types/wasteland.dm
+++ b/code/modules/jobs/job_types/wasteland.dm
@@ -237,8 +237,6 @@ Pusher
 	suit = /obj/item/clothing/suit/armor/khan
 	uniform = /obj/item/clothing/under/f13/khan
 
-	chemwhiz = TRUE
-
 /datum/outfit/job/wasteland/f13pusher/pre_equip(mob/living/carbon/human/H)
 	..()
 	r_pocket = pick(


### PR DESCRIPTION
## Description
Cleans out all the chemwiz code
Cleans out unused and pointless chemwiz and technophreak code

## Motivation and Context
It rantime to hell and back and was also leading to nonfunctionality

## How Has This Been Tested?
Joining game as Paladin and then removing/equipping the armor again
Joining game as raider and then attempting to equip spawned-in armor

## Changelog (neccesary)
:cl:
fix: fixed technophreak
code: cleaned up unused code
/:cl: