### PR TITLE
Makes sentient ghouls not unplayable.

### DIFF
--- a/code/modules/mob/living/carbon/human/species_types/ghoul.dm
+++ b/code/modules/mob/living/carbon/human/species_types/ghoul.dm
@@ -6,6 +6,7 @@
 	inherent_traits = list(TRAIT_RADIMMUNE)
 	inherent_biotypes = list(MOB_INORGANIC, MOB_HUMANOID)
 	armor = -25 // very weak fag 100-25 = 85hp + the weak limbs is a big oof!
+	burnmod = 0.25 // Leather skinless boys
 	brutemod = 1.2 //weaker fags
 	punchdamagehigh = 0
 	punchstunthreshold = 6

--- a/code/modules/mob/living/carbon/human/species_types/ghoul.dm
+++ b/code/modules/mob/living/carbon/human/species_types/ghoul.dm
@@ -1,6 +1,7 @@
 /datum/species/ghoul
 	name = "Ghoul"
 	id = "ghoul"
+	say_mod = "rasps"
 	limbs_id = "ghoul"
 	species_traits = list(HAIR,FACEHAIR)
 	inherent_traits = list(TRAIT_RADIMMUNE)

--- a/code/modules/mob/living/carbon/human/species_types/ghoul.dm
+++ b/code/modules/mob/living/carbon/human/species_types/ghoul.dm
@@ -6,13 +6,11 @@
 	inherent_traits = list(TRAIT_RADIMMUNE)
 	inherent_biotypes = list(MOB_INORGANIC, MOB_HUMANOID)
 	armor = -25 // very weak fag 100-25 = 85hp + the weak limbs is a big oof!
-	speedmod = 0.5 //little slow
-	burnmod = 0.25 // Leather skinless boys
 	brutemod = 1.2 //weaker fags
 	punchdamagehigh = 0
 	punchstunthreshold = 6
 	use_skintones = 0
-	sexes = 1 
+	sexes = 1
 	disliked_food = GROSS
 	liked_food = JUNKFOOD | FRIED | RAW
 


### PR DESCRIPTION
Maybe making a species move at half the speed of everyone else wasn't a great idea.
**Raspy boys.**
:cl:
balance: Removed sentient ghouls' 0.5x speed modifier.
add: Gives ghouls a **raspy** say_mod.
/:cl:
