### PR TITLE
Small Fixes

### DIFF
--- a/code/game/objects/effects/spawners/f13lootdrop.dm
+++ b/code/game/objects/effects/spawners/f13lootdrop.dm
@@ -339,13 +339,8 @@
 				/obj/item/clothing/head/helmet/f13/combat/mk2
 				)
 
-	var/loot5 = list(
-				/obj/item/clothing/suit/armor/f13/rangercombat,
-				/obj/item/clothing/head/helmet/f13/ncr/rangercombat
-				)
-
 /obj/effect/spawner/lootdrop/f13/armor/tier3/Initialize(mapload) //on mapload, pick what shit to spawn
-	loot = pick(loot1, loot2, loot3, loot4, loot5)
+	loot = pick(loot1, loot2, loot3, loot4)
 	. = ..()
 
 /obj/effect/spawner/lootdrop/f13/armor/tier4 //TIER 4 ARMOR

--- a/code/modules/jobs/job_types/den.dm
+++ b/code/modules/jobs/job_types/den.dm
@@ -33,7 +33,9 @@ Sheriff
 	glasses =		/obj/item/clothing/glasses/sunglasses
 	l_hand = 		/obj/item/gun/ballistic/shotgun/automatic/hunting/cowboy
 	l_pocket =		/obj/item/storage/bag/money/small/den
-	backpack_contents = list(/obj/item/storage/box/deputy_badges=1)
+	backpack_contents = list(
+		/obj/item/storage/box/deputy_badges=1, \
+		/obj/item/ammo_box/tube/a357=2)
 
 
 	//pick("grey", "white", "yellow", "purple", "brown", "whatever")

--- a/code/modules/jobs/job_types/legion.dm
+++ b/code/modules/jobs/job_types/legion.dm
@@ -194,13 +194,13 @@ Prime Decan
 	head = 			/obj/item/clothing/head/helmet/f13/legion/legdecan/vet/prime
 	mask =			/obj/item/clothing/mask/bandana/legdecan
 	glasses = 		/obj/item/clothing/glasses/sunglasses/big
-	suit_store = 	/obj/item/gun/ballistic/automatic/pistol/n99
+	suit_store = 	/obj/item/gun/ballistic/revolver/m29/alt
 	backpack_contents = list(
 		/obj/item/restraints/legcuffs/bola=1, \
 		/obj/item/throwing_star/spear, \
 		/obj/item/claymore/machete/gladius=1, \
 		/obj/item/reagent_containers/pill/patch/healingpowder=2, \
-		/obj/item/ammo_box/magazine/m10mm_adv=2, \
+		/obj/item/ammo_box/m44=2, \
 		/obj/item/flashlight/flare/torch=1, \
 		/obj/item/storage/bag/money/small/legofficers)
 
@@ -233,13 +233,13 @@ Decan
 	head = 			/obj/item/clothing/head/helmet/f13/legion/legdecan
 	mask =			/obj/item/clothing/mask/bandana/legdecan
 	glasses = 		/obj/item/clothing/glasses/sunglasses/big
-	suit_store = 	/obj/item/gun/ballistic/revolver/m29/alt
+	suit_store = 	/obj/item/gun/ballistic/automatic/pistol/n99
 	backpack_contents = list(
 		/obj/item/restraints/legcuffs/bola=1, \
 		/obj/item/throwing_star/spear, \
 		/obj/item/claymore/machete/gladius=1, \
 		/obj/item/reagent_containers/pill/patch/healingpowder=2, \
-		/obj/item/ammo_box/m44=2, \
+		/obj/item/ammo_box/magazine/m10mm_adv=2, \
 		/obj/item/flashlight/flare/torch=1, \
 		/obj/item/storage/bag/money/small/legofficers)
 


### PR DESCRIPTION
## Description
Removes NCR faction veteran ranger armor from the loot table that was spawning occasionally.
Swaps the prime and recruit decanus weapons, as the recruit had a better weapon than the prime.
Gives the Sheriff a couple .357 tubes for their repeater.

## Motivation and Context
Faction ranger armor shouldn't be spawning. The sheriff may as well toss his repeater after the first raider. The lower ranking decanus had a better weapon than his more experienced counterpart.

## How Has This Been Tested?
Started a local test and ensured all the item paths were coded correctly. People spawn with what I changed.

## Changelog (neccesary)
:cl:
add: Sheriff spawns with some ammo for their repeater.
del: Removed NCR Veteran Ranger faction armor from the loot table.
fix: Prime and Recruit Decanus guns are swapped as the recruit had the better weapon.
/:cl:
