### PR TITLE
Pleasure Bots - Pleasure Edition

### DIFF
--- a/code/modules/mob/living/silicon/robot/robot_modules.dm
+++ b/code/modules/mob/living/silicon/robot/robot_modules.dm
@@ -600,7 +600,12 @@
 /obj/item/robot_module/fisto_protectron
 	name = "Fisto"
 	basic_modules = list(
+		/obj/item/crowbar/cyborg,
+		/obj/item/restraints/handcuffs/cable/zipties,
+		/obj/item/melee/chainofcommand,
+		/obj/item/assembly/flash/cyborg,
 		/obj/item/dildo/cyborg,
+		/obj/item/soap/nanotrasen,
 		/obj/item/reagent_containers/spray/sexborg_oil)
 	emag_modules = list(/obj/item/reagent_containers/spray/cyborg_lube)
 	ratvar_modules = list(/obj/item/clockwork/weapon/ratvarian_spear)
@@ -612,7 +617,12 @@
 /obj/item/robot_module/sexy_handy
 	name = "Hans"
 	basic_modules = list(
+		/obj/item/crowbar/cyborg,
+		/obj/item/restraints/handcuffs/cable/zipties,
+		/obj/item/melee/chainofcommand,
+		/obj/item/assembly/flash/cyborg,
 		/obj/item/dildo/cyborg,
+		/obj/item/soap/nanotrasen,
 		/obj/item/reagent_containers/spray/sexborg_oil)
 	emag_modules = list(/obj/item/reagent_containers/spray/cyborg_lube)
 	ratvar_modules = list(/obj/item/clockwork/weapon/ratvarian_spear)

--- a/interactions/_interaction.dm
+++ b/interactions/_interaction.dm
@@ -165,11 +165,16 @@ var/list/interactions
 			return TRUE
 */
 
-/mob/living/silicon/silicon/proc/list_interaction_attributes()
-	has_penis = TRUE
-	has_vagina = TRUE
-	has_breasts = TRUE
-	has_anus = TRUE
-	return
+//mob/living/silicon/silicon/proc/list_interaction_attributes()
+//	has_penis = TRUE
+//	has_vagina = TRUE
+//	has_breasts = TRUE
+//	has_anus = TRUE
+//	return
 
-/mob/partner/proc/list_interaction_attributes()
+//mob/partner/proc/list_interaction_attributes()
+
+//I'm a terrible coder, tried to add body parts to the borgs so
+//they could use the interaction menu but I failed terribly.
+//Feel free to try and fix it.
+//Love, Moose/Bob.

--- a/interactions/_interaction.dm
+++ b/interactions/_interaction.dm
@@ -164,3 +164,12 @@ var/list/interactions
 		if(user_buckle_mob(M, user))
 			return TRUE
 */
+
+/mob/living/silicon/silicon/proc/list_interaction_attributes()
+	has_penis = TRUE
+	has_vagina = TRUE
+	has_breasts = TRUE
+	has_anus = TRUE
+	return
+
+/mob/partner/proc/list_interaction_attributes()

--- a/interactions/interaction_interface.dm
+++ b/interactions/interaction_interface.dm
@@ -17,6 +17,10 @@
 
 	user.try_interaction(src)
 
+/mob/living/silicon/MouseDrop_T(mob/M as mob, mob/user as mob)
+	if(M == src || src == usr || M != usr)		return
+	if(usr.restrained())		return
+
 /mob/living/carbon/human/verb/interact_with()
 	set name = "Interact With"
 	set desc = "Perform an interaction with someone."
@@ -30,6 +34,29 @@
 	var/dat = "<B><HR><FONT size=3>Interacting with \the [partner]...</FONT></B><HR>"
 
 	dat += "You...<br>[list_interaction_attributes()]<hr>"
+	dat += "They...<br>[partner.list_interaction_attributes()]<hr>"
+
+/mob/living/carbon/human/try_interaction(mob/living/silicon/partner)
+	var/dat = "<B><HR><FONT size=3>Interacting with \the [partner]...</FONT></B><HR>"
+
+	dat += "You...<br>[list_interaction_attributes()]<hr>"
+	dat += "They...<br>[]<hr>"
+
+	make_interactions()
+	for(var/interaction_key in interactions)
+		var/datum/interaction/I = interactions[interaction_key]
+		if(I.evaluate_user(src) && I.evaluate_target(src, partner))
+			dat += I.get_action_link_for(src, partner)
+
+	var/datum/browser/popup = new(usr, "interactions", "Interactions", 340, 480)
+	popup.set_content(dat)
+	popup.open()
+
+/mob/living/silicon/try_interaction(mob/living/carbon/human/partner)
+
+	var/dat = "<B><HR><FONT size=3>Interacting with \the [partner]...</FONT></B><HR>"
+
+	dat += "You...<br>[]<hr>"
 	dat += "They...<br>[partner.list_interaction_attributes()]<hr>"
 
 	make_interactions()

--- a/interactions/lewd/_lewd.dm
+++ b/interactions/lewd/_lewd.dm
@@ -366,12 +366,12 @@
 
 		if(has_vagina())
 			message = pick(list(
-				"presses their weight down onto \the [partner]'s face, blocking their vision completely.",
+				"presses their weight down onto \the [partner]'s face, blocking their vision completely.", 
 				"rides \the [partner]'s face, grinding their wet pussy all over it."))
 
 		else if(has_penis())
-			message = pick(list("presses their weight down onto \the [partner]'s face, blocking their vision completely.",
-				"forces their dick and nutsack into \the [partner]'s face as they're stuck locked in between their thighs.",
+			message = pick(list("presses their weight down onto \the [partner]'s face, blocking their vision completely.", 
+				"forces their dick and nutsack into \the [partner]'s face as they're stuck locked in between their thighs.", 
 				"slips their cock into \the [partner]'s helpless mouth, keeping their shaft pressed hard into their face."))
 
 		else
@@ -381,12 +381,12 @@
 
 		if(has_vagina())
 			message = pick(list(
-				"clambers over \the [partner]'s face and pins them down with their thighs, their moist slit rubbing all over \the [partner]'s mouth and nose.",
+				"clambers over \the [partner]'s face and pins them down with their thighs, their moist slit rubbing all over \the [partner]'s mouth and nose.", 
 				"locks their legs around \the [partner]'s head before pulling it into their mound."))
 
 		else if(has_penis())
 			message = pick(list(
-				"clambers over \the [partner]'s face and pins them down with their thighs, then slowly inching closer and covering their eyes and nose with their leaking erection.",
+				"clambers over \the [partner]'s face and pins them down with their thighs, then slowly inching closer and covering their eyes and nose with their leaking erection.", 
 				"locks their legs around \the [partner]'s head before pulling it into their fat package, smothering them."))
 
 		else
@@ -428,8 +428,8 @@
 
 	if(is_fucking(partner, CUM_TARGET_THROAT))
 		message = "[pick(
-			"brutally fucks \the [partner]'s throat.",
-			"chokes \the [partner] on their dick.",
+			"brutally fucks \the [partner]'s throat.", 
+			"chokes \the [partner] on their dick.", 
 			"brutally shoves their dick deep into \the [partner]'s mouth.")]"
 		if(rand(3))
 			partner.emote("chokes on \The [src]")
@@ -467,9 +467,9 @@
 
 	if(is_fucking(partner, NUTS_TO_FACE))
 		message = pick(list(
-			"grabs the back of [partner]'s head and pulls it into their crotch.",
-			"jams their nutsack right into [partner]'s face.",
-			"roughly grinds their fat nutsack into [partner]'s mouth.",
+			"grabs the back of [partner]'s head and pulls it into their crotch.", 
+			"jams their nutsack right into [partner]'s face.", 
+			"roughly grinds their fat nutsack into [partner]'s mouth.", 
 			"pulls out their saliva-covered nuts from [partner]'s violated mouth and then wipes off the slime onto their face."))
 	else
 		message = pick(list("wedges a digit into the side of [partner]'s jaw and pries it open before using their other hand to shove their whole nutsack inside!", "stands with their groin inches away from [partner]'s face, then thrusting their hips forward and smothering [partner]'s whole face with their heavy ballsack."))
@@ -519,7 +519,7 @@
 	var/message
 
 	if(partner.is_fucking(src, CUM_TARGET_VAGINA))
-		message = "[pick("rides \the [partner]'s dick.",
+		message = "[pick("rides \the [partner]'s dick.", 
 			"forces [partner]'s cock on their pussy")]"
 	else
 		message = "slides their pussy onto \the [partner]'s cock."
@@ -535,7 +535,7 @@
 	var/message
 
 	if(partner.is_fucking(src, CUM_TARGET_ANUS))
-		message = "[pick("rides \the [partner]'s dick.",
+		message = "[pick("rides \the [partner]'s dick.", 
 			"forces [partner]'s cock on their ass")]"
 	else
 		message = "lowers their ass onto \the [partner]'s cock."
@@ -546,28 +546,10 @@
 	handle_post_sex(NORMAL_LUST, null, partner)
 	partner.dir = get_dir(partner,src)
 	do_fucking_animation(get_dir(src, partner))
-	
-/mob/living/carbon/human/proc/do_tribadism(mob/living/carbon/human/partner)
-	var/message
-
-	if(partner.is_fucking(src, CUM_TARGET_VAGINA))
-		message = "[pick("grinds their pussy against \the [partner]'s cunt.",
-			"rubs their cunt against \the [partner]'s pussy.",
-			"thrusts against \the [partner]'s pussy.",
-			"humps \the [partner], their pussies grinding against eachother.")]"
-	else
-		message = "presses their pussy into \the [partner]'s own."
-		partner.set_is_fucking(src, CUM_TARGET_VAGINA)
-	playsound(loc, "honk/sound/interactions/squelch[rand(1, 3)].ogg", 70, 1, -1)
-	visible_message("<font color=purple><b>\The [src]</b> [message]</font>")
-	partner.handle_post_sex(NORMAL_LUST, CUM_TARGET_VAGINA, src)
-	handle_post_sex(NORMAL_LUST, null, partner)
-	partner.dir = get_dir(partner,src)
-	do_fucking_animation(get_dir(src, partner))
 
 /mob/living/carbon/human/proc/do_fingering(mob/living/carbon/human/partner)
-	visible_message("<font color=purple><b>\The [src]</b> [pick("fingers \the [partner].",
-		"fingers \the [partner]'s pussy.",
+	visible_message("<font color=purple><b>\The [src]</b> [pick("fingers \the [partner].", 
+		"fingers \the [partner]'s pussy.", 
 		"fingers \the [partner] hard.")]</font>")
 	playsound(loc, "honk/sound/interactions/champ_fingering.ogg", 50, 1, -1)
 	partner.handle_post_sex(NORMAL_LUST, null, src)
@@ -575,8 +557,8 @@
 	do_fucking_animation(get_dir(src, partner))
 
 /mob/living/carbon/human/proc/do_fingerass(mob/living/carbon/human/partner)
-	visible_message("<font color=purple><b>\The [src]</b> [pick("fingers \the [partner].",
-		"fingers \the [partner]'s asshole.",
+	visible_message("<font color=purple><b>\The [src]</b> [pick("fingers \the [partner].", 
+		"fingers \the [partner]'s asshole.", 
 		"fingers \the [partner] hard.")]</font>")
 	playsound(loc, "honk/sound/interactions/champ_fingering.ogg", 50, 1, -1)
 	partner.handle_post_sex(NORMAL_LUST, null, src)
@@ -594,11 +576,11 @@
 	var/message
 
 	if(partner.is_fucking(src, CUM_TARGET_HAND))
-		message = "[pick("jerks \the [partner] off.",
-			"works \the [partner]'s shaft.",
+		message = "[pick("jerks \the [partner] off.", 
+			"works \the [partner]'s shaft.", 
 			"wanks \the [partner]'s cock hard.")]"
 	else
-		message = "[pick("wraps their hand around \the [partner]'s cock.",
+		message = "[pick("wraps their hand around \the [partner]'s cock.", 
 			"starts playing with \the [partner]'s cock")]"
 		partner.set_is_fucking(src, CUM_TARGET_HAND)
 
@@ -612,9 +594,9 @@
 	var/message
 
 	if(is_fucking(partner, CUM_TARGET_BREASTS))
-		message = "[pick("fucks \the [partner]'s' breasts.",
-			"grinds their cock between \the [partner]'s boobs.",
-			"thrusts into \the [partner]'s tits.",
+		message = "[pick("fucks \the [partner]'s' breasts.", 
+			"grinds their cock between \the [partner]'s boobs.", 
+			"thrusts into \the [partner]'s tits.", 
 			"grabs \the [partner]'s breasts together and presses their dick between them.")]"
 	else
 		message = "pushes \the [partner]'s breasts together and presses their dick between them."
@@ -631,11 +613,11 @@
 	var/message
 
 	if(is_fucking(partner, GRINDING_FACE_WITH_ANUS))
-		message = "[pick("grinds their ass into \the [partner]'s face.",
+		message = "[pick("grinds their ass into \the [partner]'s face.", 
 			"shoves their ass into \the [partner]'s face.")]"
 	else
 		message = "[pick(
-			"grabs the back of \the [partner]'s head and forces it into their asscheeks.",
+			"grabs the back of \the [partner]'s head and forces it into their asscheeks.", 
 			"squats down and plants their ass right on \the [partner]'s face")]"
 		set_is_fucking(partner , GRINDING_FACE_WITH_ANUS)
 
@@ -665,32 +647,32 @@
 
 	if(is_fucking(partner, GRINDING_FACE_WITH_FEET))
 		if(src.get_item_by_slot(SLOT_SHOES) != null)
-			message = "[pick(list("grinds their [get_shoes()] into [partner]'s face.",
-				"presses their footwear down hard on [partner]'s face.",
+			message = "[pick(list("grinds their [get_shoes()] into [partner]'s face.", 
+				"presses their footwear down hard on [partner]'s face.", 
 				"rubs off the dirt from their [get_shoes()] onto [partner]'s face."))]</span>"
 		else
-			message = "[pick(list("grinds their bare feet into [partner]'s face.",
-				"deviously covers [partner]'s mouth and nose with their bare feet.",
+			message = "[pick(list("grinds their bare feet into [partner]'s face.", 
+				"deviously covers [partner]'s mouth and nose with their bare feet.", 
 				"runs the soles of their bare feet against [partner]'s lips."))]</span>"
 
 	else if(is_fucking(partner, GRINDING_MOUTH_WITH_FEET))
 		if(src.get_item_by_slot(SLOT_SHOES) != null)
-			message = "[pick(list("pulls their [get_shoes()] out of [partner]'s mouth and puts them on their face.",
+			message = "[pick(list("pulls their [get_shoes()] out of [partner]'s mouth and puts them on their face.", 
 				"slowly retracts their [get_shoes()] from [partner]'s mouth, putting them on their face instead."))]</span>"
 		else
-			message = "[pick(list("pulls their bare feet out of [partner]'s mouth and rests them on their face instead.",
+			message = "[pick(list("pulls their bare feet out of [partner]'s mouth and rests them on their face instead.", 
 				"retracts their bare feet from [partner]'s mouth and grinds them into their face instead."))]</span>"
 
 		set_is_fucking(partner , GRINDING_FACE_WITH_FEET)
 
 	else
 		if(src.get_item_by_slot(SLOT_SHOES) != null)
-			message = "[pick(list("plants their [get_shoes()] ontop of [partner]'s face.",
-				"rests their [get_shoes()] on [partner]'s face and presses down hard.",
+			message = "[pick(list("plants their [get_shoes()] ontop of [partner]'s face.", 
+				"rests their [get_shoes()] on [partner]'s face and presses down hard.", 
 				"harshly places their [get_shoes()] atop [partner]'s face."))]</span>"
 		else
-			message = "[pick(list("plants their bare feet ontop of [partner]'s face.",
-				"rests their feet on [partner]'s face, smothering them.",
+			message = "[pick(list("plants their bare feet ontop of [partner]'s face.", 
+				"rests their feet on [partner]'s face, smothering them.", 
 				"positions their bare feet atop [partner]'s face."))]</span>"
 
 		set_is_fucking(partner , GRINDING_FACE_WITH_FEET)
@@ -707,31 +689,31 @@
 
 	if(is_fucking(partner, GRINDING_MOUTH_WITH_FEET))
 		if(src.get_item_by_slot(SLOT_SHOES) != null)
-			message = "[pick(list("roughly shoves their [get_shoes()] deeper into [partner]'s mouth.",
-				"harshly forces another inch of their [get_shoes()] into [partner]'s mouth.",
+			message = "[pick(list("roughly shoves their [get_shoes()] deeper into [partner]'s mouth.", 
+				"harshly forces another inch of their [get_shoes()] into [partner]'s mouth.", 
 				"presses their weight down, their [get_shoes()] prying deeper into [partner]'s mouth."))]</span>"
 		else
-			message = "[pick(list("wiggles their toes deep inside [partner]'s mouth.",
+			message = "[pick(list("wiggles their toes deep inside [partner]'s mouth.", 
 				"crams their barefeet down deeper into [partner]'s mouth, making them gag.",
 				"roughly grinds their feet on [partner]'s tongue."))]</span>"
 
 	else if(is_fucking(partner, GRINDING_FACE_WITH_FEET))
 		if(src.get_item_by_slot(SLOT_SHOES) != null)
-			message = "[pick(list("decides to force their [get_shoes()] deep into [partner]'s mouth.",
+			message = "[pick(list("decides to force their [get_shoes()] deep into [partner]'s mouth.", 
 				"pressed the tip of their [get_shoes()] against [partner]'s lips and shoves inwards."))]</span>"
 		else
-			message = "[pick(list("pries open [partner]'s mouth with their toes and shoves their bare foot in.",
+			message = "[pick(list("pries open [partner]'s mouth with their toes and shoves their bare foot in.", 
 				"presses down their foot even harder, cramming their foot into [partner]'s mouth."))]</span>"
 
 		set_is_fucking(partner , GRINDING_MOUTH_WITH_FEET)
 
 	else
 		if(src.get_item_by_slot(SLOT_SHOES) != null)
-			message = "[pick(list("readies themselves and in one swift motion, shoves their [get_shoes()] into [partner]'s mouth.",
+			message = "[pick(list("readies themselves and in one swift motion, shoves their [get_shoes()] into [partner]'s mouth.", 
 				"grinds the tip of their [get_shoes()] against [partner]'s mouth before pushing themselves in."))]</span>"
 		else
-			message = "[pick(list("rubs their dirty bare feet across [partner]'s face before prying them into their muzzle.",
-				"forces their barefeet into [partner]'s mouth.",
+			message = "[pick(list("rubs their dirty bare feet across [partner]'s face before prying them into their muzzle.", 
+				"forces their barefeet into [partner]'s mouth.", 
 				"covers [partner]'s mouth and nose with their foot until they gasp for breath, then shoves both feet inside before they can react."))]</span>"
 		set_is_fucking(partner , GRINDING_MOUTH_WITH_FEET)
 

--- a/interactions/lewd/lewd_datums.dm
+++ b/interactions/lewd/lewd_datums.dm
@@ -248,20 +248,6 @@
 /datum/interaction/lewd/mountass/display_interaction(mob/living/carbon/human/user, mob/living/carbon/human/target)
 	user.do_mountass(target)
 
-/datum/interaction/lewd/tribadism
-	command = "tribadism"
-	description = "Grind your pussy against theirs."
-	interaction_sound = null
-	require_target_vagina = TRUE
-	require_user_vagina = TRUE
-	user_not_tired = TRUE
-	require_user_bottomless = TRUE
-	require_target_bottomless = TRUE
-	max_distance = 0
-	
-/datum/interaction/lewd/tribadism/display_interaction(mob/living/carbon/human/user, mob/living/carbon/human/target)
-	user.do_tribadism(target)
-
 /datum/interaction/lewd/rimjob
 	command = "rimjob"
 	description = "Lick their ass."

--- a/interactions/lewd/lewd_interactions.dm
+++ b/interactions/lewd/lewd_interactions.dm
@@ -149,3 +149,25 @@
 	else
 		dat += "<br>...are clothed."
 	return dat
+//mob/living/silicon/proc/list_interaction_attributes()
+//	var/dat = ..()
+//	if(refactory_period)
+//		dat += "<br>...are sexually exhausted for the time being."
+//	if(a_intent == INTENT_HELP)
+//		dat += "<br>...are acting gentle."
+//	else if (a_intent == INTENT_DISARM)
+//		dat += "<br>...are acting playful."
+//	else if (a_intent == INTENT_GRAB)
+//		dat += "<br>...are acting rough."
+//	else if(a_intent == INTENT_HARM)
+//		dat += "<br>...are fighting anyone who comes near."
+//		if(has_breasts())
+//			dat += "<br>...have breasts."
+//		if(has_penis())
+//			dat += "<br>...have a penis."
+//		if(has_vagina())
+//			dat += "<br>...have a vagina."
+//		if(has_anus())
+//			dat += "<br>...have an anus."
+//	return dat
+//**^Can't figure this shit out, staying for someone else to figure it out or for me to wrap my mind around it - Moose/Bob^**//

--- a/interactions/lewd/objects.dm
+++ b/interactions/lewd/objects.dm
@@ -5,7 +5,7 @@
 	icon_state = "dildo_map"
 	item_state = "dildo"
 	throwforce = 0
-	force = 5
+	force = 0
 	w_class = WEIGHT_CLASS_SMALL
 	attack_verb = list("slammed", "bashed", "whipped")
 


### PR DESCRIPTION
The Pleasure Modules for cyborgs are not so useless now. They come equipped with a USEABLE inventory. Sadly, they can't interact much. I've made it so they can use the interaction drop down menu but they do not have any body parts like a vagina, breast, penis, ect.

The simplemobs being added or the "revamp ERP" hindered most of my abilities. Feel free to find out how to do what I couldn't.

Also, if you are planning to add onto this please note that only borgs can interact with humans while humans can't interact with the borgs. This may or may not be easily changeable. But the interactions are almost useless without the borgs having bodyparts.

Jesus I've done so many pull request for this.

Motivation and Context
I opened a issue quite a long time ago and I don't think it'll ever get fixed. #822

How Has This Been Tested?
I tested this on my own private server, tested inside the vault using both the modules on dummies.

Screenshots (if appropriate):
Changelog (neccesary)
🆑
add: Added new things
/🆑