### PR TITLE
drops powerfist force to 45

### DIFF
--- a/code/game/objects/items/powerfist.dm
+++ b/code/game/objects/items/powerfist.dm
@@ -7,7 +7,7 @@
 	righthand_file = 'icons/mob/inhands/weapons/melee_righthand.dmi'
 	flags_1 = CONDUCT_1
 	attack_verb = list("whacked", "fisted", "power-punched")
-	force = 72
+	force = 45
 	throwforce = 10
 	throw_range = 7
 	w_class = WEIGHT_CLASS_BULKY


### PR DESCRIPTION
OOC: Adam El-Tablawy: I can open a PR right now to drop the fucking powerfist's force to 30 if I felt like it

OOC: Snooper44: Okay retard do it.
## Description

powerfist strong, apparently, and people are mad that at max setting it literally instant kills given that it does a staggering 216 damage

while they're incapable of using basic reasoning to figure out that a shotgun dart is just as powerful i hate big number so now it does 90 damage on force setting 2 and 135 on force setting 3, enough to solidly drop someone into crit (not accounting for armor) but not enough for an instant kill