### PR TITLE
Update vault.dm

### DIFF
--- a/code/modules/jobs/job_types/vault.dm
+++ b/code/modules/jobs/job_types/vault.dm
@@ -436,3 +436,10 @@ Station Engineer
 		uniform = /obj/item/clothing/under/f13/vault13
 		ears = /obj/item/radio/headset/headset_vault
 		shoes = /obj/item/clothing/shoes/jackboots
+
+
+/datum/job/vault/New()
+	..()
+	if(SSmapping.config.map_name == "Pahrump")
+		total_positions = 0
+		spawn_positions = 0 


### PR DESCRIPTION

## Description
Should fix people spawning as vault
## Motivation and Context
Wanted to make it so I didnt have to fix this issue every round on the new map

## How Has This Been Tested?
It hasnt

## Screenshots (if appropriate):

## Changelog (neccesary)
-Edited Vault.dm to change job slots to zero
/:cl:
