### PR TITLE
The Great Hotfix of 2281

### DIFF
--- a/code/modules/fallout/turf/walls.dm
+++ b/code/modules/fallout/turf/walls.dm
@@ -23,6 +23,7 @@
 	baseturfs = /turf/open/indestructible/ground/outside/ruins
 	sheet_type = null
 	canSmoothWith = list(/turf/closed/wall/f13/ruins, /turf/closed/wall)
+	unbreakable = 0
 
 
 /turf/closed/wall/f13/wood
@@ -39,7 +40,6 @@
 	sheet_amount = 2
 	girder_type = 0
 	canSmoothWith = list(/turf/closed/wall/f13/wood, /turf/closed/wall)
-	unbreakable = 0
 
 /turf/closed/wall/f13/wood/house
 	name = "house wall"
@@ -50,7 +50,6 @@
 	hardness = 50
 	var/broken = 0
 	canSmoothWith = list(/turf/closed/wall/f13/wood/house, /turf/closed/wall/f13/wood/house/broken, /turf/closed/wall)
-	unbreakable = 0
 
 /turf/closed/wall/f13/wood/house/broken
 	broken = 1
@@ -84,7 +83,6 @@
 	hardness = 10
 	smooth = SMOOTH_OLD
 	canSmoothWith = list(/turf/closed/wall/f13/wood/interior, /turf/closed/wall)
-	unbreakable = 0
 
 /turf/closed/wall/f13/store
 	name = "store wall"
@@ -99,6 +97,7 @@
 	girder_type = 0
 	sheet_type = null
 	canSmoothWith = list(/turf/closed/wall/f13/store, /turf/closed/wall)
+	unbreakable = 0
 
 /turf/closed/wall/f13/supermart
 	name = "supermart wall"
@@ -114,6 +113,7 @@
 	girder_type = 0
 	sheet_type = null
 	canSmoothWith = list(/turf/closed/wall/f13/supermart, /turf/closed/wall)
+	unbreakable = 0
 
 /turf/closed/wall/f13/tunnel
 	name = "utility tunnel wall"
@@ -127,6 +127,7 @@
 	girder_type = 0
 	sheet_type = null
 	canSmoothWith = list(/turf/closed/wall/f13/tunnel, /turf/closed/wall)
+	unbreakable = 0
 
 /turf/closed/wall/f13/vault
 	name = "vault wall"
@@ -138,6 +139,7 @@
 	explosion_block = 5
 	smooth = SMOOTH_OLD
 	canSmoothWith = list(/turf/closed/wall/f13/vault, /turf/closed/wall/r_wall/f13/vault, /turf/closed/wall)
+	unbreakable = 0
 
 /turf/closed/wall/r_wall/f13
 	name = "glitch"


### PR DESCRIPTION
## Description
Fixes the despicable returning problem of being able to melee solid walls.

## Motivation and Context
I couldn't sit idly by watching people break my beautiful 2 foot thick steel/concrete walls anymore. 
I'm not going to stand here and listen to ping whores badmouth the greatest fallout server this world has ever seen.

## How Has This Been Tested?
Local testing.

## Changelog (neccesary)
:cl:
fix: You can no longer melee down solid concrete/steel walls. You can melee wooden and house walls. You can still use fuel barrels to destroy steel/concrete however.
/:cl:
