### PR TITLE
Removes Autosurgeon and Medbeam from RND

### DIFF
--- a/code/modules/research/designs/medical_designs.dm
+++ b/code/modules/research/designs/medical_designs.dm
@@ -2,7 +2,7 @@
 ////////////Medical Tools////////////////
 /////////////////////////////////////////
 
-/datum/design/medbeam
+/* /datum/design/medbeam
 	name = "Medbeam Gun"
 	desc = "DONT CROSS THE DAMM BEAMS!"
 	id = "medbeam"
@@ -12,8 +12,9 @@
 	build_path = /obj/item/gun/medbeam
 	category = list("Misc", "Medical Designs")
 	departmental_flags = DEPARTMENTAL_FLAG_MEDICAL
+*/
 
-/datum/design/autosurgeon
+/* /datum/design/autosurgeon
 	name = "Autosurgeon"
 	desc = "Automatically implants things inside of it."
 	id = "autosurgeon"
@@ -23,6 +24,7 @@
 	build_path = /obj/item/autosurgeon
 	category = list("Misc", "Medical Designs")
 	departmental_flags = DEPARTMENTAL_FLAG_MEDICAL
+*/
 
 /datum/design/mmi
 	name = "Man-Machine Interface"

--- a/code/modules/research/designs/medical_designs.dm
+++ b/code/modules/research/designs/medical_designs.dm
@@ -2,7 +2,7 @@
 ////////////Medical Tools////////////////
 /////////////////////////////////////////
 
-/* /datum/design/medbeam
+ /datum/design/medbeam
 	name = "Medbeam Gun"
 	desc = "DONT CROSS THE DAMM BEAMS!"
 	id = "medbeam"
@@ -12,9 +12,8 @@
 	build_path = /obj/item/gun/medbeam
 	category = list("Misc", "Medical Designs")
 	departmental_flags = DEPARTMENTAL_FLAG_MEDICAL
-*/
 
-/* /datum/design/autosurgeon
+ /datum/design/autosurgeon
 	name = "Autosurgeon"
 	desc = "Automatically implants things inside of it."
 	id = "autosurgeon"
@@ -24,7 +23,7 @@
 	build_path = /obj/item/autosurgeon
 	category = list("Misc", "Medical Designs")
 	departmental_flags = DEPARTMENTAL_FLAG_MEDICAL
-*/
+
 
 /datum/design/mmi
 	name = "Man-Machine Interface"

--- a/code/modules/research/techweb/all_nodes.dm
+++ b/code/modules/research/techweb/all_nodes.dm
@@ -27,7 +27,7 @@
 	display_name = "Advanced Biotechnology"
 	description = "Advanced Biotechnology"
 	prereq_ids = list("biotech")
-	design_ids = list("piercesyringe", "smoke_machine", "limbgrower", "defibrillator", "meta_beaker", "medbeam", "virusmaker")
+	design_ids = list("piercesyringe", "smoke_machine", "limbgrower", "defibrillator", "meta_beaker", "virusmaker")
 	research_costs = list(TECHWEB_POINT_TYPE_GENERIC = 2500)
 	export_price = 5000
 
@@ -791,7 +791,7 @@
 	display_name = "Advanced Biological Tools"
 	description = "Advanced biological tools."
 	prereq_ids = list("alientech", "adv_biotech")
-	design_ids = list("alien_scalpel", "alien_hemostat", "alien_retractor", "alien_saw", "alien_drill", "alien_cautery", "autosurgeon")
+	design_ids = list("alien_scalpel", "alien_hemostat", "alien_retractor", "alien_saw", "alien_drill", "alien_cautery")
 	research_costs = list(TECHWEB_POINT_TYPE_GENERIC = 2500)
 	export_price = 20000
 


### PR DESCRIPTION

## Description
Removes the Autosurgeon and Medbeam from RnD - doesn't touch the items themselves or any possible map spawns, just means you cannot research and print them.

While the items were removed from the tech web, the designs themselves has simply been commented out in case they're needed in the future.

## Motivation and Context
Requested by Ren, and I agree as well. 

The Autosurgeon allows someone (Vault and BoS, at present) to load themselves up with a bunch of fancy implants without any surgery, as if surgery wasn't critically under-used already. You can still aug yourself up, you just need a competent doctor to help you.

The Medbeam gun was infinite free heals, and using our simpler medical system it means that you can heal someone up from basically anything but being _dead_ with no limit of any kind. Make medicine instead, ya bums.

## How Has This Been Tested?
Tested on local server


## Changelog (neccesary)
:cl:
tweak: Removed Medbeam and Autosurgeon from RnD
/:cl:
