### PR TITLE
Stimpak and Healing Powder Change Proposal

### DIFF
--- a/code/modules/reagents/chemistry/reagents/medicine_reagents.dm
+++ b/code/modules/reagents/chemistry/reagents/medicine_reagents.dm
@@ -1285,7 +1285,6 @@
 	M.adjustOxyLoss(-6*REM, 0)
 	M.AdjustStun(-10, 0)
 	M.AdjustKnockdown(-10, 0)
-	M.AdjustUnconscious(-10, 0)
 	M.adjustStaminaLoss(-4*REM, 0)
 	. = 1
 	..()

--- a/code/modules/reagents/chemistry/reagents/medicine_reagents.dm
+++ b/code/modules/reagents/chemistry/reagents/medicine_reagents.dm
@@ -1264,11 +1264,11 @@
 /datum/reagent/medicine/stimpak
 	name = "Stimpak Fluid"
 	id = "stimpak"
-	description = "Rapidly heals damage when injected. Deals minor toxin damage if injested."
+	description = "Rapidly heals damage when injected. Deals minor toxin damage if ingested."
 	reagent_state = LIQUID
 	color = "#C8A5DC"
 	taste_description = "grossness"
-	metabolization_rate = 3 * REAGENTS_METABOLISM
+	metabolization_rate = 5 * REAGENTS_METABOLISM
 	overdose_threshold = 20
 
 /datum/reagent/medicine/stimpak/reaction_mob(mob/living/M, method=TOUCH, reac_volume, show_message = 1)
@@ -1280,15 +1280,19 @@
 	..()
 
 /datum/reagent/medicine/stimpak/on_mob_life(mob/living/carbon/M)
-	M.adjustBruteLoss(-4*REM, 0)
-	M.adjustFireLoss(-4*REM, 0)
-	M.adjustOxyLoss(-3*REM, 0)
+	M.adjustBruteLoss(-6*REM, 0)
+	M.adjustFireLoss(-6*REM, 0)
+	M.adjustOxyLoss(-6*REM, 0)
+	M.AdjustStun(-10, 0)
+	M.AdjustKnockdown(-10, 0)
+	M.AdjustUnconscious(-10, 0)
+	M.adjustStaminaLoss(-4*REM, 0)
 	. = 1
 	..()
 
 /datum/reagent/medicine/stimpak/overdose_process(mob/living/M)
-	M.adjustToxLoss(2.5*REM, 0)
-	M.adjustOxyLoss(7*REM, 0)
+	M.adjustToxLoss(5*REM, 0)
+	M.adjustOxyLoss(8*REM, 0)
 	..()
 	. = 1
 

--- a/code/modules/reagents/chemistry/reagents/medicine_reagents.dm
+++ b/code/modules/reagents/chemistry/reagents/medicine_reagents.dm
@@ -1303,7 +1303,7 @@
 	reagent_state = SOLID
 	color = "#A9FBFB"
 	taste_description = "bitterness"
-	metabolization_rate = 0.25 * REAGENTS_METABOLISM
+	metabolization_rate = 0.35 * REAGENTS_METABOLISM
 	overdose_threshold = 30
 
 /datum/reagent/medicine/healing_powder/on_mob_life(mob/living/carbon/M)

--- a/code/modules/reagents/reagent_containers/hypospray.dm
+++ b/code/modules/reagents/reagent_containers/hypospray.dm
@@ -179,10 +179,10 @@
 	name = "stimpak"
 	desc = "A handheld delivery system for medicine, used to rapidly heal physical damage to the body."
 	icon_state = "stimpakpen"
-	volume = 10
-	amount_per_transfer_from_this = 10
-	list_reagents = list("stimpak" = 10)
-	
+	volume = 16
+	amount_per_transfer_from_this = 16
+	list_reagents = list("stimpak" = 10, "tricordrazine" = 6)
+
 /*
 /obj/item/reagent_containers/hypospray/medipen/psycho
 	name = "Psycho"


### PR DESCRIPTION
<!-- Thanks for choosing to take the time to contribute to our project! We have a few things below that we'd like you to fill out -->
<!-- The more detail you can give us, the faster we can code review, test, and merge your changes -->

<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
Buffs stimpacks, nerfs healing powder, differentiates the two to create distinct classes of healing compared to the current state of "stimpaks bad, healing powder good"

Before:
Stimpaks healed 40 burn/brute/oxy over 10 game ticks
Healing Powder healed 300 burn/brute over 100 game ticks

After:
Stimpaks initially heal 35 burn/brute/oxy over 5 game ticks, and reduce stuns during those 5 game ticks 
Stimpaks then heal about an additional 15 burn/brute/oxy/tox over 15 game ticks (for a total of 50 brute/burn/oxy and 15 tox)
Healing Powder heals 214 burn/brute over about 71 game ticks (Heal at the same speed, around a 30% reduction in total healing/duration so they don't last forever anymore)

Results:
Stimpaks heal very fast up front and then a little extra afterwards, and reduce stuns for a few seconds
Healing powder doesn't last a ridiculous amount of time anymore but is still good

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Healing powder is far, far better than stimpaks at the moment and is not very different. This change makes stimpaks (the harder to make healing source) more viable and differentiates the two in an interesting way.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- This helps us replicate your tests, to speed up review. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->
Tested on a private server, worked well enough.
## Screenshots (if appropriate):

## Changelog (neccesary)

🆑 ChronicPwnage:
balance: Stimpaks now heal you a fair amount very quickly, then a little bit afterwards 
balance: Healing Powder total duration reduced by about 30%
 /🆑
