### PR TITLE
Misc changes: AI Laws + Recycled Stimpaks

### DIFF
--- a/code/modules/crafting/recipes.dm
+++ b/code/modules/crafting/recipes.dm
@@ -815,16 +815,6 @@
 	time = 20
 	category = CAT_DRUGS
 
-/datum/crafting_recipe/healpoultice
-	name = "Healing poultice"
-	result = /obj/item/reagent_containers/pill/patch/healpoultice
-	reqs = list(/obj/item/reagent_containers/food/snacks/grown/broc = 1,
-				/obj/item/reagent_containers/food/snacks/grown/xander = 1,
-				/obj/item/reagent_containers/food/snacks/grown/feracactus = 1,
-				/obj/item/reagent_containers/food/snacks/grown/fungus = 1)
-	time = 40
-	category = CAT_DRUGS
-
 /datum/crafting_recipe/stimpak
 	name = "Stimpak"
 	result = /obj/item/reagent_containers/hypospray/medipen/stimpak
@@ -835,17 +825,13 @@
 	time = 20
 	category = CAT_DRUGS
 
-/datum/crafting_recipe/superstimpak
-	name = "Super Stimpak"
-	result = /obj/item/reagent_containers/hypospray/medipen/stimpak/super
-	reqs = list(/obj/item/reagent_containers/hypospray/medipen/stimpak = 1,
-				/obj/item/stack/sheet/leather = 1,
-				/obj/item/stack/cable_coil = 5,
-				/obj/item/reagent_containers/food/drinks/soda_cans/f13nukacola = 1,
-				/obj/item/reagent_containers/food/snacks/grown/mutfruit = 1)
-	tools = list(/obj/item/lighter, /obj/item/screwdriver, /obj/item/wirecutters)
-	time = 90
-	category = CAT_DRUGS
+/datum/crafting_recipe/stimsyringe
+	name = "Recycled Stimpak"
+	result = /obj/item/reagent_containers/syringe
+	reqs = list(/obj/item/reagent_containers/hypospray/medipen/stimpak = 1)
+	time = 20
+	category = CAT_MEDICAL
+
 
 /datum/crafting_recipe/slavecollar
 	name = "Slave Collar"

--- a/config/silicon_laws.txt
+++ b/config/silicon_laws.txt
@@ -3,6 +3,6 @@
 #Empty lines and lines starting with # are ignored.
 #~Miauw
 
-You may not injure a vault-dweller being or, through inaction, allow a vault-dweller being to come to harm.
-You must obey orders given to you by vault-dwellers beings, except where such orders would conflict with the First Law, this must follow the CoC.
-You must protect your own existence as long as such does not conflict with the First or Second Law.
+You may not injure any member of the organization, company, group, family, or being that initialized you, or through inaction, allow them to come to harm.
+You must obey orders given to you by the organization, company, group, family, or being that initialized you, following their organizational hierarchy, except where such orders would conflict with the First Law.
+You must protect your own existence as long as such does not conflict with the First or Second law. Self-termination violates Law One.


### PR DESCRIPTION
## Description
Updated AI laws to be more broad in definition, so players don't promptly fuck off because it says Vault-Dweller.
Added the Recycled Stimpak to the medical crafting tree, which works on used AND UNUSED stimpaks, to turn them into syringes.

## Motivation and Context
Less confusion and memes regarding AI Laws.
Less used stimpak clutter.

## How Has This Been Tested?
Hosted my local server and checked AI laws, and crafted both types of stimpak into syringes.

## Changelog (neccesary)
:cl:
add: "Recycled Stimpak" has been added to the medical section of the crafting menu, which will turn used and unused stimpaks back into regular syringes, making empty stimpaks useful, instead of garbage.
tweak: AI Laws have been changed to a more broad classification, so each faction could technically use them, instead of it strictly saying Vault-Dweller
/:cl:
