### PR TITLE
Explorer-Machete

### DIFF
--- a/code/modules/jobs/job_types/legion.dm
+++ b/code/modules/jobs/job_types/legion.dm
@@ -428,7 +428,7 @@ Legionary
 	suit_store = /obj/item/gun/ballistic/shotgun/automatic/hunting
 	backpack_contents = list(
 		/obj/item/restraints/legcuffs/bola=1, \
-		/obj/item/claymore/machete=1, \
+		/obj/item/claymore/machete/gladius=1, \
 		/obj/item/ammo_box/a762/doublestacked=2, \
 		/obj/item/reagent_containers/pill/patch/healingpowder=2, \
 		/obj/item/flashlight/flare/torch=1, \


### PR DESCRIPTION
## Description
Gives the legion explorer a gladius due to their veteran rank, they should have one.

## Motivation and Context
Makes sense they would in the rank hierarchy.

## How Has This Been Tested?
Joined local game and spawned as explorer, gladius was in the backpack.

## Changelog (neccesary)
:cl:
add: Added a machete gladius to the legion explorer bag as befitting of a veteran.
/:cl:
