### PR TITLE
Changes verb cooldown from 5s to 3s

### DIFF
--- a/interactions/_interaction.dm
+++ b/interactions/_interaction.dm
@@ -124,7 +124,7 @@ var/list/interactions
 
 	display_interaction(user, target)
 	post_interaction(user, target)
-	user.refactory_period = 5
+	user.refactory_period = 3
 
 	//if(write_log_user)
 		//add_logs(target, user, "fucked")


### PR DESCRIPTION
## Description
Basically the title

## Motivation and Context
People complained and I guess 5 seconds is a tad long.

## How Has This Been Tested?
It hasn't but I literally changed one number and said number is the correct number to change.

## Screenshots (if appropriate):

## Changelog (neccesary)
:cl:

balance: Buffs ERP by reducing verb cooldown from 5s to 3s

/:cl:
