### PR TITLE
Adds cover to dense objects

### DIFF
--- a/code/game/machinery/_machinery.dm
+++ b/code/game/machinery/_machinery.dm
@@ -94,6 +94,8 @@ Class Procs:
 	var/obj/item/circuitboard/circuit // Circuit to be created and inserted when the machinery is created
 	var/interaction_flags_machine = INTERACT_MACHINE_WIRES_IF_OPEN | INTERACT_MACHINE_ALLOW_SILICON | INTERACT_MACHINE_OPEN_SILICON | INTERACT_MACHINE_SET_MACHINE
 	var/machine_tool_behaviour = NONE //can it be used as a tool in crafting?
+	var/barricade = 1 //if 1, acts as barricade
+	var/proj_pass_rate = 80 //percentage change for bullets to fly over, if barricade=1
 
 /obj/machinery/Initialize()
 	if(!armor)
@@ -210,6 +212,23 @@ Class Procs:
 			if(!(istype(H) && H.has_dna() && H.dna.check_mutation(TK)))
 				return FALSE
 	return TRUE
+
+/obj/machinery/CanPass(atom/movable/mover, turf/target)//So bullets will fly over and stuff.
+	if(barricade == 0)
+		return !density
+	else if(density == FALSE)
+		return 1
+	else if(locate(/obj/structure) in get_turf(mover))
+		return 1
+	else if(istype(mover, /obj/item/projectile))
+		var/obj/item/projectile/proj = mover
+		if(proj.firer && Adjacent(proj.firer))
+			return 1
+		if(prob(proj_pass_rate))
+			return 1
+		return 0
+	else
+		return !density
 
 ////////////////////////////////////////////////////////////////////////////////////////////
 

--- a/code/game/machinery/_machinery.dm
+++ b/code/game/machinery/_machinery.dm
@@ -95,7 +95,7 @@ Class Procs:
 	var/interaction_flags_machine = INTERACT_MACHINE_WIRES_IF_OPEN | INTERACT_MACHINE_ALLOW_SILICON | INTERACT_MACHINE_OPEN_SILICON | INTERACT_MACHINE_SET_MACHINE
 	var/machine_tool_behaviour = NONE //can it be used as a tool in crafting?
 	var/barricade = 1 //if 1, acts as barricade
-	var/proj_pass_rate = 80 //percentage change for bullets to fly over, if barricade=1
+	var/proj_pass_rate = 65 //percentage change for bullets to fly over, if barricade=1
 
 /obj/machinery/Initialize()
 	if(!armor)

--- a/code/game/machinery/_machinery.dm
+++ b/code/game/machinery/_machinery.dm
@@ -94,7 +94,7 @@ Class Procs:
 	var/obj/item/circuitboard/circuit // Circuit to be created and inserted when the machinery is created
 	var/interaction_flags_machine = INTERACT_MACHINE_WIRES_IF_OPEN | INTERACT_MACHINE_ALLOW_SILICON | INTERACT_MACHINE_OPEN_SILICON | INTERACT_MACHINE_SET_MACHINE
 	var/machine_tool_behaviour = NONE //can it be used as a tool in crafting?
-	var/barricade = 1 //if 1, acts as barricade
+	var/barricade = TRUE //if true, acts as barricade
 	var/proj_pass_rate = 65 //percentage change for bullets to fly over, if barricade=1
 
 /obj/machinery/Initialize()
@@ -214,7 +214,7 @@ Class Procs:
 	return TRUE
 
 /obj/machinery/CanPass(atom/movable/mover, turf/target)//So bullets will fly over and stuff.
-	if(barricade == 0)
+	if(barricade == FALSE)
 		return !density
 	else if(density == FALSE)
 		return 1

--- a/code/game/machinery/computer/_computer.dm
+++ b/code/game/machinery/computer/_computer.dm
@@ -9,6 +9,8 @@
 	max_integrity = 200
 	integrity_failure = 100
 	armor = list("melee" = 0, "bullet" = 0, "laser" = 0, "energy" = 0, "bomb" = 0, "bio" = 0, "rad" = 0, "fire" = 40, "acid" = 20)
+	barricade = 1
+	proj_pass_rate = 80
 	var/brightness_on = 2
 	var/icon_keyboard = "generic_key"
 	var/icon_screen = "generic"

--- a/code/game/machinery/computer/_computer.dm
+++ b/code/game/machinery/computer/_computer.dm
@@ -10,7 +10,7 @@
 	integrity_failure = 100
 	armor = list("melee" = 0, "bullet" = 0, "laser" = 0, "energy" = 0, "bomb" = 0, "bio" = 0, "rad" = 0, "fire" = 40, "acid" = 20)
 	barricade = 1
-	proj_pass_rate = 80
+	proj_pass_rate = 65
 	var/brightness_on = 2
 	var/icon_keyboard = "generic_key"
 	var/icon_screen = "generic"

--- a/code/game/machinery/computer/_computer.dm
+++ b/code/game/machinery/computer/_computer.dm
@@ -9,7 +9,7 @@
 	max_integrity = 200
 	integrity_failure = 100
 	armor = list("melee" = 0, "bullet" = 0, "laser" = 0, "energy" = 0, "bomb" = 0, "bio" = 0, "rad" = 0, "fire" = 40, "acid" = 20)
-	barricade = 1
+	barricade = TRUE
 	proj_pass_rate = 65
 	var/brightness_on = 2
 	var/icon_keyboard = "generic_key"

--- a/code/game/machinery/constructable_frame.dm
+++ b/code/game/machinery/constructable_frame.dm
@@ -4,6 +4,8 @@
 	icon_state = "box_0"
 	density = TRUE
 	max_integrity = 250
+	barricade = 1
+	proj_pass_rate = 80
 	var/obj/item/circuitboard/machine/circuit = null
 	var/state = 1
 

--- a/code/game/machinery/constructable_frame.dm
+++ b/code/game/machinery/constructable_frame.dm
@@ -5,7 +5,7 @@
 	density = TRUE
 	max_integrity = 250
 	barricade = 1
-	proj_pass_rate = 80
+	proj_pass_rate = 65
 	var/obj/item/circuitboard/machine/circuit = null
 	var/state = 1
 

--- a/code/game/machinery/constructable_frame.dm
+++ b/code/game/machinery/constructable_frame.dm
@@ -4,7 +4,7 @@
 	icon_state = "box_0"
 	density = TRUE
 	max_integrity = 250
-	barricade = 1
+	barricade = TRUE
 	proj_pass_rate = 65
 	var/obj/item/circuitboard/machine/circuit = null
 	var/state = 1

--- a/code/game/machinery/deployable.dm
+++ b/code/game/machinery/deployable.dm
@@ -14,7 +14,8 @@
 	anchored = TRUE
 	density = TRUE
 	max_integrity = 100
-	var/proj_pass_rate = 50 //How many projectiles will pass the cover. Lower means stronger cover
+	proj_pass_rate = 50
+	barricade = 1
 	var/material = METAL
 
 /obj/structure/barricade/deconstruct(disassembled = TRUE)
@@ -45,28 +46,6 @@
 			to_chat(user, "<span class='notice'>The [src] doesn't need to be repaired.</span>")
 	else
 		return ..()
-
-/obj/structure/barricade/CanPass(atom/movable/mover, turf/target)//So bullets will fly over and stuff.
-	if(locate(/obj/structure/barricade) in get_turf(mover))
-		return 1
-	else if(istype(mover, /obj/item/projectile))
-		if(!anchored)
-			return 1
-		var/obj/item/projectile/proj = mover
-		if(proj.firer && Adjacent(proj.firer))
-			return 1
-		if(prob(proj_pass_rate))
-			return 1
-		/* /obj/item/restraints/legcuffs/bola/energy/throw_impact(atom/hit_atom)
-		if(iscarbon(hit_atom))
-			var/obj/item/restraints/legcuffs/beartrap/B = new /obj/item/restraints/legcuffs/beartrap/energy/cyborg(get_turf(hit_atom))
-			B.Crossed(hit_atom)
-			qdel(src)
-		..() */
-		return 0
-	else
-		return !density
-
 
 
 /////BARRICADE TYPES///////

--- a/code/game/machinery/deployable.dm
+++ b/code/game/machinery/deployable.dm
@@ -15,7 +15,7 @@
 	density = TRUE
 	max_integrity = 100
 	proj_pass_rate = 35
-	barricade = 1
+	barricade = TRUE
 	var/material = METAL
 
 /obj/structure/barricade/deconstruct(disassembled = TRUE)

--- a/code/game/machinery/deployable.dm
+++ b/code/game/machinery/deployable.dm
@@ -14,7 +14,7 @@
 	anchored = TRUE
 	density = TRUE
 	max_integrity = 100
-	proj_pass_rate = 50
+	proj_pass_rate = 35
 	barricade = 1
 	var/material = METAL
 
@@ -81,7 +81,7 @@
 	icon_state = "woodenbarricade-old"
 	drop_amount = 2
 	max_integrity = 80
-	proj_pass_rate = 65
+	proj_pass_rate = 50
 
 /obj/structure/barricade/wooden/crude/snow
 	desc = "This space is blocked off by a crude assortment of planks. It seems to be covered in a layer of snow."

--- a/code/game/objects/structures.dm
+++ b/code/game/objects/structures.dm
@@ -8,8 +8,8 @@
 	var/climbable = FALSE
 	var/mob/living/structureclimber
 	var/broken = 0 //similar to machinery's stat BROKEN
-	var/barricade = 0 //set to 1 to allow projectiles to always pass over it, default 0 (checks vs density)
-	var/proj_pass_rate = 0 //if barricade=1, sets how many projectiles will pass the cover. Lower means stronger cover
+	var/barricade = 1 //set to 1 to allow projectiles to always pass over it, default 0 (checks vs density)
+	var/proj_pass_rate = 80 //if barricade=1, sets how many projectiles will pass the cover. Lower means stronger cover
 
 /obj/structure/Initialize()
 	if (!armor)

--- a/code/game/objects/structures.dm
+++ b/code/game/objects/structures.dm
@@ -8,6 +8,8 @@
 	var/climbable = FALSE
 	var/mob/living/structureclimber
 	var/broken = 0 //similar to machinery's stat BROKEN
+	var/barricade = 0 //set to 1 to allow projectiles to always pass over it, default 0 (checks vs density)
+	var/proj_pass_rate = 0 //if barricade=1, sets how many projectiles will pass the cover. Lower means stronger cover
 
 /obj/structure/Initialize()
 	if (!armor)
@@ -108,3 +110,20 @@
 		if(0 to 25)
 			if(!broken)
 				return  "<span class='warning'>It's falling apart!</span>"
+
+/obj/structure/CanPass(atom/movable/mover, turf/target)//So bullets will fly over and stuff.
+	if(barricade == 0)
+		return !density
+	else if(density == FALSE)
+		return 1
+	else if(locate(/obj/structure) in get_turf(mover))
+		return 1
+	else if(istype(mover, /obj/item/projectile))
+		var/obj/item/projectile/proj = mover
+		if(proj.firer && Adjacent(proj.firer))
+			return 1
+		if(prob(proj_pass_rate))
+			return 1
+		return 0
+	else
+		return !density

--- a/code/game/objects/structures.dm
+++ b/code/game/objects/structures.dm
@@ -9,7 +9,7 @@
 	var/mob/living/structureclimber
 	var/broken = 0 //similar to machinery's stat BROKEN
 	var/barricade = 1 //set to 1 to allow projectiles to always pass over it, default 0 (checks vs density)
-	var/proj_pass_rate = 80 //if barricade=1, sets how many projectiles will pass the cover. Lower means stronger cover
+	var/proj_pass_rate = 65 //if barricade=1, sets how many projectiles will pass the cover. Lower means stronger cover
 
 /obj/structure/Initialize()
 	if (!armor)

--- a/code/game/objects/structures.dm
+++ b/code/game/objects/structures.dm
@@ -8,7 +8,7 @@
 	var/climbable = FALSE
 	var/mob/living/structureclimber
 	var/broken = 0 //similar to machinery's stat BROKEN
-	var/barricade = 1 //set to 1 to allow projectiles to always pass over it, default 0 (checks vs density)
+	var/barricade = TRUE //set to true to allow projectiles to always pass over it, default false (checks vs density)
 	var/proj_pass_rate = 65 //if barricade=1, sets how many projectiles will pass the cover. Lower means stronger cover
 
 /obj/structure/Initialize()
@@ -112,7 +112,7 @@
 				return  "<span class='warning'>It's falling apart!</span>"
 
 /obj/structure/CanPass(atom/movable/mover, turf/target)//So bullets will fly over and stuff.
-	if(barricade == 0)
+	if(barricade == FALSE)
 		return !density
 	else if(density == FALSE)
 		return 1

--- a/code/game/objects/structures/crates_lockers/closets.dm
+++ b/code/game/objects/structures/crates_lockers/closets.dm
@@ -6,7 +6,7 @@
 	density = TRUE
 	layer = BELOW_OBJ_LAYER
 	barricade = 1
-	proj_pass_rate = 80
+	proj_pass_rate = 65
 	var/icon_door = null
 	var/icon_door_override = FALSE //override to have open overlay use icon different to its base's
 	var/secure = FALSE //secure locker or not, also used if overriding a non-secure locker with a secure door overlay to add fancy lights

--- a/code/game/objects/structures/crates_lockers/closets.dm
+++ b/code/game/objects/structures/crates_lockers/closets.dm
@@ -5,7 +5,7 @@
 	icon_state = "generic"
 	density = TRUE
 	layer = BELOW_OBJ_LAYER
-	barricade = 1
+	barricade = TRUE
 	proj_pass_rate = 65
 	var/icon_door = null
 	var/icon_door_override = FALSE //override to have open overlay use icon different to its base's

--- a/code/game/objects/structures/crates_lockers/closets.dm
+++ b/code/game/objects/structures/crates_lockers/closets.dm
@@ -5,6 +5,8 @@
 	icon_state = "generic"
 	density = TRUE
 	layer = BELOW_OBJ_LAYER
+	barricade = 1
+	proj_pass_rate = 80
 	var/icon_door = null
 	var/icon_door_override = FALSE //override to have open overlay use icon different to its base's
 	var/secure = FALSE //secure locker or not, also used if overriding a non-secure locker with a secure door overlay to add fancy lights
@@ -84,11 +86,6 @@
 		to_chat(user, "<span class='notice'>The parts are <b>welded</b> together.</span>")
 	else if(secure && !opened)
 		to_chat(user, "<span class='notice'>Alt-click to [locked ? "unlock" : "lock"].</span>")
-
-/obj/structure/closet/CanPass(atom/movable/mover, turf/target)
-	if(wall_mounted)
-		return TRUE
-	return !density
 
 /obj/structure/closet/proc/can_open(mob/living/user)
 	if(welded || locked)

--- a/code/game/objects/structures/crates_lockers/crates.dm
+++ b/code/game/objects/structures/crates_lockers/crates.dm
@@ -29,7 +29,21 @@
 				return 1
 			if(!locatedcrate.opened) //otherwise, if the located crate is closed, allow entering
 				return 1
-	return !density
+	if(barricade == 0)
+		return !density
+	else if(density == FALSE)
+		return 1
+	else if(locate(/obj/structure) in get_turf(mover))
+		return 1
+	else if(istype(mover, /obj/item/projectile)) //bullets can fly over crates, guaranteed if the shooter is adjacent
+		var/obj/item/projectile/proj = mover
+		if(proj.firer && Adjacent(proj.firer))
+			return 1
+		if(prob(proj_pass_rate))
+			return 1
+		return 0
+	else
+		return !density
 
 /obj/structure/closet/crate/update_icon()
 	icon_state = "[initial(icon_state)][opened ? "open" : ""]"
@@ -69,7 +83,7 @@
 	desc = "It's a burial receptacle for the dearly departed."
 	icon_state = "coffin"
 	resistance_flags = FLAMMABLE
-	max_integrity = 70 
+	max_integrity = 70
 	material_drop = /obj/item/stack/sheet/mineral/wood
 	material_drop_amount = 5
 

--- a/code/game/objects/structures/crates_lockers/crates.dm
+++ b/code/game/objects/structures/crates_lockers/crates.dm
@@ -29,7 +29,7 @@
 				return 1
 			if(!locatedcrate.opened) //otherwise, if the located crate is closed, allow entering
 				return 1
-	if(barricade == 0)
+	if(barricade == FALSE)
 		return !density
 	else if(density == FALSE)
 		return 1

--- a/code/game/objects/structures/fence.dm
+++ b/code/game/objects/structures/fence.dm
@@ -19,7 +19,7 @@
 	icon = 'icons/obj/fence.dmi'
 	icon_state = "straight"
 	barricade = 1
-	proj_pass_rate = 60
+	proj_pass_rate = 40
 
 	var/cuttable = TRUE
 	var/hole_size= NO_HOLE

--- a/code/game/objects/structures/fence.dm
+++ b/code/game/objects/structures/fence.dm
@@ -18,6 +18,8 @@
 
 	icon = 'icons/obj/fence.dmi'
 	icon_state = "straight"
+	barricade = 1
+	proj_pass_rate = 60
 
 	var/cuttable = TRUE
 	var/hole_size= NO_HOLE

--- a/code/game/objects/structures/fence.dm
+++ b/code/game/objects/structures/fence.dm
@@ -18,7 +18,7 @@
 
 	icon = 'icons/obj/fence.dmi'
 	icon_state = "straight"
-	barricade = 1
+	barricade = TRUE
 	proj_pass_rate = 40
 
 	var/cuttable = TRUE

--- a/code/game/objects/structures/girders.dm
+++ b/code/game/objects/structures/girders.dm
@@ -6,7 +6,7 @@
 	density = TRUE
 	layer = BELOW_OBJ_LAYER
 	barricade = 1
-	proj_pass_rate = 50
+	proj_pass_rate = 40
 	var/state = GIRDER_NORMAL
 	var/can_displace = TRUE //If the girder can be moved around by wrenching it
 	max_integrity = 200
@@ -307,7 +307,7 @@
 	icon_state = "displaced"
 	anchored = FALSE
 	state = GIRDER_DISPLACED
-	proj_pass_rate = 80
+	proj_pass_rate = 65
 	max_integrity = 120
 
 /obj/structure/girder/reinforced

--- a/code/game/objects/structures/girders.dm
+++ b/code/game/objects/structures/girders.dm
@@ -5,7 +5,7 @@
 	anchored = TRUE
 	density = TRUE
 	layer = BELOW_OBJ_LAYER
-	barricade = 1
+	barricade = TRUE
 	proj_pass_rate = 40
 	var/state = GIRDER_NORMAL
 	var/can_displace = TRUE //If the girder can be moved around by wrenching it

--- a/code/game/objects/structures/girders.dm
+++ b/code/game/objects/structures/girders.dm
@@ -5,8 +5,9 @@
 	anchored = TRUE
 	density = TRUE
 	layer = BELOW_OBJ_LAYER
+	barricade = 1
+	proj_pass_rate = 50
 	var/state = GIRDER_NORMAL
-	var/girderpasschance = 20 // percentage chance that a projectile passes through the girder.
 	var/can_displace = TRUE //If the girder can be moved around by wrenching it
 	max_integrity = 200
 
@@ -278,15 +279,6 @@
 			qdel(src)
 		return TRUE
 
-/obj/structure/girder/CanPass(atom/movable/mover, turf/target)
-	if(istype(mover) && (mover.pass_flags & PASSGRILLE))
-		return prob(girderpasschance)
-	else
-		if(istype(mover, /obj/item/projectile))
-			return prob(girderpasschance)
-		else
-			return 0
-
 /obj/structure/girder/CanAStarPass(ID, dir, caller)
 	. = !density
 	if(ismovableatom(caller))
@@ -315,14 +307,14 @@
 	icon_state = "displaced"
 	anchored = FALSE
 	state = GIRDER_DISPLACED
-	girderpasschance = 25
+	proj_pass_rate = 80
 	max_integrity = 120
 
 /obj/structure/girder/reinforced
 	name = "reinforced girder"
 	icon_state = "reinforced"
 	state = GIRDER_REINF
-	girderpasschance = 0
+	proj_pass_rate = 20
 	max_integrity = 350
 
 


### PR DESCRIPTION
## Description
Dense objects now no longer act as guaranteed portable cover- instead, they only block 35% of projectiles. If you're adjacent to them, they don't block any, like sandbags, so you can use them as really, really ghetto barricades if you want. (Don't expect them to save you, though.)

Similarly, fences now block 40% of projectiles, unless adjacent. This lets you use the Legion base entrance as a giant deathtrap, if you're so inclined- you can stand behind the fence and gun people down while taking limited fire in return.

This does **not** apply to people or turfs, so you can't shoot through walls... unless those walls are girders, in which case you can, because girders are actually fairly good cover- doubly so for reinforced girders.

Pass rate = how many projectiles ignore the cover. Lower is stronger cover.
**Machinery, computers, frames, structures, closets, crates and displaced girders**: 65% pass rate
^this covers pretty much everything you can build and move around.
**Fence barricades**: 50% pass rate
^only 50% because fences themselves have a 40%, and it checks for both (bringing it to 20% combined).
**Fences**: 40% pass rate
**Barricades**: 35% pass rate
**Sandbags**: 20% pass rate
**Reinforced girders**: 20% pass rate

## Motivation and Context
You now can't cheese the enclave bunker with 50 sheets of metal and guaranteed portable cover. Buffing fences is also a defensive boost anywhere fences can be found- but if an attacker can get up close to the fence, the tables can turn.

## How Has This Been Tested?
Yup.

## Screenshots (if appropriate):

## Changelog (neccesary)
:cl:
balance: Dense objects (e.g. fences, computers, machine frames, closets) can now be shot through while adjacent.
balance: While not adjacent, dense objects provide varying amounts of cover depending on the object in question. Moveable objects such as closets provide 35% cover, while static ones such as reinforced girders provide more.
/:cl:
