### PR TITLE
BOS access fix

### DIFF
--- a/code/modules/jobs/job_types/bos.dm
+++ b/code/modules/jobs/job_types/bos.dm
@@ -3,7 +3,7 @@ BoS access:
 Main doors: ACCESS_CAPTAIN 20
 */
 
-/datum/job/bos //do NOT use this for anything, it's just to store faction datums
+/datum/job/bos //do NOT use this for anything, it's just to store faction datums.
 	department_flag = BOS
 	selection_color = "#95a5a6"
 	exp_type = EXP_TYPE_BROTHERHOOD

--- a/code/modules/jobs/job_types/bos.dm
+++ b/code/modules/jobs/job_types/bos.dm
@@ -226,8 +226,8 @@ Initiate Knight
 
 	outfit = /datum/outfit/job/bos/f13initiateknight
 
-	access = list(ACCESS_BOS)
-	minimal_access = list(ACCESS_BOS)
+	access = list(ACCESS_ROBOTICS, ACCESS_BOS, ACCESS_ENGINE_EQUIP, ACCESS_ENGINE, ACCESS_HYDROPONICS, ACCESS_KITCHEN, ACCESS_BAR)
+	minimal_access = list(ACCESS_ROBOTICS, ACCESS_BOS, ACCESS_ENGINE_EQUIP, ACCESS_ENGINE, ACCESS_HYDROPONICS, ACCESS_KITCHEN, ACCESS_BAR)
 
 /datum/outfit/job/bos/f13initiateknight
 	name = "Initiate Knight"
@@ -257,8 +257,8 @@ Initiate Scribe
 
 	outfit = /datum/outfit/job/bos/f13initiatescribe
 
-	access = list(ACCESS_BOS, ACCESS_ENGINE_EQUIP, ACCESS_ENGINE, ACCESS_HYDROPONICS)
-	minimal_access = list(ACCESS_BOS, ACCESS_ENGINE_EQUIP, ACCESS_ENGINE, ACCESS_HYDROPONICS)
+	access = list(ACCESS_ROBOTICS, ACCESS_BOS, ACCESS_ENGINE_EQUIP, ACCESS_ENGINE, ACCESS_HYDROPONICS, ACCESS_KITCHEN, ACCESS_BAR)
+	minimal_access = list(ACCESS_ROBOTICS, ACCESS_BOS, ACCESS_ENGINE_EQUIP, ACCESS_ENGINE, ACCESS_HYDROPONICS, ACCESS_KITCHEN, ACCESS_BAR)
 
 /datum/outfit/job/bos/f13initiatescribe
 	name = "Initiate Scribe"


### PR DESCRIPTION
## Description
BOS initiate knights can now open BOS-only airlocks that have been constructed using an RCD or airlock electronics.

## Motivation and Context
Really niche bug, but now BOS initiate knights can... yeah. 

## How Has This Been Tested?
Yup.

## Screenshots (if appropriate):

## Changelog (neccesary)
:cl:
fix: Fixes BOS Initiate Knight access to allow them to open constructed doors locked to BOS-specific access restrictions.
/:cl:
