### PR TITLE
Hard Yards quirk and trait added.

### DIFF
--- a/code/__DEFINES/traits.dm
+++ b/code/__DEFINES/traits.dm
@@ -44,6 +44,7 @@
 #define TRAIT_HOLY				"holy"
 #define TRAIT_DEPRESSION		"depression"
 #define TRAIT_JOLLY				"jolly"
+#define TRAIT_HARD_YARDS        "hard_yards"
 #define TRAIT_NOCRITDAMAGE		"no_crit"
 #define TRAIT_NOSLIPWATER		"noslip_water"
 #define TRAIT_NOSLIPALL			"noslip_all"

--- a/code/datums/traits/_quirk.dm
+++ b/code/datums/traits/_quirk.dm
@@ -5,6 +5,7 @@
 	var/desc = "This is a test quirk."
 	var/value = 0
 	var/human_only = TRUE
+	var/locked = FALSE
 	var/gain_text
 	var/lose_text
 	var/medical_record_text //This text will appear on medical records for the trait. Not yet implemented

--- a/code/datums/traits/good.dm
+++ b/code/datums/traits/good.dm
@@ -79,6 +79,15 @@
 	mob_trait = TRAIT_JOLLY
 	mood_quirk = TRUE
 
+/datum/quirk/hard_yards
+	name = "Hard Yards"
+	desc = "You've put them in, now reap the rewards."
+	value = 3
+	locked = TRUE
+	mob_trait = TRAIT_HARD_YARDS
+	gain_text = "<span class='notice'>Rain or shine, nothing slows you down.</span>"
+	lose_text = "<span class='danger'>You walk with a less sure gait, the ground seeming less firm somehow.</span>"
+
 /datum/quirk/lifegiver
 	name = "Lifegiver"
 	desc = "You embody wellness! Instantly gain +15 maximum Health"

--- a/code/modules/client/preferences.dm
+++ b/code/modules/client/preferences.dm
@@ -1124,6 +1124,8 @@ GLOBAL_LIST_EMPTY(preferences_datums)
 			var/quirk_cost = initial(T.value) * -1
 			var/lock_reason = "This trait is unavailable."
 			var/quirk_conflict = FALSE
+			if(initial(T.locked))
+				quirk_conflict = TRUE
 			for(var/_V in all_quirks)
 				if(_V == quirk_name)
 					has_quirk = TRUE

--- a/code/modules/jobs/job_types/legion.dm
+++ b/code/modules/jobs/job_types/legion.dm
@@ -55,6 +55,11 @@ Needs whitelist
 	access = list()
 	minimal_access = list()
 
+
+/datum/job/CaesarsLegion/Legionnaire/f13legate/after_spawn(mob/living/carbon/human/H, mob/M)
+	H.add_quirk("Hard Yards")
+
+
 /datum/outfit/job/CaesarsLegion/Legionnaire/f13legate
 	name = "Legate"
 	jobtype = /datum/job/CaesarsLegion/Legionnaire/f13legate
@@ -71,7 +76,6 @@ Needs whitelist
 		/obj/item/ammo_box/magazine/r20=2, \
 		/obj/item/flashlight/flare/torch=1, \
 		/obj/item/storage/bag/money/small/legion)
-
 
 /*
 Centurion
@@ -92,8 +96,12 @@ Centurion
 	req_admin_notify = 1
 	exp_requirements = 1920
 
-
 	outfit = /datum/outfit/job/CaesarsLegion/Legionnaire/f13centurion
+
+
+/datum/job/CaesarsLegion/Legionnaire/f13centurion/after_spawn(mob/living/carbon/human/H, mob/M)
+	H.add_quirk("Hard Yards")
+
 
 /datum/outfit/job/CaesarsLegion/Legionnaire/f13centurion
 	name = "Legion Centurion"
@@ -132,6 +140,11 @@ Veteran Decan
 
 	outfit = /datum/outfit/job/CaesarsLegion/Legionnaire/f13vetdecan
 
+
+/datum/job/CaesarsLegion/Legionnaire/f13vetdecan/after_spawn(mob/living/carbon/human/H, mob/M)
+	H.add_quirk("Hard Yards")
+
+
 /datum/outfit/job/CaesarsLegion/Legionnaire/f13vetdecan
 	name = "Legion Veteran Decanus"
 	jobtype = /datum/job/CaesarsLegion/Legionnaire/f13vetdecan
@@ -167,8 +180,8 @@ Prime Decan
 
 	exp_requirements = 1320
 
-
 	outfit = /datum/outfit/job/CaesarsLegion/Legionnaire/f13primedecan
+
 
 /datum/outfit/job/CaesarsLegion/Legionnaire/f13primedecan
 	name = "Legion Prime Decanus"
@@ -243,8 +256,12 @@ Vexillarius
 
 	exp_requirements = 840
 
-
 	outfit = /datum/outfit/job/CaesarsLegion/Legionnaire/f13vexillarius
+
+
+/datum/job/CaesarsLegion/Legionnaire/f13vexillarius/after_spawn(mob/living/carbon/human/H, mob/M)
+	H.add_quirk("Hard Yards")
+
 
 /datum/outfit/job/CaesarsLegion/Legionnaire/f13vexillarius
 	name = "Legion Vexillarius"
@@ -280,6 +297,11 @@ Veteran
 	exp_requirements = 720
 
 	outfit = /datum/outfit/job/CaesarsLegion/Legionnaire/f13vetlegion
+
+
+/datum/job/CaesarsLegion/Legionnaire/f13vetlegion/after_spawn(mob/living/carbon/human/H, mob/M)
+	H.add_quirk("Hard Yards")
+
 
 /datum/outfit/job/CaesarsLegion/Legionnaire/f13vetlegion
 	name = "Veteran Legionnaire"
@@ -391,8 +413,12 @@ Legionary
 
 	exp_requirements = 600
 
-
 	outfit = /datum/outfit/job/CaesarsLegion/Legionnaire/f13explorer
+
+
+/datum/job/CaesarsLegion/Legionnaire/f13explorer/after_spawn(mob/living/carbon/human/H, mob/M)
+	H.add_quirk("Hard Yards")
+
 
 /datum/outfit/job/CaesarsLegion/Legionnaire/f13explorer
 	name = "Legion Explorer"
@@ -423,6 +449,11 @@ Legionary
 	exp_requirements = 300
 
 	outfit = /datum/outfit/job/CaesarsLegion/Legionnaire/f13scout
+
+
+/datum/job/CaesarsLegion/Legionnaire/f13scout/after_spawn(mob/living/carbon/human/H, mob/M)
+	H.add_quirk("Hard Yards")
+
 
 /datum/outfit/job/CaesarsLegion/Legionnaire/f13scout
 	name = "Legion Scout"

--- a/code/modules/jobs/job_types/ncr.dm
+++ b/code/modules/jobs/job_types/ncr.dm
@@ -359,6 +359,11 @@ Veteran Ranger
 
 	outfit = /datum/outfit/job/ncr/f13vetranger
 
+
+/datum/job/ncr/f13vetranger/after_spawn(mob/living/carbon/human/H, mob/M)
+	H.add_quirk("Hard Yards")
+
+
 /datum/outfit/job/ncr/f13vetranger
 	name = "NCR Veteran Ranger"
 	jobtype = /datum/job/ncr/f13vetranger
@@ -394,6 +399,11 @@ Ranger
 	exp_requirements = 720
 
 	outfit = /datum/outfit/job/ncr/f13ranger
+
+
+/datum/job/ncr/f13ranger/after_spawn(mob/living/carbon/human/H, mob/M)
+	H.add_quirk("Hard Yards")
+
 
 /datum/outfit/job/ncr/f13ranger
 	name = "NCR Ranger"
@@ -432,6 +442,11 @@ Recon Ranger
 	exp_requirements = 420
 
 	outfit = /datum/outfit/job/ncr/f13recranger
+
+
+/datum/job/ncr/f13recranger/after_spawn(mob/living/carbon/human/H, mob/M)
+	H.add_quirk("Hard Yards")
+
 
 /datum/outfit/job/ncr/f13recranger
 	name = "NCR Recon Ranger"

--- a/code/modules/mob/living/living.dm
+++ b/code/modules/mob/living/living.dm
@@ -515,7 +515,7 @@
 	. = 0
 	if(isopenturf(loc) && !is_flying())
 		var/turf/open/T = loc
-		. += T.slowdown
+		. += ( has_trait(TRAIT_HARD_YARDS) ? T.slowdown * 0.5 : T.slowdown )
 	var/static/datum/config_entry/number/run_delay/config_run_delay
 	var/static/datum/config_entry/number/walk_delay/config_walk_delay
 	if(isnull(config_run_delay))


### PR DESCRIPTION
## Motivation and Context
Blame Ren for most of this PR.

## How Has This Been Tested?
Locally. It works.

## Changelog (neccesary)
:cl:
add: New quirk: Hard Yards. It halves the rough terrain slowdown penalty. Locked for certain roles or badminery for now.
balance: All NCR Rangers plus Legion Legates, Centurions, Veterans, Vex, Explorers and Scouts get the quirk for free.
/:cl:
