### PR TITLE
Datum components and clone notifications

### DIFF
--- a/code/__DEFINES/atom_hud.dm
+++ b/code/__DEFINES/atom_hud.dm
@@ -60,5 +60,6 @@
 #define NOTIFY_JUMP "jump"
 #define NOTIFY_ATTACK "attack"
 #define NOTIFY_ORBIT "orbit"
+#define NOTIFY_JOIN "join"
 
 #define ADD_HUD_TO_COOLDOWN 20 //cooldown for being shown the images for any particular data hud

--- a/code/__DEFINES/components.dm
+++ b/code/__DEFINES/components.dm
@@ -185,6 +185,9 @@
 //NTnet
 #define COMSIG_COMPONENT_NTNET_RECIEVE "ntnet_recieve"			//called on an object by its NTNET connection component on recieve. (sending_id(number), sending_netname(text), data(datum/netdata))
 
+//Notifications
+#define COMSIG_NOTIFY_JOIN "notify_join"
+
 // /datum/component/storage signals
 #define COMSIG_CONTAINS_STORAGE "is_storage"						//() - returns bool.
 #define COMSIG_TRY_STORAGE_INSERT "storage_try_insert"				//(obj/item/inserting, mob/user, silent, force) - returns bool

--- a/code/_onclick/hud/alert.dm
+++ b/code/_onclick/hud/alert.dm
@@ -561,6 +561,8 @@ so as to remain in compliance with the most up-to-date laws."
 				G.forceMove(T)
 		if(NOTIFY_ORBIT)
 			G.ManualFollow(target)
+		if(NOTIFY_JOIN)
+			SEND_SIGNAL(target, COMSIG_NOTIFY_JOIN, G)
 
 //OBJECT-BASED
 

--- a/code/datums/components/_component.dm
+++ b/code/datums/components/_component.dm
@@ -1,16 +1,18 @@
 /datum/component
-	var/enabled = FALSE
 	var/dupe_mode = COMPONENT_DUPE_HIGHLANDER
 	var/dupe_type
-	var/list/signal_procs
 	var/datum/parent
+	//only set to true if you are able to properly transfer this component
+	//At a minimum RegisterWithParent and UnregisterFromParent should be used
+	//Make sure you also implement PostTransfer for any post transfer handling
+	var/can_transfer = FALSE
 
 /datum/component/New(datum/P, ...)
 	parent = P
 	var/list/arguments = args.Copy(2)
 	if(Initialize(arglist(arguments)) == COMPONENT_INCOMPATIBLE)
 		qdel(src, TRUE, TRUE)
-		CRASH("Incompatible [type] assigned to a [P.type]!")
+		CRASH("Incompatible [type] assigned to a [P.type]! args: [json_encode(arguments)]")
 
 	_JoinParent(P)
 
@@ -57,15 +59,11 @@
 	return
 
 /datum/component/Destroy(force=FALSE, silent=FALSE)
-	enabled = FALSE
-	var/datum/P = parent
-	if(!force)
+	if(!force && parent)
 		_RemoveFromParent()
 	if(!silent)
-		SEND_SIGNAL(P, COMSIG_COMPONENT_REMOVING, src)
+		SEND_SIGNAL(parent, COMSIG_COMPONENT_REMOVING, src)
 	parent = null
-	for(var/target in signal_procs)
-		UnregisterSignal(target, signal_procs[target])
 	return ..()
 
 /datum/component/proc/_RemoveFromParent()
@@ -89,7 +87,7 @@
 /datum/component/proc/UnregisterFromParent()
 	return
 
-/datum/component/proc/RegisterSignal(datum/target, sig_type_or_types, proc_or_callback, override = FALSE)
+/datum/proc/RegisterSignal(datum/target, sig_type_or_types, proc_or_callback, override = FALSE)
 	if(QDELETED(src) || QDELETED(target))
 		return
 
@@ -122,9 +120,9 @@
 		else // Many other things have registered here
 			lookup[sig_type][src] = TRUE
 
-	enabled = TRUE
+	signal_enabled = TRUE
 
-/datum/component/proc/UnregisterSignal(datum/target, sig_type_or_types)
+/datum/proc/UnregisterSignal(datum/target, sig_type_or_types)
 	var/list/lookup = target.comp_lookup
 	if(!signal_procs || !signal_procs[target] || !lookup)
 		return
@@ -160,7 +158,7 @@
 	return
 
 /datum/component/proc/PostTransfer()
-	return
+	return COMPONENT_INCOMPATIBLE //Do not support transfer by default as you must properly support it
 
 /datum/component/proc/_GetInverseTypeList(our_type = type)
 	//we can do this one simple trick
@@ -174,15 +172,15 @@
 /datum/proc/_SendSignal(sigtype, list/arguments)
 	var/target = comp_lookup[sigtype]
 	if(!length(target))
-		var/datum/component/C = target
-		if(!C.enabled)
+		var/datum/C = target
+		if(!C.signal_enabled)
 			return NONE
 		var/datum/callback/CB = C.signal_procs[src][sigtype]
 		return CB.InvokeAsync(arglist(arguments))
 	. = NONE
 	for(var/I in target)
-		var/datum/component/C = I
-		if(!C.enabled)
+		var/datum/C = I
+		if(!C.signal_enabled)
 			continue
 		var/datum/callback/CB = C.signal_procs[src][sigtype]
 		. |= CB.InvokeAsync(arglist(arguments))
@@ -226,12 +224,9 @@
 	if(ispath(nt))
 		if(nt == /datum/component)
 			CRASH("[nt] attempted instantiation!")
-		if(!isnum(dm))
-			CRASH("[nt]: Invalid dupe_mode ([dm])!")
-		if(dt && !ispath(dt))
-			CRASH("[nt]: Invalid dupe_type ([dt])!")
 	else
 		new_comp = nt
+		nt = new_comp.type
 
 	args[1] = src
 
@@ -281,18 +276,22 @@
 	var/datum/old_parent = parent
 	PreTransfer()
 	_RemoveFromParent()
+	parent = null
 	SEND_SIGNAL(old_parent, COMSIG_COMPONENT_REMOVING, src)
 
 /datum/proc/TakeComponent(datum/component/target)
-	if(!target)
+	if(!target || target.parent == src)
 		return
 	if(target.parent)
 		target.RemoveComponent()
 	target.parent = src
-	if(target.PostTransfer() == COMPONENT_INCOMPATIBLE)
-		var/c_type = target.type
-		qdel(target)
-		CRASH("Incompatible [c_type] transfer attempt to a [type]!")
+	var/result = target.PostTransfer()
+	switch(result)
+		if(COMPONENT_INCOMPATIBLE)
+			var/c_type = target.type
+			qdel(target)
+			CRASH("Incompatible [c_type] transfer attempt to a [type]!")
+
 	if(target == AddComponent(target))
 		target._JoinParent()
 
@@ -302,10 +301,13 @@
 		return
 	var/comps = dc[/datum/component]
 	if(islist(comps))
-		for(var/I in comps)
-			target.TakeComponent(I)
+		for(var/datum/component/I in comps)
+			if(I.can_transfer)
+				target.TakeComponent(I)
 	else
-		target.TakeComponent(comps)
+		var/datum/component/C = comps
+		if(C.can_transfer)
+			target.TakeComponent(comps)
 
 /datum/component/ui_host()
 	return parent

--- a/code/datums/datum.dm
+++ b/code/datums/datum.dm
@@ -2,7 +2,9 @@
 	var/gc_destroyed //Time when this object was destroyed.
 	var/list/active_timers  //for SStimer
 	var/list/datum_components //for /datum/components
-	var/list/comp_lookup //for /datum/components
+	var/list/comp_lookup //it used to be for looking up components which had registered a signal but now anything can register
+	var/list/list/datum/callback/signal_procs
+	var/signal_enabled = FALSE
 	var/datum_flags = NONE
 	var/datum/weakref/weak_reference
 
@@ -31,6 +33,9 @@
 			continue
 		qdel(timer)
 
+	//BEGIN: ECS SHIT
+	signal_enabled = FALSE
+
 	var/list/dc = datum_components
 	if(dc)
 		var/all_components = dc[/datum/component]
@@ -55,6 +60,10 @@
 				var/datum/component/comp = comps
 				comp.UnregisterSignal(src, sig)
 		comp_lookup = lookup = null
+
+	for(var/target in signal_procs)
+		UnregisterSignal(target, signal_procs[target])
+	//END: ECS SHIT
 
 	return QDEL_HINT_QUEUE
 

--- a/code/game/gamemodes/clown_ops/clown_weapons.dm
+++ b/code/game/gamemodes/clown_ops/clown_weapons.dm
@@ -74,7 +74,7 @@
 	. = ..()
 	AddComponent(/datum/component/slippery, 60, GALOSHES_DONT_HELP)
 	GET_COMPONENT(slipper, /datum/component/slippery)
-	slipper.enabled = active
+	slipper.signal_enabled = active
 
 /obj/item/melee/transforming/energy/sword/bananium/attack(mob/living/M, mob/living/user)
 	..()
@@ -99,7 +99,7 @@
 /obj/item/melee/transforming/energy/sword/bananium/transform_weapon(mob/living/user, supress_message_text)
 	..()
 	GET_COMPONENT(slipper, /datum/component/slippery)
-	slipper.enabled = active
+	slipper.signal_enabled = active
 
 /obj/item/melee/transforming/energy/sword/bananium/ignition_effect(atom/A, mob/user)
 	return ""
@@ -131,12 +131,12 @@
 	. = ..()
 	AddComponent(/datum/component/slippery, 60, GALOSHES_DONT_HELP)
 	GET_COMPONENT(slipper, /datum/component/slippery)
-	slipper.enabled = active
+	slipper.signal_enabled = active
 
 /obj/item/shield/energy/bananium/attack_self(mob/living/carbon/human/user)
 	..()
 	GET_COMPONENT(slipper, /datum/component/slippery)
-	slipper.enabled = active
+	slipper.signal_enabled = active
 
 /obj/item/shield/energy/bananium/throw_at(atom/target, range, speed, mob/thrower, spin=1)
 	if(active)

--- a/code/game/machinery/exp_cloner.dm
+++ b/code/game/machinery/exp_cloner.dm
@@ -47,12 +47,36 @@
 	H.add_trait(TRAIT_MUTE, "cloning")
 	H.add_trait(TRAIT_NOBREATH, "cloning")
 	H.add_trait(TRAIT_NOCRITDAMAGE, "cloning")
+	H.faction |= factions
 	H.Unconscious(80)
 
-	var/list/candidates = pollCandidatesForMob("Do you want to play as [clonename]'s defective clone?", null, null, null, 100, H)
-	if(LAZYLEN(candidates))
-		var/mob/dead/observer/C = pick(candidates)
-		H.key = C.key
+	RegisterSignal(src, COMSIG_NOTIFY_JOIN, .proc/join_as_defective_clone)
+	notify_ghosts("[clonename] is available to play as a defective clone.", source = src, action = NOTIFY_JOIN, flashwindow = FALSE)
+
+	addtimer(CALLBACK(src, .proc/finish_cloning), 30 SECONDS)
+
+	return TRUE
+
+
+/obj/machinery/clonepod/experimental/proc/join_as_defective_clone(mob/dead/observer/C)
+	if(!C.client)
+		return FALSE
+
+	var/mob/living/carbon/human/H = locate() in contents
+
+	if(QDELETED(H))
+		to_chat(C, "<span class='warning'>Something bad happened with the clone.</span>")
+		return FALSE
+
+	if(H.key)
+		to_chat(C, "<span class='warning'>The clone seems to have been already taken.</span>")
+		return FALSE
+
+	H.key = C.key
+
+
+/obj/machinery/clonepod/experimental/proc/finish_cloning(mob/dead/observer/C)
+	var/mob/living/carbon/human/H = locate() in contents
 
 	if(grab_ghost_when == CLONER_FRESH_CLONE)
 		H.grab_ghost()
@@ -63,13 +87,12 @@
 		to_chat(H.get_ghost(TRUE), "<span class='notice'>Your body is beginning to regenerate in a cloning pod. You will become conscious when it is complete.</span>")
 
 	if(H)
-		H.faction |= factions
-
 		H.set_cloned_appearance()
 
 		H.suiciding = FALSE
+
+	UnregisterSignal(src, COMSIG_NOTIFY_JOIN)
 	attempting = FALSE
-	return TRUE
 
 
 //Prototype cloning console, much more rudimental and lacks modern functions such as saving records, autocloning, or safety checks.

--- a/code/game/machinery/exp_cloner.dm
+++ b/code/game/machinery/exp_cloner.dm
@@ -75,8 +75,11 @@
 	H.key = C.key
 
 
-/obj/machinery/clonepod/experimental/proc/finish_cloning(mob/dead/observer/C)
+/obj/machinery/clonepod/experimental/proc/finish_cloning()
 	var/mob/living/carbon/human/H = locate() in contents
+
+	if(!H)
+		return FALSE
 
 	if(grab_ghost_when == CLONER_FRESH_CLONE)
 		H.grab_ghost()

--- a/code/game/machinery/exp_cloner.dm
+++ b/code/game/machinery/exp_cloner.dm
@@ -62,6 +62,15 @@
 	if(!C.client)
 		return FALSE
 
+	switch(alert(C, "Are you sure you want to play as this clone?", "Play as defective clone", "Yes", "No", "Jump to it instead"))
+		if("Yes")
+			//Just continue.
+		if("Jump to it instead")
+			C.forceMove(loc)
+			return FALSE
+		else //A "No" or another type of cancel.
+			return FALSE
+
 	var/mob/living/carbon/human/H = locate() in contents
 
 	if(QDELETED(H))


### PR DESCRIPTION
## Description
Removed the annoying popup message asking if you want to play a defective clone and substituted it with an alert you can click on.

Ported datum signals, so you can use them on any object or mob, just to make the code a little better.

## How Has This Been Tested?
Tested it locally. You can join via the notice alert alright.

## Changelog (neccesary)
:cl:
tweak: Annoying popup asking if you want to play a defective clone substituted by clickable alert.
/:cl:
