### PR TITLE
Removes raiders.

### DIFF
--- a/code/modules/jobs/job_types/wasteland.dm
+++ b/code/modules/jobs/job_types/wasteland.dm
@@ -85,8 +85,8 @@ Raider
 	department_head = list("Captain")
 	head_announce = list("Security")
 	faction = "Wastelander"
-	total_positions = -1
-	spawn_positions = -1
+	total_positions = 0
+	spawn_positions = 0
 	supervisors = "no one"
 	selection_color = "#dddddd"
 


### PR DESCRIPTION
## Description
Controversial PR time! Removes raiders (by setting the slots to 0).

## Motivation and Context
Raiders don't add anything to the quality of the server- in fact, they actively detract from it. Having a role whose sole purpose is "being an asshole" isn't necessary, and it causes a hell of a lot of problems for players and staff alike. There's nothing that raiders can mechanically do that anyone else can't, and wastelanders are already the infinite-job-slots option. If you want to be an asshole who takes people as slaves and/or steals their shit, play Legion Recruit or something.

## How Has This Been Tested?
Ayup.

## Screenshots (if appropriate):

## Changelog (neccesary)
:cl:
del: removes Raider role. Finally.
/:cl:
