### PR TITLE
Assorted issues fixes.

### DIFF
--- a/code/__HELPERS/unsorted.dm
+++ b/code/__HELPERS/unsorted.dm
@@ -1630,8 +1630,6 @@ proc/childtypesof()
 			types -= typesof(t) - t
 		. += types
 
-#define islist(x) istype(x, /list)
-
 //In which we let it just generate new instances.
 proc/newchildtypesof()
 	var/prevtypes[]

--- a/code/controllers/configuration/configuration.dm
+++ b/code/controllers/configuration/configuration.dm
@@ -24,7 +24,7 @@
 	if(_directory)
 		directory = _directory
 	if(entries)
-		CRASH("[THIS_PROC_TYPE_WEIRD] called more than once!")
+		CRASH("/datum/controller/configuration/Load() called more than once!")
 	InitEntries()
 	LoadModes()
 	if(fexists("[directory]/config.txt") && LoadEntries("config.txt") <= 1)

--- a/code/datums/position_point_vector.dm
+++ b/code/datums/position_point_vector.dm
@@ -7,7 +7,7 @@
 #define RETURN_PRECISE_POINT(A) new /datum/point(A)
 
 #define RETURN_POINT_VECTOR(ATOM, ANGLE, SPEED) {new /datum/point/vector(ATOM, null, null, null, null, ANGLE, SPEED)}
-#define RETURN_POINT_VECTOR_INCREMENT(ATOM, ANGLE, SPEED, AMT) {new /datum/point/vector(ATOM, null, null, null, null, ANGLE, SPEED, AMT)}
+#define RETURN_POINT_VECTOR_INCREMENT(ATOM, ANGLE, SPEED, AMT) (new /datum/point/vector(ATOM, null, null, null, null, ANGLE, SPEED, AMT))
 
 /proc/point_midpoint_points(datum/point/a, datum/point/b)	//Obviously will not support multiZ calculations! Same for the two below.
 	var/datum/point/P = new

--- a/code/game/machinery/computer/apc_control.dm
+++ b/code/game/machinery/computer/apc_control.dm
@@ -137,7 +137,7 @@
 		active_apc = APC
 	if(href_list["name_filter"])
 		playsound(src, 'sound/machines/terminal_prompt.ogg', 50, 0)
-		var/new_filter = stripped_input(usr, "What name are you looking for?", name) as null|text
+		var/new_filter = stripped_input(usr, "What name are you looking for?", name)
 		if(!src || !usr || !usr.canUseTopic(src) || stat || QDELETED(src))
 			return
 		log_activity("changed name filter to \"[new_filter]\"")

--- a/code/game/machinery/computer/launchpad_control.dm
+++ b/code/game/machinery/computer/launchpad_control.dm
@@ -128,7 +128,7 @@
 		pad.x_offset = 0
 
 	if(href_list["change_name"])
-		var/new_name = stripped_input(usr, "What do you wish to name the launchpad?", "Launchpad", pad.display_name, 15) as text|null
+		var/new_name = stripped_input(usr, "What do you wish to name the launchpad?", "Launchpad", pad.display_name, 15)
 		if(!new_name)
 			return
 		pad.display_name = new_name

--- a/code/game/machinery/doors/airlock.dm
+++ b/code/game/machinery/doors/airlock.dm
@@ -414,7 +414,7 @@
 	if(!prob(prb))
 		return FALSE //you lucked out, no shock for you
 	do_sparks(5, TRUE, src)
-	var/tmp/check_range = TRUE
+	var/check_range = TRUE
 	if(electrocute_mob(user, get_area(src), src, 1, check_range))
 		shockCooldown = world.time + 10
 		return TRUE

--- a/code/game/machinery/newscaster.dm
+++ b/code/game/machinery/newscaster.dm
@@ -298,7 +298,7 @@ GLOBAL_LIST_EMPTY(allCasters)
 						if(CHANNEL.is_admin_channel)
 							dat+="<B><FONT style='BACKGROUND-COLOR: LightGreen '><A href='?src=[REF(src)];show_channel=[REF(CHANNEL)]'>[CHANNEL.channel_name]</A></FONT></B><BR>"
 						else
-							dat+="<B><A href='?src=[REF(src)];show_channel=[REF(CHANNEL)]'>[CHANNEL.channel_name]</A> [(CHANNEL.censored) ? ("<FONT COLOR='red'>***</FONT>") : ()]<BR></B>"
+							dat+="<B><A href='?src=[REF(src)];show_channel=[REF(CHANNEL)]'>[CHANNEL.channel_name]</A> [(CHANNEL.censored) ? ("<FONT COLOR='red'>***</FONT>") : ""]<BR></B>"
 				dat+="<BR><HR><A href='?src=[REF(src)];refresh=1'>Refresh</A>"
 				dat+="<BR><A href='?src=[REF(src)];setScreen=[0]'>Back</A>"
 			if(2)
@@ -403,7 +403,7 @@ GLOBAL_LIST_EMPTY(allCasters)
 					dat+="<I>No feed channels found active...</I><BR>"
 				else
 					for(var/datum/newscaster/feed_channel/CHANNEL in GLOB.news_network.network_channels)
-						dat+="<A href='?src=[REF(src)];pick_censor_channel=[REF(CHANNEL)]'>[CHANNEL.channel_name]</A> [(CHANNEL.censored) ? ("<FONT COLOR='red'>***</FONT>") : ()]<BR>"
+						dat+="<A href='?src=[REF(src)];pick_censor_channel=[REF(CHANNEL)]'>[CHANNEL.channel_name]</A> [(CHANNEL.censored) ? ("<FONT COLOR='red'>***</FONT>") : ""]<BR>"
 				dat+="<BR><A href='?src=[REF(src)];setScreen=[0]'>Cancel</A>"
 			if(11)
 				dat+="<B>Nanotrasen D-Notice Handler</B><HR>"
@@ -414,7 +414,7 @@ GLOBAL_LIST_EMPTY(allCasters)
 					dat+="<I>No feed channels found active...</I><BR>"
 				else
 					for(var/datum/newscaster/feed_channel/CHANNEL in GLOB.news_network.network_channels)
-						dat+="<A href='?src=[REF(src)];pick_d_notice=[REF(CHANNEL)]'>[CHANNEL.channel_name]</A> [(CHANNEL.censored) ? ("<FONT COLOR='red'>***</FONT>") : ()]<BR>"
+						dat+="<A href='?src=[REF(src)];pick_d_notice=[REF(CHANNEL)]'>[CHANNEL.channel_name]</A> [(CHANNEL.censored) ? ("<FONT COLOR='red'>***</FONT>") : ""]<BR>"
 				dat+="<BR><A href='?src=[REF(src)];setScreen=[0]'>Back</A>"
 			if(12)
 				dat+="<B>[viewing_channel.channel_name]: </B><FONT SIZE=1>\[ created by: <FONT COLOR='maroon'>[viewing_channel.returnAuthor(-1)]</FONT> \]</FONT><BR>"

--- a/code/game/mecha/mecha_actions.dm
+++ b/code/game/mecha/mecha_actions.dm
@@ -265,7 +265,7 @@
 		if("fire")
 			new_damtype = "tox"
 			chassis.occupant_message("A bone-chillingly thick plasteel needle protracts from the exosuit's palm.")
-	chassis.damtype = new_damtype.
+	chassis.damtype = new_damtype
 	button_icon_state = "mech_damtype_[new_damtype]"
 	playsound(src, 'sound/mecha/mechmove01.ogg', 50, 1)
 	UpdateButtonIcon()

--- a/code/game/objects/items/candle.dm
+++ b/code/game/objects/items/candle.dm
@@ -110,7 +110,7 @@
 		if (do_after(user, 20, target=src))
 			qdel(src)
 			new /obj/structure/destructible/tribal_torch(get_turf(user))
-				light_color = LIGHT_COLOR_ORANGE
+			light_color = LIGHT_COLOR_ORANGE
 			user.visible_message("<span class='notice'>[user] plants \the [src] firmly in the ground.</span>", "<span class='notice'>You plant \the [src] firmly in the ground.</span>")
 			return
 	else if(lit)

--- a/code/game/objects/items/clown_items.dm
+++ b/code/game/objects/items/clown_items.dm
@@ -29,7 +29,7 @@
 
 /obj/item/soap/Initialize()
 	. = ..()
-	AddComponent(/datum/component/slippery, 80)
+	AddComponent(/datum/component/slippery, 3 SECONDS)
 
 /obj/item/soap/nanotrasen
 	desc = "A Nanotrasen brand bar of soap. Smells of plasma."

--- a/code/game/objects/items/handcuffs.dm
+++ b/code/game/objects/items/handcuffs.dm
@@ -347,7 +347,7 @@
 	desc = "A strong bola, made with a long steel chain. It looks heavy, enough so that it could trip somebody."
 	icon_state = "bola_r"
 	breakouttime = 3 SECONDS //quick to remove
-	knockdown = 2 SECONDS
+	knockdown = 1 SECONDS
 
 /obj/item/restraints/legcuffs/bola/energy //For Security
 	name = "energy bola"

--- a/code/game/objects/items/handcuffs.dm
+++ b/code/game/objects/items/handcuffs.dm
@@ -320,7 +320,7 @@
 	name = "bola"
 	desc = "A restraining device designed to be thrown at the target. Upon connecting with said target, it will wrap around their legs, making it difficult for them to move quickly."
 	icon_state = "bola"
-	breakouttime = 45//easy to apply, easy to break out of
+	breakouttime = 6 SECONDS //no stun, harder to remove
 	gender = NEUTER
 	var/knockdown = 0
 
@@ -346,8 +346,8 @@
 	name = "reinforced bola"
 	desc = "A strong bola, made with a long steel chain. It looks heavy, enough so that it could trip somebody."
 	icon_state = "bola_r"
-	breakouttime = 70
-	knockdown = 20
+	breakouttime = 3 SECONDS //quick to remove
+	knockdown = 2 SECONDS
 
 /obj/item/restraints/legcuffs/bola/energy //For Security
 	name = "energy bola"

--- a/code/game/objects/items/handcuffs.dm
+++ b/code/game/objects/items/handcuffs.dm
@@ -320,7 +320,7 @@
 	name = "bola"
 	desc = "A restraining device designed to be thrown at the target. Upon connecting with said target, it will wrap around their legs, making it difficult for them to move quickly."
 	icon_state = "bola"
-	breakouttime = 6 SECONDS //no stun, harder to remove
+	breakouttime = 45//easy to apply, easy to break out of
 	gender = NEUTER
 	var/knockdown = 0
 
@@ -346,8 +346,8 @@
 	name = "reinforced bola"
 	desc = "A strong bola, made with a long steel chain. It looks heavy, enough so that it could trip somebody."
 	icon_state = "bola_r"
-	breakouttime = 3 SECONDS //quick to remove
-	knockdown = 1 SECONDS
+	breakouttime = 70
+	knockdown = 20
 
 /obj/item/restraints/legcuffs/bola/energy //For Security
 	name = "energy bola"

--- a/code/game/objects/items/stacks/f13Cash.dm
+++ b/code/game/objects/items/stacks/f13Cash.dm
@@ -1,10 +1,10 @@
 #define maxCoinIcon 6
-#define CAP 1
+#define CASH_CAP 1
 
 /* exchange rates X * CAP*/
-#define AUR 100 /* 100 caps to 1 AUR */
-#define DEN 4 /* 4 caps to 1 DEN */
-#define NCR 0.4 /* $100 to 40 caps */
+#define CASH_AUR 100 /* 100 caps to 1 AUR */
+#define CASH_DEN 4 /* 4 caps to 1 DEN */
+#define CASH_NCR 0.4 /* $100 to 40 caps */
 
 /* value of coins to spawn, use as-is for caps */
 /* LOW_MIN / AUR = amount in AUR */
@@ -35,7 +35,7 @@
 	full_w_class = WEIGHT_CLASS_TINY
 	resistance_flags = FLAMMABLE
 	var/flavor_desc = ""
-	var/value = CAP
+	var/value = CASH_CAP
 
 /obj/item/stack/f13Cash/Initialize()
 	. = ..()
@@ -96,16 +96,16 @@
 	qdel(src)
 
 /obj/item/stack/f13Cash/random/bottle_cap/low
-	min_qty = LOW_MIN / CAP
-	max_qty = LOW_MAX / CAP
+	min_qty = LOW_MIN / CASH_CAP
+	max_qty = LOW_MAX / CASH_CAP
 
 /obj/item/stack/f13Cash/random/bottle_cap/med
-	min_qty = MED_MIN / CAP
-	max_qty = MED_MAX / CAP
+	min_qty = MED_MIN / CASH_CAP
+	max_qty = MED_MAX / CASH_CAP
 
 /obj/item/stack/f13Cash/random/bottle_cap/high
-	min_qty = HIGH_MIN / CAP
-	max_qty = HIGH_MAX / CAP
+	min_qty = HIGH_MIN / CASH_CAP
+	max_qty = HIGH_MAX / CASH_CAP
 
 /obj/item/stack/f13Cash/denarius
 	name = "Denarius"
@@ -116,7 +116,7 @@
 	flavor_desc =	"The inscriptions are in Latin,\n\
 		'Caesar Dictator' on the front and\n\
 		'Magnum Chasma' on the back."
-	value = DEN * CAP
+	value = CASH_DEN * CASH_CAP
 
 /obj/item/stack/f13Cash/random/denarius/Initialize()
 	var/obj/item/stack/f13Cash/denarius/R = new
@@ -126,16 +126,16 @@
 	qdel(src)
 
 /obj/item/stack/f13Cash/random/denarius/low
-	min_qty = LOW_MIN / DEN
-	max_qty = LOW_MAX / DEN
+	min_qty = LOW_MIN / CASH_DEN
+	max_qty = LOW_MAX / CASH_DEN
 
 /obj/item/stack/f13Cash/random/denarius/med
-	min_qty = MED_MIN / DEN
-	max_qty = MED_MAX / DEN
+	min_qty = MED_MIN / CASH_DEN
+	max_qty = MED_MAX / CASH_DEN
 
 /obj/item/stack/f13Cash/random/denarius/high
-	min_qty = HIGH_MIN / DEN
-	max_qty = HIGH_MAX / DEN
+	min_qty = HIGH_MIN / CASH_DEN
+	max_qty = HIGH_MAX / CASH_DEN
 
 /obj/item/stack/f13Cash/random/denarius/legionpay_basic
 	min_qty = 1
@@ -158,7 +158,7 @@
 	flavor_desc = 	"The inscriptions are in Latin,\n\
 					'Aeternit Imperi' on the front and\n\
 					'Pax Per Bellum' on the back."
-	value = AUR * CAP
+	value = CASH_AUR * CASH_CAP
 
 /obj/item/stack/f13Cash/random/aureus/Initialize()
 	var/obj/item/stack/f13Cash/aureus/R = new
@@ -184,7 +184,7 @@
 	singular_name = "NCR Dollar"  /* same for denarius, we can pretend the legion can't latin properly */
 	icon = 'icons/obj/economy.dmi'
 	icon_state = "ncr" /* 10 points to whoever writes flavour text for each bill */
-	value = NCR * CAP
+	value = CASH_NCR * CASH_CAP
 
 /obj/item/stack/f13Cash/ncr/update_icon()
 	switch(amount)
@@ -211,16 +211,16 @@
 	qdel(src)
 
 /obj/item/stack/f13Cash/random/ncr/low
-	min_qty = LOW_MIN / NCR
-	max_qty = LOW_MAX / NCR
+	min_qty = LOW_MIN / CASH_NCR
+	max_qty = LOW_MAX / CASH_NCR
 
 /obj/item/stack/f13Cash/random/ncr/med
-	min_qty = MED_MIN / NCR
-	max_qty = MED_MAX / NCR
+	min_qty = MED_MIN / CASH_NCR
+	max_qty = MED_MAX / CASH_NCR
 
 /obj/item/stack/f13Cash/random/ncr/high
-	min_qty = HIGH_MIN / NCR
-	max_qty = HIGH_MAX / NCR
+	min_qty = HIGH_MIN / CASH_NCR
+	max_qty = HIGH_MAX / CASH_NCR
 
 /obj/item/stack/f13Cash/random/ncr/ncrpay_basic
 	min_qty = 10
@@ -235,10 +235,10 @@
 	max_qty = 400
 
 #undef maxCoinIcon
-#undef CAP
-#undef AUR
-#undef DEN
-#undef NCR
+#undef CASH_CAP
+#undef CASH_AUR
+#undef CASH_DEN
+#undef CASH_NCR
 #undef LOW_MIN
 #undef LOW_MAX
 #undef MED_MIN

--- a/code/game/objects/items/stacks/stack.dm
+++ b/code/game/objects/items/stacks/stack.dm
@@ -139,7 +139,7 @@
 		if (istype(E, /datum/stack_recipe))
 			var/datum/stack_recipe/R = E
 			var/max_multiplier = round(get_amount() / R.req_amount)
-			var/title as text
+			var/title
 			var/can_build = 1
 			can_build = can_build && (max_multiplier>0)
 

--- a/code/modules/admin/admin.dm
+++ b/code/modules/admin/admin.dm
@@ -239,7 +239,7 @@
 					if(CHANNEL.is_admin_channel)
 						dat+="<B><FONT style='BACKGROUND-COLOR: LightGreen'><A href='?src=[REF(src)];ac_show_channel=[REF(CHANNEL)]'>[CHANNEL.channel_name]</A></FONT></B><BR>"
 					else
-						dat+="<B><A href='?src=[REF(src)];[HrefToken()];ac_show_channel=[REF(CHANNEL)]'>[CHANNEL.channel_name]</A> [(CHANNEL.censored) ? ("<FONT COLOR='red'>***</FONT>") : ()]<BR></B>"
+						dat+="<B><A href='?src=[REF(src)];[HrefToken()];ac_show_channel=[REF(CHANNEL)]'>[CHANNEL.channel_name]</A> [(CHANNEL.censored) ? ("<FONT COLOR='red'>***</FONT>") : ""]<BR></B>"
 			dat+="<BR><HR><A href='?src=[REF(src)];[HrefToken()];ac_refresh=1'>Refresh</A>"
 			dat+="<BR><A href='?src=[REF(src)];[HrefToken()];ac_setScreen=[0]'>Back</A>"
 		if(2)
@@ -311,7 +311,7 @@
 				dat+="<I>No feed channels found active...</I><BR>"
 			else
 				for(var/datum/newscaster/feed_channel/CHANNEL in GLOB.news_network.network_channels)
-					dat+="<A href='?src=[REF(src)];[HrefToken()];ac_pick_censor_channel=[REF(CHANNEL)]'>[CHANNEL.channel_name]</A> [(CHANNEL.censored) ? ("<FONT COLOR='red'>***</FONT>") : ()]<BR>"
+					dat+="<A href='?src=[REF(src)];[HrefToken()];ac_pick_censor_channel=[REF(CHANNEL)]'>[CHANNEL.channel_name]</A> [(CHANNEL.censored) ? ("<FONT COLOR='red'>***</FONT>") : ""]<BR>"
 			dat+="<BR><A href='?src=[REF(src)];[HrefToken()];ac_setScreen=[0]'>Cancel</A>"
 		if(11)
 			dat+="<B>Nanotrasen D-Notice Handler</B><HR>"
@@ -322,7 +322,7 @@
 				dat+="<I>No feed channels found active...</I><BR>"
 			else
 				for(var/datum/newscaster/feed_channel/CHANNEL in GLOB.news_network.network_channels)
-					dat+="<A href='?src=[REF(src)];[HrefToken()];ac_pick_d_notice=[REF(CHANNEL)]'>[CHANNEL.channel_name]</A> [(CHANNEL.censored) ? ("<FONT COLOR='red'>***</FONT>") : ()]<BR>"
+					dat+="<A href='?src=[REF(src)];[HrefToken()];ac_pick_d_notice=[REF(CHANNEL)]'>[CHANNEL.channel_name]</A> [(CHANNEL.censored) ? ("<FONT COLOR='red'>***</FONT>") : ""]<BR>"
 
 			dat+="<BR><A href='?src=[REF(src)];[HrefToken()];ac_setScreen=[0]'>Back</A>"
 		if(12)

--- a/code/modules/events/holiday/vday.dm
+++ b/code/modules/events/holiday/vday.dm
@@ -160,7 +160,7 @@
                 "A heart-shaped candy that reads: ERP",
                 "A heart-shaped candy that reads: LEWD",
                 "A heart-shaped candy that reads: LUSTY",
-                "A heart-shaped candy that reads: SPESS LOVE"
+                "A heart-shaped candy that reads: SPESS LOVE",
                 "A heart-shaped candy that reads: AYY LMAO",
                 "A heart-shaped candy that reads: TABLE ME",
                 "A heart-shaped candy that reads: HAND CUFFS",

--- a/code/modules/hydroponics/plant_genes.dm
+++ b/code/modules/hydroponics/plant_genes.dm
@@ -184,7 +184,7 @@
 	// Makes plant slippery, unless it has a grown-type trash. Then the trash gets slippery.
 	// Applies other trait effects (teleporting, etc) to the target by on_slip.
 	name = "Slippery Skin"
-	rate = 0.8 //Down from /tg/'s 1.6
+	rate = 1.6
 	examine_line = "<span class='info'>It has a very slippery skin.</span>"
 
 /datum/plant_gene/trait/slip/on_new(obj/item/reagent_containers/food/snacks/grown/G, newloc)
@@ -197,7 +197,7 @@
 	if(!istype(G, /obj/item/grown/bananapeel) && (!G.reagents || !G.reagents.has_reagent("lube")))
 		stun_len /= 3
 
-	G.AddComponent(/datum/component/slippery, min(stun_len, 7 SECONDS), NONE, CALLBACK(src, .proc/handle_slip, G))
+	G.AddComponent(/datum/component/slippery, min(stun_len,140), NONE, CALLBACK(src, .proc/handle_slip, G))
 
 /datum/plant_gene/trait/slip/proc/handle_slip(obj/item/reagent_containers/food/snacks/grown/G, mob/M)
 	for(var/datum/plant_gene/trait/T in G.seed.genes)

--- a/code/modules/hydroponics/plant_genes.dm
+++ b/code/modules/hydroponics/plant_genes.dm
@@ -184,7 +184,7 @@
 	// Makes plant slippery, unless it has a grown-type trash. Then the trash gets slippery.
 	// Applies other trait effects (teleporting, etc) to the target by on_slip.
 	name = "Slippery Skin"
-	rate = 1.6
+	rate = 0.8 //Down from /tg/'s 1.6
 	examine_line = "<span class='info'>It has a very slippery skin.</span>"
 
 /datum/plant_gene/trait/slip/on_new(obj/item/reagent_containers/food/snacks/grown/G, newloc)
@@ -197,7 +197,7 @@
 	if(!istype(G, /obj/item/grown/bananapeel) && (!G.reagents || !G.reagents.has_reagent("lube")))
 		stun_len /= 3
 
-	G.AddComponent(/datum/component/slippery, min(stun_len,140), NONE, CALLBACK(src, .proc/handle_slip, G))
+	G.AddComponent(/datum/component/slippery, min(stun_len, 7 SECONDS), NONE, CALLBACK(src, .proc/handle_slip, G))
 
 /datum/plant_gene/trait/slip/proc/handle_slip(obj/item/reagent_containers/food/snacks/grown/G, mob/M)
 	for(var/datum/plant_gene/trait/T in G.seed.genes)

--- a/code/modules/jobs/job_types/legion.dm
+++ b/code/modules/jobs/job_types/legion.dm
@@ -25,7 +25,7 @@
 	if(H.gender == FEMALE)
 		H.gender = MALE
 		H.real_name = random_unique_name(MALE)
-			H.name = H.real_name
+		H.name = H.real_name
 	if(H.real_name == ("Biggus Dickus" || "Bigus Dickus"))
 		H.real_name = "Minimae Coles"
 		H.name = "Minimae Coles"

--- a/code/modules/mob/living/carbon/alien/larva/powers.dm
+++ b/code/modules/mob/living/carbon/alien/larva/powers.dm
@@ -15,7 +15,7 @@
 						"<span class='noticealien'>You are now hiding.</span>")
 	else
 		user.layer = MOB_LAYER
-		user.visible_message("[user.] slowly peeks up from the ground...", \
+		user.visible_message("[user] slowly peeks up from the ground...", \
 					"<span class='noticealien'>You stop hiding.</span>")
 	return 1
 

--- a/code/modules/mob/living/carbon/human/species.dm
+++ b/code/modules/mob/living/carbon/human/species.dm
@@ -601,15 +601,15 @@ GLOBAL_LIST_EMPTY(roundstart_races)
 				if("tail_lizard")
 					S = GLOB.tails_list_lizard[H.dna.features["tail_lizard"]]
 				if("waggingtail_lizard")
-					S.= GLOB.animated_tails_list_lizard[H.dna.features["tail_lizard"]]
+					S = GLOB.animated_tails_list_lizard[H.dna.features["tail_lizard"]]
 				if("tail_human")
 					S = GLOB.tails_list_human[H.dna.features["tail_human"]]
 				if("waggingtail_human")
-					S.= GLOB.animated_tails_list_human[H.dna.features["tail_human"]]
+					S = GLOB.animated_tails_list_human[H.dna.features["tail_human"]]
 				if("spines")
 					S = GLOB.spines_list[H.dna.features["spines"]]
 				if("waggingspines")
-					S.= GLOB.animated_spines_list[H.dna.features["spines"]]
+					S = GLOB.animated_spines_list[H.dna.features["spines"]]
 				if("snout")
 					S = GLOB.snouts_list[H.dna.features["snout"]]
 				if("frills")

--- a/code/modules/mob/living/say.dm
+++ b/code/modules/mob/living/say.dm
@@ -70,9 +70,8 @@ GLOBAL_LIST_INIT(department_radio_keys, list(
     if(chance >= 100)
         return original_msg
 
-    var/list
-        words = splittext(original_msg," ")
-        new_words = list()
+    var/list/words = splittext(original_msg," ")
+    var/list/new_words = list()
 
     var/new_msg = ""
 

--- a/code/modules/mob/living/simple_animal/bot/honkbot.dm
+++ b/code/modules/mob/living/simple_animal/bot/honkbot.dm
@@ -123,7 +123,7 @@ Maintenance panel panel is [open ? "opened" : "closed"]"},
 
 
 /mob/living/simple_animal/bot/honkbot/attackby(obj/item/W, mob/user, params)
-	if(istype(W, /obj/item/weldingtool) && user.a_intent != INTENT_HARM).
+	if(istype(W, /obj/item/weldingtool) && user.a_intent != INTENT_HARM)
 		return
 	if(!istype(W, /obj/item/screwdriver) && (W.force) && (!target) && (W.damtype != STAMINA) ) // Check for welding tool to fix #2432.
 		retaliate(user)

--- a/code/modules/vending/_vending.dm
+++ b/code/modules/vending/_vending.dm
@@ -538,7 +538,7 @@ IF YOU MODIFY THE PRODUCTS LIST OF A MACHINE, MAKE SURE TO UPDATE ITS RESUPPLY C
 	if(!prob(prb))
 		return FALSE
 	do_sparks(5, TRUE, src)
-	var/tmp/check_range = TRUE
+	var/check_range = TRUE
 	if(electrocute_mob(user, get_area(src), src, 0.7, check_range))
 		return TRUE
 	else


### PR DESCRIPTION
## Description
* Removed a duplicate definition.
* Removed type definitions without effect.
* Replaced the `()` which means nothing for a text-null as a return.
* Removed some `tmp` from vars that had no effect.
* Cleaned the cash definitions because `DEN` was being defined for both the Den job faction and the Denarius coin.
* Added a missing comma.
* Fixed some indentation.
* Removed some unlawful dots, replaced with spaces where applicable.
* Changed two vars to full paths.

In short, a little code cleanup because the issues were bothering me.