### PR TITLE
Ranger loadout tweaks

### DIFF
--- a/code/modules/jobs/job_types/ncr.dm
+++ b/code/modules/jobs/job_types/ncr.dm
@@ -404,11 +404,9 @@ Ranger
 	gloves =	/obj/item/clothing/gloves/fingerless
 	shoes = 		/obj/item/clothing/shoes/workboots
 	glasses = 		/obj/item/clothing/glasses/sunglasses/big
-	suit_store = 	/obj/item/gun/ballistic/shotgun/automatic/hunting/brush
+	suit_store = 	/obj/item/gun/ballistic/shotgun/automatic/hunting
 	backpack_contents = list(
-		/obj/item/gun/ballistic/revolver/m29=1, \
-		/obj/item/ammo_box/c4570=2, \
-		/obj/item/ammo_box/magazine/internal/cylinder/rev44=1, \
+		/obj/item/ammo_box/a762/doublestacked = 3, \
 		/obj/item/restraints/handcuffs=1, \
 		/obj/item/kitchen/knife/combat/survival=1, \
 		/obj/item/reagent_containers/hypospray/medipen/stimpak=1, \
@@ -444,9 +442,7 @@ Recon Ranger
 	glasses = 		/obj/item/clothing/glasses/sunglasses
 	suit_store = 	/obj/item/gun/ballistic/shotgun/remington/scoped
 	backpack_contents = list(
-		/obj/item/gun/ballistic/revolver/m29=1, \
-		/obj/item/ammo_box/a762=2, \
-		/obj/item/ammo_box/magazine/internal/cylinder/rev44=1, \
+		/obj/item/ammo_box/a308 = 4, \
 		/obj/item/restraints/handcuffs=1, \
 		/obj/item/kitchen/knife/combat/survival=1, \
 		/obj/item/reagent_containers/hypospray/medipen/stimpak=1, \


### PR DESCRIPTION
## Motivation and Context
Ren asked. No idea, myself.

## How Has This Been Tested?
Untested, but the changes look simple enough.

## Changelog (neccesary)
:cl:
balance: Patrol Rangers lose their brush gun and  revolver, and gain a Colt Rangemaster with 3 extra ammo.
balance: Recon Rangers lose their revolver, and gain 4 extra ammo for their hunting rifle.
/:cl:
