### PR TITLE
Removes curses from masks

### DIFF
--- a/code/modules/clothing/masks/miscellaneous.dm
+++ b/code/modules/clothing/masks/miscellaneous.dm
@@ -68,7 +68,7 @@
 	icon_state = "joy"
 
 /obj/item/clothing/mask/joy/joyful
-	item_flags = NODROP
+	desc = "Express your happiness or hide your sorrows with this laughing face with crying tears of joy cutout. It seems happier than usual."
 
 /obj/item/clothing/mask/joy/joyful/equipped(mob/user, slot)
 	var/mob/living/carbon/C = user
@@ -78,7 +78,7 @@
 
 /obj/item/clothing/mask/pig
 	name = "pig mask"
-	desc = "A rubber pig mask."
+	desc = "It's a very stylish pig mask which seems to have a voice modulator built into it."
 	icon_state = "pig"
 	item_state = "pig"
 	flags_inv = HIDEFACE|HIDEHAIR|HIDEFACIALHAIR
@@ -97,13 +97,12 @@
 
 /obj/item/clothing/mask/spig //needs to be different otherwise you could turn the speedmodification off and on
 	name = "Pig face"
-	desc = "It looks like a mask, but closer inspection reveals it's melded onto this persons face!" //It's only ever going to be attached to your face.
+	desc = "It's a very stylish pig mask which seems to have a voice modulator built into it."
 	icon_state = "pig"
 	item_state = "pig"
 	flags_inv = HIDEFACE|HIDEHAIR|HIDEFACIALHAIR
 	w_class = WEIGHT_CLASS_SMALL
 	var/voicechange = 1
-	item_flags = NODROP
 
 /obj/item/clothing/mask/spig/speechModification(message)
 	if(voicechange)
@@ -133,7 +132,6 @@
 	return message
 
 /obj/item/clothing/mask/frog/cursed
-	item_flags = NODROP //reee!!
 
 /obj/item/clothing/mask/frog/cursed/attack_self(mob/user)
 	return //no voicebox to alter.
@@ -147,14 +145,13 @@
 
 /obj/item/clothing/mask/cowmask
 	name = "Cowface"
-	desc = "It looks like a mask, but closer inspection reveals it's melded onto this persons face!"
+	desc = "It's a very stylish cow mask which seems to have a voice modulator built into it."
 	icon = 'icons/mob/mask.dmi'
 	icon_state = "cowmask"
 	item_state = "cowmask"
 	flags_inv = HIDEFACE|HIDEHAIR|HIDEFACIALHAIR
 	w_class = WEIGHT_CLASS_SMALL
 	var/voicechange = 1
-	item_flags = NODROP
 
 /obj/item/clothing/mask/cowmask/speechModification(message)
 	if(voicechange)
@@ -169,7 +166,6 @@
 	flags_inv = HIDEFACE|HIDEHAIR|HIDEFACIALHAIR|HIDEEYES|HIDEEARS
 	w_class = WEIGHT_CLASS_SMALL
 	var/voicechange = 1
-	item_flags = NODROP
 
 /obj/item/clothing/mask/horsehead/speechModification(message)
 	if(voicechange)

--- a/tgstation.dme
+++ b/tgstation.dme
@@ -14,7 +14,6 @@
 
 // BEGIN_INCLUDE
 #include "_maps\_basemap.dm"
-#include "_maps\map_files\BoxStation\BoxStation.dmm"
 #include "code\_compile_options.dm"
 #include "code\world.dm"
 #include "code\__DEFINES\_globals.dm"


### PR DESCRIPTION
## Description
Cursed masks are dumb. They're no longer cursed to be nodrop.

## Motivation and Context
Cause they're dumb and cause problems.

## How Has This Been Tested?
Ayup.

## Screenshots (if appropriate):

## Changelog (neccesary)
:cl:
tweak: Cursed masks are no longer nodrop.
/:cl:
