### PR TITLE
Brotherhood Jobs spawn with two extra reloads for their respective secondary weapon

### DIFF
--- a/code/modules/jobs/job_types/bos.dm
+++ b/code/modules/jobs/job_types/bos.dm
@@ -98,7 +98,9 @@ Paladin
 	backpack_contents = list(
 		/obj/item/stock_parts/cell/ammo/mfc=2, \
 		/obj/item/kitchen/knife/combat=1, \
-		/obj/item/gun/ballistic/automatic/pistol/n99=1)
+		/obj/item/gun/ballistic/automatic/pistol/n99=1, \
+		/obj/item/ammo_box/magazine/m10mm_adv=2)
+
 
 
 /*Head Scribe
@@ -131,7 +133,8 @@ Paladin
 	suit_store =	/obj/item/gun/energy/laser/pistol
 	belt = 			/obj/item/storage/belt/utility/full/engi
 	backpack_contents = list(
-		/obj/item/kitchen/knife/combat=1)
+		/obj/item/kitchen/knife/combat=1, \
+		/obj/item/stock_parts/cell/ammo/ec=2)
 
 
 /*
@@ -166,7 +169,9 @@ Knight
 	backpack_contents = list(
 		/obj/item/stock_parts/cell/ammo/mfc=2, \
 		/obj/item/kitchen/knife/combat=1, \
-		/obj/item/gun/ballistic/automatic/pistol/n99=1)
+		/obj/item/gun/ballistic/automatic/pistol/n99=1, \
+		/obj/item/ammo_box/magazine/m10mm_adv=2)
+
 
 
 /*
@@ -235,7 +240,8 @@ Initiate Knight
 	backpack_contents = list(
 		/obj/item/stock_parts/cell/ammo/mfc=2, \
 		/obj/item/kitchen/knife/combat=1, \
-		/obj/item/gun/energy/laser/pistol=1)
+		/obj/item/gun/energy/laser/pistol=1, \
+		/obj/item/stock_parts/cell/ammo/ec=2)
 
 /*
 Initiate Scribe
@@ -269,4 +275,5 @@ Initiate Scribe
 	glasses =		/obj/item/clothing/glasses/sunglasses/big
 	id = 			/obj/item/card/id/dogtag
 	backpack_contents = list(
-		/obj/item/gun/energy/laser/pistol=1)
+		/obj/item/gun/energy/laser/pistol=1, \
+		/obj/item/stock_parts/cell/ammo/ec=2)

--- a/config/config.txt
+++ b/config/config.txt
@@ -216,10 +216,10 @@ CHECK_RANDOMIZER
 # SERVER ss13.example.com:2506
 
 ## forum address
-# FORUMURL https://discord.gg/BbsYDrR
+FORUMURL https://discord.gg/BbsYDrR
 
 ## Wiki address
-# WIKIURL https://www.patreon.com/baddeathclaw
+WIKIURL https://www.patreon.com/baddeathclaw
 
 ## Rules address
 RULESURL https://pastebin.com/ETeb6x3D

--- a/interface/interface.dm
+++ b/interface/interface.dm
@@ -1,17 +1,15 @@
 //Please use mob or src (not usr) in these procs. This way they can be called in the same fashion as procs.
-/client/verb/wiki(query as text)
+/client/verb/patreon()
 	set name = "wiki"
 	set desc = "Opens the Patreon in your browser."
 	set hidden = 1
 	var/wikiurl = CONFIG_GET(string/wikiurl)
 	if(wikiurl)
-		if(query)
-			var/output = wikiurl + "/index.php?title=Special%3ASearch&profile=default&search=" + query
-			src << link(output)
-		else if (query != null)
-			src << link(wikiurl)
+		if(alert("This will open the Patreon in your browser. Are you sure?",,"Yes","No")!="Yes")
+			return
+		src << link(wikiurl)
 	else
-		to_chat(src, "<span class='danger'>The patreon URL is not set in the server configuration.</span>")
+		to_chat(src, "<span class='danger'>The Patreon URL is not set in the server configuration.</span>")
 	return
 
 /client/verb/forum()


### PR DESCRIPTION
## Description
Knight and Paladin spawn with 2 10mm mags for their N99 pistol
Initiate Scribe, Initiate Knight, and Head Scribe spawn with two Energy Cells (Scribe rank does already) for their laser pistol

And since I'm too new at github and wasn't able to properly separate them, fixes #858 as well

## Motivation and Context
The jobs should start out with enough ammo for their pistols to be at all useful without cannibalizing the backup guns in the armory (or nowhere in the bunker, for the 10mm), plus consistency with Scribe already

## How Has This Been Tested?
Tested on local server

## Screenshots (if appropriate):
![image](https://user-images.githubusercontent.com/16696858/56755823-fdd53400-6755-11e9-8a4b-a36b8fe950a2.png)

![image](https://user-images.githubusercontent.com/16696858/56761522-2a437d00-6763-11e9-8a11-f42e2049e479.png)



## Changelog (neccesary)
:cl:
tweak: Brotherhood Jobs spawn with extra ammo for their pistols
fix: Patreon and Discord menu buttons lead where they should
/:cl:
