### PR TITLE
Mantle vest protection

### DIFF
--- a/code/modules/clothing/suits/armor.dm
+++ b/code/modules/clothing/suits/armor.dm
@@ -576,7 +576,7 @@
 	desc = "A standard issue NCR protective vest."
 	icon_state = "ncr_vest"
 	item_state = "ncr_vest"
-	body_parts_covered = CHEST
+	body_parts_covered = CHEST|GROIN|ARMS
 	armor = list("melee" = 30, "bullet" = 30, "laser" = 20, "energy" = 20, "bomb" = 25, "bio" = 30, "rad" = 20, "fire" = 60, "acid" = 0)
 	strip_delay = 60
 


### PR DESCRIPTION
## Description
Alters the NCR vest and by inheriting vars, the NCO vest, to protect the arms and groin of the wearer, same as legion armor.

## Motivation and Context
The extreme ease of destroying an NCR troopers arm in a one click win button fashion shouldn't exist.
Balancing it with legion armor.

## Changelog (neccesary)
:cl:
tweak: Changed NCR vest and mantle vest to cover the arms and groin, like legion armor.
/:cl:
