### PR TITLE
Adds a verb cooldown to prevent spam

### DIFF
--- a/interactions/_interaction.dm
+++ b/interactions/_interaction.dm
@@ -47,6 +47,11 @@ var/list/interactions
 	var/needs_physical_contact
 
 /datum/interaction/proc/evaluate_user(mob/living/user, silent = TRUE)
+	if(user.refactory_period)
+		if(!silent) //bye spam
+			to_chat(user, "<span class='warning'>You're still exhausted from the last time. You need to wait [DisplayTimeText(user.refactory_period * 10, TRUE)] until you can do that!</span>")
+		return FALSE
+
 	if(require_user_mouth)
 		if(!user.has_mouth())
 			if(!silent)
@@ -119,7 +124,7 @@ var/list/interactions
 
 	display_interaction(user, target)
 	post_interaction(user, target)
-
+	user.refactory_period = 10
 
 	//if(write_log_user)
 		//add_logs(target, user, "fucked")

--- a/interactions/_interaction.dm
+++ b/interactions/_interaction.dm
@@ -124,7 +124,7 @@ var/list/interactions
 
 	display_interaction(user, target)
 	post_interaction(user, target)
-	user.refactory_period = 10
+	user.refactory_period = 5
 
 	//if(write_log_user)
 		//add_logs(target, user, "fucked")


### PR DESCRIPTION
## Description
Title basically, adds a 5s cooldown to all verbs to prevent spam, this is mainly meant to combat things like ass slap spam but to be perfectly honest, you shouldn't be spamming "salute" or "wave" either.

## Motivation and Context
Verb spam is literally evil.

## How Has This Been Tested?
Tested in a private and it worked.

## Screenshots (if appropriate):
https://cdn.discordapp.com/attachments/470355438572011530/590774200663408642/unknown.png

## Changelog (neccesary)
:cl:

add: 5 second verb cooldown.

/:cl:
