### PR TITLE
Bible Tweak

### DIFF
--- a/code/game/objects/items/storage/book.dm
+++ b/code/game/objects/items/storage/book.dm
@@ -83,10 +83,27 @@ GLOBAL_LIST_INIT(bibleitemstates, list("bible", "koran", "scrapbook", "bible",  
 		usr << browse(null, "window=editicon")
 
 /obj/item/storage/book/bible/proc/bless(mob/living/carbon/human/H, mob/living/user)
-	H.visible_message("<span class='notice'>[user] blesses [H] with the power of [deity_name]!</span>")
-	to_chat(H, "<span class='boldnotice'>May the power of [deity_name] bless you!</span>")
-	SEND_SIGNAL(H, COMSIG_ADD_MOOD_EVENT, "blessing", /datum/mood_event/blessing)
-	return 1
+	to_chat(user, "<span class='notice'>You begin to invoke your deity for a blessing...</span>")
+	if(do_after(user, 100, target = H))
+		for(var/X in H.bodyparts)
+			var/obj/item/bodypart/BP = X
+			if(BP.status == BODYPART_ROBOTIC)
+				to_chat(user, "<span class='warning'>[src.deity_name] refuses to heal this metallic taint!</span>")
+				return 0
+
+		var/heal_amt = 2
+		var/list/hurt_limbs = H.get_damaged_bodyparts(1, 1)
+
+		if(hurt_limbs.len)
+			for(var/X in hurt_limbs)
+				var/obj/item/bodypart/affecting = X
+				if(affecting.heal_damage(heal_amt, heal_amt))
+					H.update_damage_overlays()
+		H.visible_message("<span class='notice'>[user] heals [H] with the power of [deity_name]!</span>")
+		to_chat(H, "<span class='boldnotice'>May the power of [deity_name] compel you to be healed!</span>")
+		playsound(src.loc, "punch", 25, 1, -1)
+		SEND_SIGNAL(H, COMSIG_ADD_MOOD_EVENT, "blessing", /datum/mood_event/blessing)
+
 
 /obj/item/storage/book/bible/attack(mob/living/M, mob/living/carbon/human/user, heal_mode = TRUE)
 
@@ -113,7 +130,7 @@ GLOBAL_LIST_INIT(bibleitemstates, list("bible", "koran", "scrapbook", "bible",  
 		if(ishuman(M) && chaplain == 1 && bless(M, user))
 			smack = 0
 
-		if(smack)
+		if(smack && chaplain == 0)
 			M.visible_message("<span class='danger'>[user] beats [M] over the head with [src]!</span>", \
 					"<span class='userdanger'>[user] beats [M] over the head with [src]!</span>")
 			playsound(src.loc, "punch", 25, 1, -1)

--- a/code/game/objects/items/storage/book.dm
+++ b/code/game/objects/items/storage/book.dm
@@ -162,7 +162,7 @@ GLOBAL_LIST_INIT(bibleitemstates, list("bible", "koran", "scrapbook", "bible",  
 			var/water2holy = A.reagents.get_reagent_amount("water")
 			A.reagents.del_reagent("water")
 			A.reagents.add_reagent("holywater",water2holy)
-		if(A.reagents && A.reagents.has_reagent("unholywater")) // yeah yeah, copy pasted code - sue me
+		if(A.reagents && A.reagents.has_reagent("unholywater")) // yeah, yeah, copy pasted code - sue me
 			to_chat(user, "<span class='notice'>You purify [A].</span>")
 			var/unholy2clean = A.reagents.get_reagent_amount("unholywater")
 			A.reagents.del_reagent("unholywater")

--- a/code/game/objects/items/storage/book.dm
+++ b/code/game/objects/items/storage/book.dm
@@ -38,6 +38,7 @@ GLOBAL_LIST_INIT(bibleitemstates, list("bible", "koran", "scrapbook", "bible",  
 	var/mob/affecting = null
 	var/deity_name = "Christ"
 	force_string = "holy"
+	var/blessing = 0
 
 /obj/item/storage/book/bible/Initialize()
 	. = ..()
@@ -83,26 +84,33 @@ GLOBAL_LIST_INIT(bibleitemstates, list("bible", "koran", "scrapbook", "bible",  
 		usr << browse(null, "window=editicon")
 
 /obj/item/storage/book/bible/proc/bless(mob/living/carbon/human/H, mob/living/user)
-	to_chat(user, "<span class='notice'>You begin to invoke your deity for a blessing...</span>")
-	if(do_after(user, 100, target = H))
-		for(var/X in H.bodyparts)
-			var/obj/item/bodypart/BP = X
-			if(BP.status == BODYPART_ROBOTIC)
-				to_chat(user, "<span class='warning'>[src.deity_name] refuses to heal this metallic taint!</span>")
-				return 0
+	if(blessing == 0)
+		to_chat(user, "<span class='notice'>You begin to invoke your deity for a blessing...</span>")
+		blessing = 1
+		if(do_after(user, 100, target = H))
+			for(var/X in H.bodyparts)
+				var/obj/item/bodypart/BP = X
+				if(BP.status == BODYPART_ROBOTIC)
+					to_chat(user, "<span class='warning'>[src.deity_name] refuses to heal this metallic taint!</span>")
+					return 0
 
-		var/heal_amt = 2
-		var/list/hurt_limbs = H.get_damaged_bodyparts(1, 1)
+			var/heal_amt = 2
+			var/list/hurt_limbs = H.get_damaged_bodyparts(1, 1)
 
-		if(hurt_limbs.len)
-			for(var/X in hurt_limbs)
-				var/obj/item/bodypart/affecting = X
-				if(affecting.heal_damage(heal_amt, heal_amt))
-					H.update_damage_overlays()
-		H.visible_message("<span class='notice'>[user] heals [H] with the power of [deity_name]!</span>")
-		to_chat(H, "<span class='boldnotice'>May the power of [deity_name] compel you to be healed!</span>")
-		playsound(src.loc, "punch", 25, 1, -1)
-		SEND_SIGNAL(H, COMSIG_ADD_MOOD_EVENT, "blessing", /datum/mood_event/blessing)
+			if(hurt_limbs.len)
+				for(var/X in hurt_limbs)
+					var/obj/item/bodypart/affecting = X
+					if(affecting.heal_damage(heal_amt, heal_amt))
+						H.update_damage_overlays()
+			H.visible_message("<span class='notice'>[user] heals [H] with the power of [deity_name]!</span>")
+			to_chat(H, "<span class='boldnotice'>May the power of [deity_name] compel you to be healed!</span>")
+			playsound(src.loc, "punch", 25, 1, -1)
+			SEND_SIGNAL(H, COMSIG_ADD_MOOD_EVENT, "blessing", /datum/mood_event/blessing)
+			blessing = 0
+		else
+			blessing = 0
+	else
+		to_chat(user, "<span class='notice'>You're already blessing someone!</span>")
 
 
 /obj/item/storage/book/bible/attack(mob/living/M, mob/living/carbon/human/user, heal_mode = TRUE)
@@ -126,7 +134,6 @@ GLOBAL_LIST_INIT(bibleitemstates, list("bible", "koran", "scrapbook", "bible",  
 		if(user == M)
 			to_chat(user, "<span class='warning'>You can't bless yourself!</span>")
 			return
-
 		if(ishuman(M) && chaplain == 1 && bless(M, user))
 			smack = 0
 

--- a/code/game/objects/items/storage/book.dm
+++ b/code/game/objects/items/storage/book.dm
@@ -83,24 +83,9 @@ GLOBAL_LIST_INIT(bibleitemstates, list("bible", "koran", "scrapbook", "bible",  
 		usr << browse(null, "window=editicon")
 
 /obj/item/storage/book/bible/proc/bless(mob/living/carbon/human/H, mob/living/user)
-	for(var/X in H.bodyparts)
-		var/obj/item/bodypart/BP = X
-		if(BP.status == BODYPART_ROBOTIC)
-			to_chat(user, "<span class='warning'>[src.deity_name] refuses to heal this metallic taint!</span>")
-			return 0
-
-	var/heal_amt = 10
-	var/list/hurt_limbs = H.get_damaged_bodyparts(1, 1)
-
-	if(hurt_limbs.len)
-		for(var/X in hurt_limbs)
-			var/obj/item/bodypart/affecting = X
-			if(affecting.heal_damage(heal_amt, heal_amt))
-				H.update_damage_overlays()
-		H.visible_message("<span class='notice'>[user] heals [H] with the power of [deity_name]!</span>")
-		to_chat(H, "<span class='boldnotice'>May the power of [deity_name] compel you to be healed!</span>")
-		playsound(src.loc, "punch", 25, 1, -1)
-		SEND_SIGNAL(H, COMSIG_ADD_MOOD_EVENT, "blessing", /datum/mood_event/blessing)
+	H.visible_message("<span class='notice'>[user] blesses [H] with the power of [deity_name]!</span>")
+	to_chat(H, "<span class='boldnotice'>May the power of [deity_name] bless you!</span>")
+	SEND_SIGNAL(H, COMSIG_ADD_MOOD_EVENT, "blessing", /datum/mood_event/blessing)
 	return 1
 
 /obj/item/storage/book/bible/attack(mob/living/M, mob/living/carbon/human/user, heal_mode = TRUE)
@@ -115,28 +100,18 @@ GLOBAL_LIST_INIT(bibleitemstates, list("bible", "koran", "scrapbook", "bible",  
 	if(user.mind && (user.mind.isholy))
 		chaplain = 1
 
-	if(!chaplain)
-		to_chat(user, "<span class='danger'>The book sizzles in your hands.</span>")
-		user.take_bodypart_damage(0,10)
-		return
-
 	if (!heal_mode)
 		return ..()
 
 	var/smack = 1
 
 	if (M.stat != DEAD)
-		if(chaplain && user == M)
-			to_chat(user, "<span class='warning'>You can't heal yourself!</span>")
+		if(user == M)
+			to_chat(user, "<span class='warning'>You can't bless yourself!</span>")
 			return
 
-		if(ishuman(M) && prob(60) && bless(M, user))
+		if(ishuman(M) && chaplain == 1 && bless(M, user))
 			smack = 0
-		else if(iscarbon(M))
-			var/mob/living/carbon/C = M
-			if(!istype(C.head, /obj/item/clothing/head/helmet))
-				C.adjustBrainLoss(5, 60)
-				to_chat(C, "<span class='danger'>You feel dumber.</span>")
 
 		if(smack)
 			M.visible_message("<span class='danger'>[user] beats [M] over the head with [src]!</span>", \


### PR DESCRIPTION
## Description
The bible's healing has been reduced from 10 brute+10 burn to 2 brute+2 burn, and takes time to use.

## Motivation and Context
People were taking Preacher and using the role as a combat medic, using the book as a source of infinite healing rather than a roleplay tool. If you're a Preacher, start Preachin', don't start bonkin' folks with a book to close up their gunshot wounds mid-fight. (It can still heal for a total of 28 HP under optimal conditions, though.)

## How Has This Been Tested?
Ayup.

## Screenshots (if appropriate):

## Changelog (neccesary)
:cl:
balance: The bible now takes time to heal people, and heals less per use.
/:cl:
