### PR TITLE
Removes dismemberment, per Ren saying I should.

### DIFF
--- a/code/modules/mob/living/carbon/human/species_types/humans.dm
+++ b/code/modules/mob/living/carbon/human/species_types/humans.dm
@@ -3,6 +3,7 @@
 	id = "human"
 	default_color = "FFFFFF"
 	species_traits = list(EYECOLOR,HAIR,FACEHAIR,LIPS)
+	inherent_traits = list(TRAIT_NODISMEMBER,TRAIT_RESISTLOWPRESSURE)
 	default_features = list("mcolor" = "FFF", "tail_human" = "None", "ears" = "None", "wings" = "None")
 	use_skintones = 1
 	skinned_type = /obj/item/stack/sheet/animalhide/human


### PR DESCRIPTION
ren said i should. so i did.

dismemberment go bye.

also because chowder keeps accidentally depressurizing his whole map i'm givin humans the ability to resist low pressure because low-pressure environments like spce shouldn't even exist in the wastes and this should just mitigate any issues where that happens

## Changelog (neccesary)
:cl:
tweak: You can no longer dismember humans. This is temporary.
/:cl:
