### PR TITLE
Cactus fruit farming

### DIFF
--- a/code/modules/hydroponics/grown/feracactus.dm
+++ b/code/modules/hydroponics/grown/feracactus.dm
@@ -10,10 +10,10 @@
 	product = /obj/item/reagent_containers/food/snacks/grown/feracactus
 	lifespan = 60
 	endurance = 20
-	yield = 1
+	yield = 2
 	growthstages = 3
-	production = 20
-	maturation = 20
+	production = 5
+	maturation = 5
 
 
 /obj/item/reagent_containers/food/snacks/grown/feracactus


### PR DESCRIPTION
## Description
Lowers the absurd growth time of barrel cactus in a soil plot. Also gives 2 yield instead of 1 which would be pointless.

## Motivation and Context
It will allow followers who are (for some stupid reason are thought to be slaves who can escape if you give them a chance) not allowed out to collect fruit from the immediate area around the gate, to actually farm cacti fruit to make poultice.

## Changelog (neccesary)
:cl:
tweak: Makes barrel cactus fruit actually worth it to farm, removes the ridiculously long growth time.
/:cl:
