### PR TITLE
Removes explosive ammo from the crafting menu until it can be balanced.

### DIFF
--- a/code/modules/crafting/recipes.dm
+++ b/code/modules/crafting/recipes.dm
@@ -337,17 +337,6 @@
 	category = CAT_WEAPONRY
 	subcategory = CAT_AMMO
 
-/datum/crafting_recipe/a50ex
-	name = ".50 MG explosive rack (NCR)"
-	result = /obj/item/ammo_box/a50MG/explosive
-	reqs = list(/obj/item/stack/sheet/metal = 20,
-				/datum/reagent/blackpowder = 50,
-				/obj/item/stack/sheet/plasteel = 5)
-	tools = list(TOOL_SCREWDRIVER, TOOL_NCR)
-	time = 5
-	category = CAT_WEAPONRY
-	subcategory = CAT_AMMO
-
 /datum/crafting_recipe/meteorslug
 	name = "Meteorslug Shell"
 	result = /obj/item/ammo_casing/shotgun/meteorslug


### PR DESCRIPTION
## Description
Removed the explosive ammo from the crafting table for now, since it's too easily craft-able and is EXTREMELY overpowered. 

## Motivation and Context
AgentAgent asked for me to post this up

## How Has This Been Tested?
Revert.

## Changelog (neccesary)
:cl:
code: removed explosive 50cal ammo from the crafting table for now, until it is balanced.
/:cl:
