### PR TITLE
shotgun dart removal

### DIFF
--- a/code/modules/research/designs/autolathe_designs.dm
+++ b/code/modules/research/designs/autolathe_designs.dm
@@ -692,7 +692,7 @@
 	materials = list(MAT_METAL = 1000)
 	build_path = /obj/item/ammo_casing/shotgun/buckshot
 	category = list("hacked", "Security")
-
+/*
 /datum/design/shotgun_dart
 	name = "Shotgun Dart"
 	id = "shotgun_dart"
@@ -700,6 +700,7 @@
 	materials = list(MAT_METAL = 1000)
 	build_path = /obj/item/ammo_casing/shotgun/dart
 	category = list("hacked", "Security")
+*/
 
 /datum/design/incendiary_slug
 	name = "Incendiary Slug"


### PR DESCRIPTION
well CLEARLY nobody will do it no matter how many times i prove it's a bad idea

no more chem darts

i might see about adding other variant types of shotgun slugs tho. dragonsbreath would be an option if it wasn't just straight up better than incendiary slugs. frag-12 is too strong, too.

i'll think of something.

## Changelog (neccesary)
:cl:
balance: chem darts gone
/:cl:
