### PR TITLE
Updates rulesurl

### DIFF
--- a/config/config.txt
+++ b/config/config.txt
@@ -222,7 +222,7 @@ CHECK_RANDOMIZER
 # WIKIURL https://www.patreon.com/baddeathclaw
 
 ## Rules address
-RULESURL https://pastebin.com/ETeb6x3D
+RULESURL  https://discord.gg/BbsYDrR
 
 
 ## Github address

--- a/config/config.txt
+++ b/config/config.txt
@@ -222,7 +222,7 @@ CHECK_RANDOMIZER
 # WIKIURL https://www.patreon.com/baddeathclaw
 
 ## Rules address
-RULESURL  https://discord.gg/BbsYDrR
+RULESURL https://discord.gg/BbsYDrR
 
 
 ## Github address


### PR DESCRIPTION
Makes the rules button link to the discord, rather than having two separate places for the rules

Also because apparently skipped over the vault rules in the pastebin and no one brought this up until five minutes ago