### PR TITLE
Legion exo slot additions

### DIFF
--- a/code/modules/clothing/suits/armor.dm
+++ b/code/modules/clothing/suits/armor.dm
@@ -455,6 +455,7 @@
 	icon_state = "legrecruit"
 	item_state = "legrecruit"
 	body_parts_covered = CHEST|GROIN|ARMS
+	allowed = list(/obj/item/gun, /obj/item/claymore, /obj/item/throwing_star/spear, /obj/item/restraints/legcuffs/bola)
 	armor = list("melee" = 40, "bullet" = 25, "laser" = 10, "energy" = 10, "bomb" = 16, "bio" = 30, "rad" = 0, "fire" = 50, "acid" = 0)
 	strip_delay = 60
 
@@ -475,6 +476,7 @@
 	icon_state = "legvexil"
 	item_state = "legvexil"
 	body_parts_covered = CHEST|GROIN|LEGS|FEET
+	allowed = list(/obj/item/gun, /obj/item/claymore, /obj/item/throwing_star/spear, /obj/item/restraints/legcuffs/bola)
 	armor = list("melee" = 60, "bullet" = 40, "laser" = 25, "energy" = 15, "bomb" = 25, "bio" = 0, "rad" = 0, "fire" = 70, "acid" = 0)
 	strip_delay = 60
 
@@ -484,6 +486,7 @@
 	icon_state = "legcenturion"
 	item_state = "legcenturion"
 	body_parts_covered = CHEST|GROIN|LEGS|FEET|ARMS
+	allowed = list(/obj/item/gun, /obj/item/claymore, /obj/item/throwing_star/spear, /obj/item/restraints/legcuffs/bola)
 	armor = list("melee" = 75, "bullet" = 50, "laser" = 35, "energy" = 35, "bomb" = 39, "bio" = 60, "rad" = 0, "fire" = 80, "acid" = 0)
 	strip_delay = 60
 
@@ -493,7 +496,8 @@
 	icon_state = "leglegat"
 	item_state = "leglegat"
 	body_parts_covered = CHEST|GROIN|LEGS|FEET|ARMS
-	armor = list("melee" = 60, "bullet" = 39, "laser" = 25, "energy" = 25, "bomb" = 39, "bio" = 0, "rad" = 0, "fire" = 0, "acid" = 0)
+	allowed = list(/obj/item/gun, /obj/item/claymore, /obj/item/throwing_star/spear, /obj/item/restraints/legcuffs/bola)
+	armor = list("melee" = 85, "bullet" = 60, "laser" = 40, "energy" = 40, "bomb" = 45, "bio" = 60, "rad" = 0, "fire" = 80, "acid" = 0)
 	strip_delay = 60
 
 /obj/item/clothing/suit/armor/f13/combat

--- a/code/modules/clothing/suits/armor.dm
+++ b/code/modules/clothing/suits/armor.dm
@@ -475,7 +475,7 @@
 	desc = "The armor appears to be based off of a suit of Legion veteran armor, with the addition of circular metal plates attached to the torso, as well as a banner displaying the flag of the Legion worn on the back."
 	icon_state = "legvexil"
 	item_state = "legvexil"
-	body_parts_covered = CHEST|GROIN|LEGS|FEET
+	body_parts_covered = CHEST|GROIN|ARMS
 	allowed = list(/obj/item/gun, /obj/item/claymore, /obj/item/throwing_star/spear, /obj/item/restraints/legcuffs/bola)
 	armor = list("melee" = 60, "bullet" = 40, "laser" = 25, "energy" = 15, "bomb" = 25, "bio" = 0, "rad" = 0, "fire" = 70, "acid" = 0)
 	strip_delay = 60


### PR DESCRIPTION
## Description 
Adds the machete, machete gladius, throwing spear, and bola to the list of acceptable items to store in the armor storage slot. Buffs Legate armor to be better than centurion (still less bullet/energy protection than NCR colonel, with slightly higher melee protection). Standardizes the vexillarius armor to be in line with veteran armor like it says it's supposed to be.

## Motivation and Context 
The main reason for this PR is to make melee builds less of a bulky annoyance of trying to organize your items to be able to use melee and also have enough storage space to carry a few small essentials. It just didn't make sense to me the primarily melee based faction wasn't able to store their weapons on their armor. 

## How Has This Been Tested? 
<!--- Please describe in detail how you tested your changes. --> 
Started up a test server with my PR, tested exo slot availability.
Immediately started round, joined as random decanus role, tested items I was adding successfully, ensured I could still put guns in exo slot if I so chose.

## Screenshots (if appropriate): 
![EXOSLOT1](https://user-images.githubusercontent.com/46360163/58680392-2d66f580-832d-11e9-87dd-0936fe7e365f.png)
![EXOSLOT2](https://user-images.githubusercontent.com/46360163/58680393-2d66f580-832d-11e9-82e8-cf46ca9886c5.png)
![EXOSLOT3](https://user-images.githubusercontent.com/46360163/58680395-2dff8c00-832d-11e9-99fe-9571dea26f15.png)

:cl: 
add: Both machetes, throwing spears, and bolas now fit on legion armor storage slots. 
tweak: Legate armor is now better than centurion armor for future events/adminbus/whitelistees to match their seniority. 
tweak: Vexillarius armor now covers arms like all other legionnaire armors, removed it's unique leg protection belonging to the centurion/legate.
/:cl: