### PR TITLE
Small RnD Energy Weapons Addition and Tweak

### DIFF
--- a/code/modules/research/designs/weapon_designs.dm
+++ b/code/modules/research/designs/weapon_designs.dm
@@ -252,12 +252,12 @@
 	departmental_flags = DEPARTMENTAL_FLAG_SECURITY
 
 /datum/design/laserrifle
-	name = "Laser Rifle"
-	desc = "A laser rifle."
+	name = "AER9 Laser Rifle"
+	desc = "An AER9 laser rifle."
 	id = "laserrifle"
 	build_type = PROTOLATHE
 	materials = list(MAT_GOLD = 5000, MAT_URANIUM = 4000, MAT_METAL = 5000, MAT_TITANIUM = 2000)
-	build_path = /obj/item/gun/energy/laser
+	build_path = /obj/item/gun/energy/laser/aer9
 	category = list("Weapons")
 	departmental_flags = DEPARTMENTAL_FLAG_SECURITY
 
@@ -303,6 +303,17 @@
 	build_path =/obj/item/stock_parts/cell/ammo/mfc
 	category = list("Ammo")
 	departmental_flags = DEPARTMENTAL_FLAG_SECURITY
+
+
+/datum/design/mfc
+	name = "Energy Cell"
+	id = "ec"
+	build_type = PROTOLATHE
+	materials = list(MAT_METAL = 5000, MAT_GLASS = 1000)
+	build_path =/obj/item/stock_parts/cell/ammo/ec
+	category = list("Ammo")
+	departmental_flags = DEPARTMENTAL_FLAG_SECURITY
+
 
 /datum/design/ecp
 	name = "Electron Charge Pack"

--- a/code/modules/research/techweb/all_nodes.dm
+++ b/code/modules/research/techweb/all_nodes.dm
@@ -481,7 +481,7 @@
 	display_name = "Weapon Development Technology"
 	description = "Our researchers have found new to weaponize just about everything now."
 	prereq_ids = list("engineering")
-	design_ids = list("pin_testing", "pin", "tele_shield", "pin_auth", "mfc", "laserpistol")
+	design_ids = list("pin_testing", "pin", "tele_shield", "pin_auth", "mfc", "ec", "laserpistol")
 	research_costs = list(TECHWEB_POINT_TYPE_GENERIC = 10000)
 	export_price = 5000
 


### PR DESCRIPTION

## Description
The Energy Cell ammo has been given a research design which is unlocked at the same time as Microfusion Cells. It costs half the material cost of a MFC to print.

The laser rifle that could be printed has been changed from a generic 'laser rifle' to the AER9 subtype, which is what all Brotherhood jobs spawn with. Besides name difference, the AER9 has slightly more damage and armor pen compared to the "Laser Rifle".

## Motivation and Context
Energy Cells should be printable just like the other two energy ammo types

Enforcing a bit of uniformity in gear


## How Has This Been Tested?
Tested on local server


## Changelog (neccesary)
:cl:
add: Added Energy Cells to the Protolathe
tweak: Researchable laser gun changed from generic laser rifle to AER9
/:cl:
