### PR TITLE
A Few Edits

### DIFF
--- a/code/game/objects/effects/spawners/f13lootdrop.dm
+++ b/code/game/objects/effects/spawners/f13lootdrop.dm
@@ -339,13 +339,8 @@
 				/obj/item/clothing/head/helmet/f13/combat/mk2
 				)
 
-	var/loot5 = list(
-				/obj/item/clothing/suit/armor/f13/rangercombat,
-				/obj/item/clothing/head/helmet/f13/ncr/rangercombat
-				)
-
 /obj/effect/spawner/lootdrop/f13/armor/tier3/Initialize(mapload) //on mapload, pick what shit to spawn
-	loot = pick(loot1, loot2, loot3, loot4, loot5)
+	loot = pick(loot1, loot2, loot3, loot4)
 	. = ..()
 
 /obj/effect/spawner/lootdrop/f13/armor/tier4 //TIER 4 ARMOR

--- a/code/modules/jobs/job_types/den.dm
+++ b/code/modules/jobs/job_types/den.dm
@@ -33,7 +33,9 @@ Sheriff
 	glasses =		/obj/item/clothing/glasses/sunglasses
 	l_hand = 		/obj/item/gun/ballistic/shotgun/automatic/hunting/cowboy
 	l_pocket =		/obj/item/storage/bag/money/small/den
-	backpack_contents = list(/obj/item/storage/box/deputy_badges=1)
+	backpack_contents = list(
+		/obj/item/storage/box/deputy_badges=1, \
+		/obj/item/ammo_box/tube/a357=2)
 
 
 	//pick("grey", "white", "yellow", "purple", "brown", "whatever")

--- a/code/modules/jobs/job_types/legion.dm
+++ b/code/modules/jobs/job_types/legion.dm
@@ -274,13 +274,13 @@ Vexillarius
 	suit = 			/obj/item/clothing/suit/armor/f13/legvexil
 	head = 			/obj/item/clothing/head/helmet/f13/legion/legvexil
 	glasses = 		/obj/item/clothing/glasses/sunglasses/big
-	suit_store = 	/obj/item/gun/ballistic/shotgun/automatic/hunting
+	suit_store = 	/obj/item/gun/ballistic/revolver/m29
 	backpack_contents = list(
 		/obj/item/throwing_star/spear, \
 		/obj/item/throwing_star/spear, \
 		/obj/item/claymore/machete/gladius=1, \
 		/obj/item/reagent_containers/pill/patch/healingpowder=2, \
-		/obj/item/ammo_box/a762/doublestacked=2, \
+		/obj/item/ammo_box/m44=2, \
 		/obj/item/flashlight/flare/torch=1, \
 		/obj/item/megaphone/cornu=1, \
 		/obj/item/storage/bag/money/small/legenlisted)
@@ -357,13 +357,13 @@ Prime
 	head = 			/obj/item/clothing/head/helmet/f13/legion/legrecruit/legprime
 	mask =			/obj/item/clothing/mask/bandana/legprime
 	glasses = 		/obj/item/clothing/glasses/sunglasses/big
-	suit_store = 	/obj/item/gun/ballistic/revolver/m29
+	suit_store = 	/obj/item/gun/ballistic/automatic/pistol/n99
 	backpack_contents = list(
 		/obj/item/restraints/legcuffs/bola=1, \
 		/obj/item/throwing_star/spear, \
 		/obj/item/throwing_star/spear, \
 		/obj/item/claymore/machete/gladius=1, \
-		/obj/item/ammo_box/m44=2, \
+		/obj/item/ammo_box/magazine/m10mm_adv=2, \
 		/obj/item/reagent_containers/pill/patch/healingpowder=2, \
 		/obj/item/flashlight/flare/torch=1, \
 		/obj/item/storage/bag/money/small/legenlisted)

--- a/code/modules/jobs/job_types/legion.dm
+++ b/code/modules/jobs/job_types/legion.dm
@@ -194,13 +194,13 @@ Prime Decan
 	head = 			/obj/item/clothing/head/helmet/f13/legion/legdecan/vet/prime
 	mask =			/obj/item/clothing/mask/bandana/legdecan
 	glasses = 		/obj/item/clothing/glasses/sunglasses/big
-	suit_store = 	/obj/item/gun/ballistic/automatic/pistol/n99
+	suit_store =    /obj/item/gun/ballistic/revolver/m29/alt
 	backpack_contents = list(
 		/obj/item/restraints/legcuffs/bola=1, \
 		/obj/item/throwing_star/spear, \
 		/obj/item/claymore/machete/gladius=1, \
 		/obj/item/reagent_containers/pill/patch/healingpowder=2, \
-		/obj/item/ammo_box/magazine/m10mm_adv=2, \
+		/obj/item/ammo_box/m44=2, \
 		/obj/item/flashlight/flare/torch=1, \
 		/obj/item/storage/bag/money/small/legofficers)
 
@@ -233,13 +233,13 @@ Decan
 	head = 			/obj/item/clothing/head/helmet/f13/legion/legdecan
 	mask =			/obj/item/clothing/mask/bandana/legdecan
 	glasses = 		/obj/item/clothing/glasses/sunglasses/big
-	suit_store = 	/obj/item/gun/ballistic/revolver/m29/alt
+	suit_store = 	/obj/item/gun/ballistic/automatic/pistol/n99
 	backpack_contents = list(
 		/obj/item/restraints/legcuffs/bola=1, \
 		/obj/item/throwing_star/spear, \
 		/obj/item/claymore/machete/gladius=1, \
 		/obj/item/reagent_containers/pill/patch/healingpowder=2, \
-		/obj/item/ammo_box/m44=2, \
+		/obj/item/ammo_box/magazine/m10mm_adv=2, \
 		/obj/item/flashlight/flare/torch=1, \
 		/obj/item/storage/bag/money/small/legofficers)
 

--- a/code/modules/jobs/job_types/ncr.dm
+++ b/code/modules/jobs/job_types/ncr.dm
@@ -232,7 +232,7 @@ Engineer
 	gloves =		/obj/item/clothing/gloves/color/yellow
 	belt =          /obj/item/storage/belt/utility/full/engi
 	backpack_contents = list(
-		/obj/item/ammo_box/magazine/internal/cylinder/rev38=2, \
+		/obj/item/ammo_box/c38=2, \
 		/obj/item/gun/ballistic/revolver/detective, \
 		/obj/item/reagent_containers/hypospray/medipen/stimpak=1, \
 		/obj/item/stack/medical/gauze=1, \

--- a/code/modules/jobs/job_types/ncr.dm
+++ b/code/modules/jobs/job_types/ncr.dm
@@ -193,7 +193,8 @@ Medic
 	backpack_contents = list(
 		/obj/item/storage/box/lethalshot, \
 		/obj/item/kitchen/knife/combat/survival=1, \
-		/obj/item/gun/ballistic/automatic/pistol/ninemil=1, \
+		/obj/item/gun/ballistic/automatic/pistol/m1911, \
+		/obj/item/ammo_box/magazine/m45=2, \
 		/obj/item/reagent_containers/hypospray/medipen/stimpak=1, \
 		/obj/item/stack/medical/gauze=1, \
 		/obj/item/storage/bag/money/small/ncrofficers)
@@ -231,8 +232,8 @@ Engineer
 	gloves =		/obj/item/clothing/gloves/color/yellow
 	belt =          /obj/item/storage/belt/utility/full/engi
 	backpack_contents = list(
-		/obj/item/ammo_box/magazine/m9mm=1, \
-		/obj/item/gun/ballistic/automatic/pistol/ninemil=1, \
+		/obj/item/ammo_box/magazine/internal/cylinder/rev38=2, \
+		/obj/item/gun/ballistic/revolver/detective, \
 		/obj/item/reagent_containers/hypospray/medipen/stimpak=1, \
 		/obj/item/stack/medical/gauze=1, \
 		/obj/item/stack/sheet/metal/ten,  \


### PR DESCRIPTION
## Description
Removes NCR faction veteran ranger armor from the loot table that was spawning occasionally.
Swaps the prime and recruit decanus weapons, as the recruit had a better weapon than the prime.
Removes the Vexillarius' Rangemaster, replaces with a default .44 revolver.
Replaces the Prime Legionnaire's .44 revolver with a 10mm pistol.
Gives the NCR Engineer a .38 revolver, and the NCR Sergeants a .45 sidearm.
Gives the Sheriff a couple .357 tubes for their repeater.

## Motivation and Context
Faction ranger armor shouldn't be spawning. Legion had the ranged advantage on the NCR with .44s being so strong (Am also going to ask a mapper to swap all the .44s in the legion armory with something less powerful). Differentiates the sidearms NCOs get because their loadouts were shoddy.

## How Has This Been Tested?
Started a local test and ensured all the item paths were coded correctly. People spawn with what I changed.

## Changelog (neccesary)
:cl:
add: NCR Engineer and Sergeant finally get some love with their own sidearms.
add: Sheriff spawns with some ammo for their repeater.
del: Removed NCR Veteran Ranger armor from the loot table.
balance: Rebalanced the loadouts of legion jobs to better fit the NCR having ranged superiority.
/:cl:
