### PR TITLE
Modifies shooting delay (no more paralysis) and adds a throwing delay

### DIFF
--- a/code/__DEFINES/status_effects.dm
+++ b/code/__DEFINES/status_effects.dm
@@ -47,6 +47,10 @@
 
 #define STATUS_EFFECT_SLEEPING /datum/status_effect/incapacitating/sleeping //the affected is asleep
 
+#define STATUS_EFFECT_WEAPON_DRAW_DELAYED /datum/status_effect/incapacitating/weapon_draw_delayed //The affected can't fire a weapon
+
+#define STATUS_EFFECT_THROW_DELAYED /datum/status_effect/incapacitating/throw_delayed //The affected can't throw something
+
 #define STATUS_EFFECT_BELLIGERENT /datum/status_effect/belligerent //forces the affected to walk, doing damage if they try to run
 
 #define STATUS_EFFECT_GEISTRACKER /datum/status_effect/geis_tracker //if you're using geis, this tracks that and keeps you from using scripture

--- a/code/datums/status_effects/debuffs.dm
+++ b/code/datums/status_effects/debuffs.dm
@@ -37,6 +37,14 @@
 	if(owner.getStaminaLoss())
 		owner.adjustStaminaLoss(-0.3) //reduce stamina loss by 0.3 per tick, 6 per 2 seconds
 
+//WEAPON DRAW DELAYED
+/datum/status_effect/incapacitating/weapon_draw_delayed
+	id = "weapon_draw_delayed"
+
+//THROW DELAYED
+/datum/status_effect/incapacitating/throw_delayed
+	id = "throw_delayed"
+
 
 //UNCONSCIOUS
 /datum/status_effect/incapacitating/unconscious

--- a/code/game/objects/items.dm
+++ b/code/game/objects/items.dm
@@ -791,7 +791,6 @@ GLOBAL_VAR_INIT(rpg_loot_items, FALSE)
 /obj/item/gun/proc/weapondraw(obj/item/gun/G, mob/living/user) // Eventually, this will be /obj/item/weapon and guns will be /obj/item/weapon/gun/etc. SOON.tm
 	user.visible_message("<span class='danger'>[user] grabs \a [G]!</span>") // probably could code in differences as to where you're picking it up from and so forth. later.
 	user.SetWeaponDrawDelay(max((4 * G.weapon_weight + 1),(user.AmountWeaponDrawDelay())))
-	//user.SetParalyze(3 * G.weapon_weight) // Need to define where you're grabbing it from, assign numbers to them, and then divide the paralyze total by that. Tables/holster/belt/back/container.
 	user.log_message("[user] pulled a [G]", INDIVIDUAL_ATTACK_LOG)
 
 /obj/item/throwing_star/proc/throwingweapondraw(obj/item/throwing_star/T, mob/living/user)

--- a/code/game/objects/items.dm
+++ b/code/game/objects/items.dm
@@ -790,5 +790,11 @@ GLOBAL_VAR_INIT(rpg_loot_items, FALSE)
 
 /obj/item/gun/proc/weapondraw(obj/item/gun/G, mob/living/user) // Eventually, this will be /obj/item/weapon and guns will be /obj/item/weapon/gun/etc. SOON.tm
 	user.visible_message("<span class='danger'>[user] grabs \a [G]!</span>") // probably could code in differences as to where you're picking it up from and so forth. later.
-	user.SetParalyze(3 * G.weapon_weight) // Need to define where you're grabbing it from, assign numbers to them, and then divide the paralyze total by that. Tables/holster/belt/back/container.
+	user.SetWeaponDrawDelay(4 * G.weapon_weight + 1)
+	//user.SetParalyze(3 * G.weapon_weight) // Need to define where you're grabbing it from, assign numbers to them, and then divide the paralyze total by that. Tables/holster/belt/back/container.
 	user.log_message("[user] pulled a [G]", INDIVIDUAL_ATTACK_LOG)
+
+/obj/item/throwing_star/proc/throwingweapondraw(obj/item/throwing_star/T, mob/living/user)
+	user.visible_message("<span class='danger'>[user] grabs \a [T]!</span>")
+	user.SetThrowDelay(6)
+	user.log_message("[user] pulled a [T]", INDIVIDUAL_ATTACK_LOG)

--- a/code/game/objects/items.dm
+++ b/code/game/objects/items.dm
@@ -790,7 +790,7 @@ GLOBAL_VAR_INIT(rpg_loot_items, FALSE)
 
 /obj/item/gun/proc/weapondraw(obj/item/gun/G, mob/living/user) // Eventually, this will be /obj/item/weapon and guns will be /obj/item/weapon/gun/etc. SOON.tm
 	user.visible_message("<span class='danger'>[user] grabs \a [G]!</span>") // probably could code in differences as to where you're picking it up from and so forth. later.
-	user.SetWeaponDrawDelay(4 * G.weapon_weight + 1)
+	user.SetWeaponDrawDelay(max((4 * G.weapon_weight + 1),(user.AmountWeaponDrawDelay())))
 	//user.SetParalyze(3 * G.weapon_weight) // Need to define where you're grabbing it from, assign numbers to them, and then divide the paralyze total by that. Tables/holster/belt/back/container.
 	user.log_message("[user] pulled a [G]", INDIVIDUAL_ATTACK_LOG)
 

--- a/code/game/objects/items.dm
+++ b/code/game/objects/items.dm
@@ -790,7 +790,8 @@ GLOBAL_VAR_INIT(rpg_loot_items, FALSE)
 
 /obj/item/gun/proc/weapondraw(obj/item/gun/G, mob/living/user) // Eventually, this will be /obj/item/weapon and guns will be /obj/item/weapon/gun/etc. SOON.tm
 	user.visible_message("<span class='danger'>[user] grabs \a [G]!</span>") // probably could code in differences as to where you're picking it up from and so forth. later.
-	user.SetWeaponDrawDelay(max((4 * G.weapon_weight + 1),(user.AmountWeaponDrawDelay())))
+	user.SetWeaponDrawDelay(max((4 * G.weapon_weight + 1),(user.AmountWeaponDrawDelay()))) 
+	// TODO: Define where you're grabbing it from, assign numbers to them, and then divide the paralyze total by that. Tables/holster/belt/back/container.
 	user.log_message("[user] pulled a [G]", INDIVIDUAL_ATTACK_LOG)
 
 /obj/item/throwing_star/proc/throwingweapondraw(obj/item/throwing_star/T, mob/living/user)

--- a/code/game/objects/items/weaponry.dm
+++ b/code/game/objects/items/weaponry.dm
@@ -333,6 +333,10 @@ for further reading, please see: https://github.com/tgstation/tgstation/pull/301
 	embedding = list("embedded_pain_multiplier" = 4, "embed_chance" = 60, "embedded_fall_chance" = 20)
 	w_class = WEIGHT_CLASS_NORMAL
 
+/obj/item/throwing_star/pickup(mob/living/user)
+	. = ..()
+	throwingweapondraw(src, user)
+
 /obj/item/switchblade
 	name = "switchblade"
 	icon_state = "switchblade"

--- a/code/modules/mob/living/carbon/carbon.dm
+++ b/code/modules/mob/living/carbon/carbon.dm
@@ -142,6 +142,10 @@
 	return
 
 /mob/living/carbon/throw_item(atom/target)
+	var/obj/item/I = src.get_active_held_item()
+	if(src.IsThrowDelayed())
+		to_chat(src, "<span class='notice'>You're not ready to throw [I] yet!</span>")
+		return
 	throw_mode_off()
 	if(!target || !isturf(loc))
 		return
@@ -149,7 +153,6 @@
 		return
 
 	var/atom/movable/thrown_thing
-	var/obj/item/I = src.get_active_held_item()
 
 	if(!I)
 		if(pulling && isliving(pulling) && grab_state >= GRAB_AGGRESSIVE)

--- a/code/modules/mob/living/status_procs.dm
+++ b/code/modules/mob/living/status_procs.dm
@@ -271,3 +271,87 @@
 	add_trait(TRAIT_FAKEDEATH, source)
 	tod = station_time_timestamp()
 	update_stat()
+
+////////////////////////////// WEAPON DRAW DELAY ////////////////////////////////////
+
+/mob/living/IsWeaponDrawDelayed() //Check if we're delayed from firing a weapon
+	return has_status_effect(STATUS_EFFECT_WEAPON_DRAW_DELAYED)
+
+/mob/living/proc/AmountWeaponDrawDelay() //Check how many deciseconds remain in our fire delay
+	var/datum/status_effect/incapacitating/weapon_draw_delayed/F = IsWeaponDrawDelayed()
+	if(F)
+		return F.duration - world.time
+	return 0
+
+/mob/living/proc/WeaponDrawDelay(amount, updating = TRUE) //Can't go below remaining duration
+	if(status_flags)
+		var/datum/status_effect/incapacitating/weapon_draw_delayed/F = IsWeaponDrawDelayed()
+		if(F)
+			F.duration = max(world.time + amount, F.duration)
+		else if(amount > 0)
+			F = apply_status_effect(STATUS_EFFECT_WEAPON_DRAW_DELAYED, amount, updating)
+		return F
+
+/mob/living/proc/SetWeaponDrawDelay(amount, updating = TRUE) //Sets remaining duration
+	if(status_flags)
+		var/datum/status_effect/incapacitating/weapon_draw_delayed/F = IsWeaponDrawDelayed()
+		if(amount <= 0)
+			if(F)
+				qdel(F)
+		else
+			if(F)
+				F.duration = world.time + amount
+			else
+				F = apply_status_effect(STATUS_EFFECT_WEAPON_DRAW_DELAYED, amount, updating)
+		return F
+
+/mob/living/proc/AdjustWeaponDrawDelay(amount, updating = TRUE) //Adds to remaining duration
+	if(status_flags)
+		var/datum/status_effect/incapacitating/weapon_draw_delayed/F = IsWeaponDrawDelayed()
+		if(F)
+			F.duration += amount
+		else if(amount > 0)
+			F = apply_status_effect(STATUS_EFFECT_WEAPON_DRAW_DELAYED, amount, updating)
+		return F
+
+////////////////////////////// THROW DELAY ////////////////////////////////////
+
+/mob/living/IsThrowDelayed() //Check if we're delayed from throwing anything
+	return has_status_effect(STATUS_EFFECT_THROW_DELAYED)
+
+/mob/living/proc/AmountThrowDelay() //Check how many deciseconds remain in our fire delay
+	var/datum/status_effect/incapacitating/throw_delayed/T = IsThrowDelayed()
+	if(T)
+		return T.duration - world.time
+	return 0
+
+/mob/living/proc/ThrowDelay(amount, updating = TRUE) //Can't go below remaining duration
+	if(status_flags)
+		var/datum/status_effect/incapacitating/throw_delayed/T = IsThrowDelayed()
+		if(T)
+			T.duration = max(world.time + amount, T.duration)
+		else if(amount > 0)
+			T = apply_status_effect(STATUS_EFFECT_THROW_DELAYED, amount, updating)
+		return T
+
+/mob/living/proc/SetThrowDelay(amount, updating = TRUE) //Sets remaining duration
+	if(status_flags)
+		var/datum/status_effect/incapacitating/throw_delayed/T = IsThrowDelayed()
+		if(amount <= 0)
+			if(T)
+				qdel(T)
+		else
+			if(T)
+				T.duration = world.time + amount
+			else
+				T = apply_status_effect(STATUS_EFFECT_THROW_DELAYED, amount, updating)
+		return T
+
+/mob/living/proc/AdjustThrowDelay(amount, updating = TRUE) //Adds to remaining duration
+	if(status_flags)
+		var/datum/status_effect/incapacitating/throw_delayed/T = IsThrowDelayed()
+		if(T)
+			T.duration += amount
+		else if(amount > 0)
+			T = apply_status_effect(STATUS_EFFECT_THROW_DELAYED, amount, updating)
+		return T

--- a/code/modules/mob/status_procs.dm
+++ b/code/modules/mob/status_procs.dm
@@ -56,6 +56,16 @@
 /mob/proc/IsStun() //non-living mobs shouldn't be stunned
 	return FALSE
 
+/////////////////////////////////// FIRE DELAY ////////////////////////////////////
+
+/mob/proc/IsWeaponDrawDelayed() //non-living mobs shouldn't be stunned
+	return FALSE
+
+/////////////////////////////////// THROW DELAY ////////////////////////////////////
+
+/mob/proc/IsThrowDelayed() //non-living mobs shouldn't be stunned
+	return FALSE
+
 /////////////////////////////////// KNOCKDOWN ////////////////////////////////////
 
 /mob/proc/IsKnockdown() //non-living mobs shouldn't be knocked down

--- a/code/modules/projectiles/gun.dm
+++ b/code/modules/projectiles/gun.dm
@@ -219,6 +219,9 @@
 	return
 
 /obj/item/gun/proc/process_burst(mob/living/user, atom/target, message = TRUE, params=null, zone_override = "", sprd = 0, randomized_gun_spread = 0, randomized_bonus_spread = 0, rand_spr = 0, iteration = 0)
+	if(user.IsWeaponDrawDelayed())
+		to_chat(user, "<span class='notice'>[src] is not yet ready to fire!</span>")
+		return FALSE
 	if(!user || !firing_burst)
 		firing_burst = FALSE
 		return FALSE
@@ -259,6 +262,9 @@
 	add_fingerprint(user)
 
 	if(semicd)
+		return
+	if(user.IsWeaponDrawDelayed())
+		to_chat(user, "<span class='notice'>[src] is not yet ready to fire!</span>")
 		return
 
 	var/sprd = 0


### PR DESCRIPTION
<!-- Thanks for choosing to take the time to contribute to our project! We have a few things below that we'd like you to fill out -->
<!-- The more detail you can give us, the faster we can code review, test, and merge your changes -->

<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
This PR adds two new status effects (like stunned, weakened, paralyzed etc) that function to add a delay when you're currently drawing a firearm or throwing a throwing weapon. If you're affected by either status effect, you can still walk around, equip stuff, drop stuff, etc. 
his means no more total body paralysis when drawing a firearm, and it makes these things easy to modify with stuff like holsters, drugs, etc.
## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Weapon draw delay: No one likes the fact that you're totally paralyzed when you draw a gun, it feels unnatural not to be able to move while doing it. This change makes it possible to move and draw at the same time, and makes it easy to add things like quick-draw holsters and the like in the future.

Throwing delay: In its current state, if you're quick with hotkeys, you can machinegun out a quiver of throwing spears faster than a fucking L6 saw and break down a door/window/person just as fast. It's hilarious to watch but ultimately super broken and needs a fix. This makes it so you can't do that. Currently it's only applied to throwing weapons, since other things don't usually do that much damage, but could be applied to other things as well if we see abuse of mechanics in that way.
## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- This helps us replicate your tests, to speed up review. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->
I've tested the changes on my personal machine and fixed the bugs that popped up. I did notice another issue, but after testing it on the live server I realized that it's not my code doing it and will look into fixing it as well (You can't fire a gun if you click right next to you, you have to fire beyond. Something to do with point blank code I presume)
## Screenshots (if appropriate):
![Screenshot](https://i.postimg.cc/52G2X8Jb/2019-04-15-21-43-51.png)
## Changelog (neccesary)
:cl: ChronicPwnage:
add: Adds a weapon draw delay, preventing you from firing a weapon right after you draw it
add: Adds a throwing weapon delay, preventing machine gun throwing spears from YATATATAT-ing doors (and people) in moments
del: Removes the existing weapon draw paralysis, which paralyzed you entirely when you drew a weapon
/:cl:
