### PR TITLE
Stun balance

### DIFF
--- a/code/game/objects/items/clown_items.dm
+++ b/code/game/objects/items/clown_items.dm
@@ -29,7 +29,7 @@
 
 /obj/item/soap/Initialize()
 	. = ..()
-	AddComponent(/datum/component/slippery, 80)
+	AddComponent(/datum/component/slippery, 3 SECONDS)
 
 /obj/item/soap/nanotrasen
 	desc = "A Nanotrasen brand bar of soap. Smells of plasma."

--- a/code/game/objects/items/handcuffs.dm
+++ b/code/game/objects/items/handcuffs.dm
@@ -347,7 +347,7 @@
 	desc = "A strong bola, made with a long steel chain. It looks heavy, enough so that it could trip somebody."
 	icon_state = "bola_r"
 	breakouttime = 3 SECONDS //quick to remove
-	knockdown = 2 SECONDS
+	knockdown = 1 SECONDS
 
 /obj/item/restraints/legcuffs/bola/energy //For Security
 	name = "energy bola"

--- a/code/game/objects/items/handcuffs.dm
+++ b/code/game/objects/items/handcuffs.dm
@@ -320,7 +320,7 @@
 	name = "bola"
 	desc = "A restraining device designed to be thrown at the target. Upon connecting with said target, it will wrap around their legs, making it difficult for them to move quickly."
 	icon_state = "bola"
-	breakouttime = 45//easy to apply, easy to break out of
+	breakouttime = 6 SECONDS //no stun, harder to remove
 	gender = NEUTER
 	var/knockdown = 0
 
@@ -346,8 +346,8 @@
 	name = "reinforced bola"
 	desc = "A strong bola, made with a long steel chain. It looks heavy, enough so that it could trip somebody."
 	icon_state = "bola_r"
-	breakouttime = 70
-	knockdown = 20
+	breakouttime = 3 SECONDS //quick to remove
+	knockdown = 2 SECONDS
 
 /obj/item/restraints/legcuffs/bola/energy //For Security
 	name = "energy bola"

--- a/code/modules/hydroponics/plant_genes.dm
+++ b/code/modules/hydroponics/plant_genes.dm
@@ -184,7 +184,7 @@
 	// Makes plant slippery, unless it has a grown-type trash. Then the trash gets slippery.
 	// Applies other trait effects (teleporting, etc) to the target by on_slip.
 	name = "Slippery Skin"
-	rate = 1.6
+	rate = 0.8 //Down from /tg/'s 1.6
 	examine_line = "<span class='info'>It has a very slippery skin.</span>"
 
 /datum/plant_gene/trait/slip/on_new(obj/item/reagent_containers/food/snacks/grown/G, newloc)
@@ -197,7 +197,7 @@
 	if(!istype(G, /obj/item/grown/bananapeel) && (!G.reagents || !G.reagents.has_reagent("lube")))
 		stun_len /= 3
 
-	G.AddComponent(/datum/component/slippery, min(stun_len,140), NONE, CALLBACK(src, .proc/handle_slip, G))
+	G.AddComponent(/datum/component/slippery, min(stun_len, 7 SECONDS), NONE, CALLBACK(src, .proc/handle_slip, G))
 
 /datum/plant_gene/trait/slip/proc/handle_slip(obj/item/reagent_containers/food/snacks/grown/G, mob/M)
 	for(var/datum/plant_gene/trait/T in G.seed.genes)


### PR DESCRIPTION
## Changelog (neccesary)
:cl:
balance: Soap stun time reduced from 8 to 3 seconds.
balance: Regular bolas take 6 instead of 4.5 seconds to be removed. No stun, hard to remove.
balance: Reinforced bolas stun for 1 second instead of 2, and take 3 seconds to be removed instead of 7. Short stun, easy to remove, hopefully viable now.
balance: All slippery plants, like bananas, have their slippery gene power halved, so will also suffer shorter stuns. A banana can reach up to 7 seconds of stun at maximum potency.
/:cl: