### PR TITLE
Drug opacity

### DIFF
--- a/code/datums/mood_events/drug_events.dm
+++ b/code/datums/mood_events/drug_events.dm
@@ -12,7 +12,7 @@
 	timeout = 3000
 
 /datum/mood_event/drugs/overdose/add_effects(drug_name)
-	description = "<span class='warning'>I think that dose was too high</span>\n"
+	description = "<span class='warning'>I feel saturated, that was too much</span>\n"
 
 /datum/mood_event/drugs/withdrawal_light
 	mood_change = -2

--- a/code/datums/mood_events/drug_events.dm
+++ b/code/datums/mood_events/drug_events.dm
@@ -12,25 +12,25 @@
 	timeout = 3000
 
 /datum/mood_event/drugs/overdose/add_effects(drug_name)
-	description = "<span class='warning'>I think I took a bit too much of that [drug_name]</span>\n"
+	description = "<span class='warning'>I think that dose was too high</span>\n"
 
 /datum/mood_event/drugs/withdrawal_light
 	mood_change = -2
 
 /datum/mood_event/drugs/withdrawal_light/add_effects(drug_name)
-	description = "<span class='warning'>I could use some [drug_name]</span>\n"
+	description = "<span class='warning'>I could use another dose</span>\n"
 
 /datum/mood_event/drugs/withdrawal_medium
 	mood_change = -5
 
 /datum/mood_event/drugs/withdrawal_medium/add_effects(drug_name)
-	description = "<span class='warning'>I really need [drug_name]</span>\n"
+	description = "<span class='warning'>I really need something to satisfy this craving</span>\n"
 
 /datum/mood_event/drugs/withdrawal_severe
 	mood_change = -8
 
 /datum/mood_event/drugs/withdrawal_severe/add_effects(drug_name)
-	description = "<span class='boldwarning'>Oh god I need some [drug_name]</span>\n"
+	description = "<span class='boldwarning'>Oh god I need a fix</span>\n"
 
 /datum/mood_event/drugs/withdrawal_critical
 	mood_change = -10


### PR DESCRIPTION
Makes the addiction messages a little more opaque to better represent the craving in a little less mechanical way (like when ODing on morphine by eating reishi). You'll still know the exact chem on the highest addiction level, though.