### PR TITLE
Buffs Salvaged Power Armor

### DIFF
--- a/code/modules/clothing/suits/armor.dm
+++ b/code/modules/clothing/suits/armor.dm
@@ -369,7 +369,7 @@
 
 /obj/item/clothing/suit/armor/f13/brokenpa
 	w_class = WEIGHT_CLASS_HUGE
-	slowdown = 3
+	slowdown = 2
 	body_parts_covered = CHEST|GROIN|LEGS|FEET|ARMS
 	cold_protection = CHEST|GROIN|LEGS|FEET|ARMS|HANDS
 	heat_protection = CHEST|GROIN|LEGS|FEET|ARMS
@@ -383,7 +383,7 @@
 	desc = "It's a set of T-45b power armor recovered by the NCR during the NCR-Brotherhood War.<br>NCR technicians have restored it to working order by replacing the back-mounted cylinders with a custom air conditioning module and stripping out the joint servomotors."
 	icon_state = "t45bpowerarmor"
 	item_state = "t45bpowerarmor"
-	armor = list("melee" = 75, "bullet" = 50, "laser" = 30, "energy" = 50, "bomb" = 48, "bio" = 60, "rad" = 50, "fire" = 75, "acid" = 0)
+	armor = list("melee" = 75, "bullet" = 60, "laser" = 30, "energy" = 50, "bomb" = 48, "bio" = 60, "rad" = 50, "fire" = 75, "acid" = 0)
 
 /obj/item/clothing/suit/armor/f13/power_armor
 	w_class = WEIGHT_CLASS_HUGE


### PR DESCRIPTION
## Description
Decreases slowdown of Salvaged Power Armor (used by NCR Heavies) from 3 to 2
Increases bullet protection from 50 to 60

## Motivation and Context
Despite supposedly being the heavy assault peoples, the SPA is somewhat lacking. It is brutally slow, forcing many people to carry it in their hand if they want to get anywhere in any reasonable timeframe. The slowdown is now reduced to 2 (for reference, the slowdown of functional T-45 and -51b is 1) to make it less debilitating.

The +10 increase in ballistic protection also makes it a little bit more useful in firefights.

Requested by Ren.

## How Has This Been Tested?
Checked on local server just to confirm the player moved faster, a bit tricky to check ballistic protection but it should be fine

## Changelog (neccesary)
:cl:
balance: Reduced slowdown of Salvaged PA and slightly increased bullet protection
/:cl:
