### PR TITLE
Small Fix

### DIFF
--- a/code/modules/clothing/head/helmet.dm
+++ b/code/modules/clothing/head/helmet.dm
@@ -603,7 +603,7 @@
 	desc = "It's a pre-War power armor helmet, recovered and maintained by NCR engineers."
 	icon_state = "t45bhelmet"
 	item_state = "t45bhelmet"
-	armor = list("melee" = 75, "bullet" = 50, "laser" = 30, "energy" = 50, "bomb" = 48, "bio" = 60, "rad" = 50, "fire" = 75, "acid" = 0)
+	armor = list("melee" = 75, "bullet" = 60, "laser" = 30, "energy" = 50, "bomb" = 48, "bio" = 60, "rad" = 50, "fire" = 75, "acid" = 0)
 
 /obj/item/clothing/head/helmet/power_armor/advanced
 	name = "Advanced power helmet"

--- a/code/modules/jobs/job_types/ncr.dm
+++ b/code/modules/jobs/job_types/ncr.dm
@@ -228,6 +228,7 @@ Engineer
 	suit =          /obj/item/clothing/suit/armor/f13/ncrarmor/mantle
 	head = 			/obj/item/clothing/head/hardhat/orange
 	glasses = 		/obj/item/clothing/glasses/welding
+	gloves =		/obj/item/clothing/gloves/color/yellow
 	belt =          /obj/item/storage/belt/utility/full/engi
 	backpack_contents = list(
 		/obj/item/ammo_box/magazine/m9mm=1, \


### PR DESCRIPTION

## Description
Made salvaged PA helmet values match the armor itself, like lots of of other armors.
Gave the NCR engineer insulated gloves so they don't kill themselves setting up additional power methods.

## Changelog (neccesary)
:cl:
add: NCR Engineer now starts with insulated gloves.
balance: Made the heavy trooper salvaged helmet have the same protection as their suit.
/:cl:
