### PR TITLE
Bad Deathclaw: Now with MORE BEDSHEETS

### DIFF
--- a/code/game/objects/items/stacks/sheets/sheet_types.dm
+++ b/code/game/objects/items/stacks/sheets/sheet_types.dm
@@ -255,7 +255,37 @@ GLOBAL_LIST_INIT(cloth_recipes, list ( \
 	null, \
 	new/datum/stack_recipe("improvised gauze", /obj/item/stack/medical/gauze/improvised, 1, 2, 6), \
 	new/datum/stack_recipe("rag", /obj/item/reagent_containers/glass/rag, 1), \
-	new/datum/stack_recipe("bedsheet", /obj/item/bedsheet, 3), \
+	null, \
+	new /datum/stack_recipe_list("bedsheets", list( \
+		new /datum/stack_recipe("White Bedsheet", /obj/item/bedsheet, 3), \
+		new /datum/stack_recipe("Black Bedsheet", /obj/item/bedsheet/black, 3), \
+		new /datum/stack_recipe("Blue Bedsheet", /obj/item/bedsheet/blue, 3), \
+		new /datum/stack_recipe("Brown Bedsheet", /obj/item/bedsheet/brown, 3), \
+		new /datum/stack_recipe("Green Bedsheet", /obj/item/bedsheet/green, 3), \
+		new /datum/stack_recipe("Grey Bedsheet", /obj/item/bedsheet/grey, 3), \
+		new /datum/stack_recipe("Orange Bedsheet", /obj/item/bedsheet/orange, 3), \
+		new /datum/stack_recipe("Purple Bedsheet", /obj/item/bedsheet/purple, 3), \
+		new /datum/stack_recipe("Red Bedsheet", /obj/item/bedsheet/red, 3), \
+		new /datum/stack_recipe("Yellow Bedsheet", /obj/item/bedsheet/yellow, 3), \
+		new /datum/stack_recipe("Central Command Bedsheet", /obj/item/bedsheet/centcom, 3), \
+		new /datum/stack_recipe("Nanotrasen Bedsheet", /obj/item/bedsheet/nanotrasen, 3), \
+		new /datum/stack_recipe("Syndicate Bedsheet", /obj/item/bedsheet/syndie, 3), \
+		new /datum/stack_recipe("Captain's Bedsheet", /obj/item/bedsheet/captain, 3), \
+		new /datum/stack_recipe("Head of Personnel's Bedsheet", /obj/item/bedsheet/hop, 3), \
+		new /datum/stack_recipe("Head of Security's Bedsheet", /obj/item/bedsheet/hos, 3), \
+		new /datum/stack_recipe("Chief Engineer's Bedsheet", /obj/item/bedsheet/ce, 3), \
+		new /datum/stack_recipe("Chief Medical Officer's Bedsheet", /obj/item/bedsheet/cmo, 3), \
+		new /datum/stack_recipe("Quartermaster's Bedsheet", /obj/item/bedsheet/qm, 3), \
+		new /datum/stack_recipe("Research Director's Bedsheet", /obj/item/bedsheet/rd, 3), \
+		new /datum/stack_recipe("Clown's Bedsheet", /obj/item/bedsheet/clown, 3), \
+		new /datum/stack_recipe("Rainbow Bedsheet", /obj/item/bedsheet/rainbow, 3), \
+		new /datum/stack_recipe("Mime's Bedsheet", /obj/item/bedsheet/mime, 3), \
+		new /datum/stack_recipe("Cosmic Bedsheet", /obj/item/bedsheet/cosmos, 3), \
+		new /datum/stack_recipe("Wizard's Bedsheet", /obj/item/bedsheet/wiz, 3), \
+		new /datum/stack_recipe("Patriot's Bedsheet", /obj/item/bedsheet/patriot, 3), \
+		new /datum/stack_recipe("Ian's Bedsheet", /obj/item/bedsheet/ian, 3), \
+	)), \
+	null, \
 	new/datum/stack_recipe("empty sandbag", /obj/item/stack/sheet/emptysandbag, 4), \
 	null, \
 	new/datum/stack_recipe("fingerless gloves", /obj/item/clothing/gloves/fingerless, 1), \


### PR DESCRIPTION
## Description
I decided that crafting just a white bedsheet was lame, and wanted all of them to be craftable.

## Motivation and Context
Tired of relying on random chance of one bedsheet to get a nice cape, and only in the vault. Now you can craft any bedsheet.

## How Has This Been Tested?
Clean compile, hosted server, created all sheets.

## Screenshots (if appropriate):
https://i.gyazo.com/3a477b4572c6aa691aab21469426e6b5.png

## Changelog (neccesary)
:cl:
tweak: Made all bedsheets craftable from the in-hand cloth menu.
/:cl:
