### PR TITLE
Fix for missing/not working ammo types + Gauss removal

### DIFF
--- a/code/game/objects/effects/spawners/f13lootdrop.dm
+++ b/code/game/objects/effects/spawners/f13lootdrop.dm
@@ -887,24 +887,18 @@
 				)
 
 	var/loot9 = list(
-				/obj/item/gun/ballistic/automatic/m72,
-				/obj/item/ammo_box/magazine/m2mm,
-				/obj/item/ammo_box/magazine/m2mm
-				)
-
-	var/loot10 = list(
 				 /obj/item/gun/ballistic/shotgun/automatic/hunting/brush,
 				 /obj/item/ammo_box/tube/c4570,
 				 /obj/item/ammo_box/tube/c4570
 				 )
 
-	var/loot11 = list(/obj/item/gun/ballistic/shotgun/automatic/hunting/brush/scoped,
+	var/loot10 = list(/obj/item/gun/ballistic/shotgun/automatic/hunting/brush/scoped,
 				 /obj/item/ammo_box/tube/c4570,
 				 /obj/item/ammo_box/tube/c4570
 				 )
 
 /obj/effect/spawner/lootdrop/f13/weapon/gun/tier4/Initialize(mapload) //on mapload, pick what shit to spawn
-	loot = pick(loot1, loot2, loot3, loot4, loot5, loot6, loot7, loot8, loot9, loot10, loot11)
+	loot = pick(loot1, loot2, loot3, loot4, loot5, loot6, loot7, loot8, loot9, loot10)
 	. = ..()
 
 /obj/effect/spawner/lootdrop/f13/weapon/gun/tier5 //TIER 5 GUN

--- a/code/modules/crafting/recipes.dm
+++ b/code/modules/crafting/recipes.dm
@@ -246,11 +246,68 @@
 	tools = list(TOOL_SCREWDRIVER,
 				TOOL_MSRELOADER)
 
+/datum/crafting_recipe/c4570/makeshift
+	name = "Makeshift 45-70 speed loader"
+	reqs = list(/obj/item/stack/sheet/metal = 8)
+	tools = list(TOOL_SCREWDRIVER,
+				TOOL_MSRELOADER)
+
+/datum/crafting_recipe/c4570tube/makeshift
+	name = "Makeshift 45-70 tube"
+	reqs = list(/obj/item/stack/sheet/metal = 8)
+	tools = list(TOOL_SCREWDRIVER,
+				TOOL_MSRELOADER)
+
+/datum/crafting_recipe/50mg/makeshift
+	name = "Makeshift .50MG ammo rack"
+	reqs = list(/obj/item/stack/sheet/metal = 10)
+	tools = list(TOOL_SCREWDRIVER,
+				TOOL_MSRELOADER)
 
 /datum/crafting_recipe/m44
 	name = ".44 Magnum speed loader"
 	result = /obj/item/ammo_box/m44
 	reqs = list(/obj/item/stack/sheet/metal = 3)
+	tools = list(TOOL_SCREWDRIVER,
+				TOOL_RELOADER)
+	time = 10
+	category = CAT_WEAPONRY
+	subcategory = CAT_AMMO
+
+/datum/crafting_recipe/a357
+	name = ".357 Magnum speed strip"
+	result = /obj/item/ammo_box/a357
+	reqs = list(/obj/item/stack/sheet/metal = 3)
+	tools = list(TOOL_SCREWDRIVER,
+				TOOL_RELOADER)
+	time = 10
+	category = CAT_WEAPONRY
+	subcategory = CAT_AMMO
+
+/datum/crafting_recipe/c4570
+	name = "45-70 speed loader"
+	result = /obj/item/ammo_box/c4570
+	reqs = list(/obj/item/stack/sheet/metal = 5)
+	tools = list(TOOL_SCREWDRIVER,
+				TOOL_RELOADER)
+	time = 10
+	category = CAT_WEAPONRY
+	subcategory = CAT_AMMO
+
+/datum/crafting_recipe/c4570tube
+	name = "45-70 tube"
+	result = /obj/item/ammo_box/tube/c4570
+	reqs = list(/obj/item/stack/sheet/metal = 5)
+	tools = list(TOOL_SCREWDRIVER,
+				TOOL_RELOADER)
+	time = 10
+	category = CAT_WEAPONRY
+	subcategory = CAT_AMMO
+
+/datum/crafting_recipe/50mg
+	name = ".50MG ammo rack"
+	result = /obj/item/ammo_box/a50MG
+	reqs = list(/obj/item/stack/sheet/metal = 7)
 	tools = list(TOOL_SCREWDRIVER,
 				TOOL_RELOADER)
 	time = 10

--- a/code/modules/crafting/recipes.dm
+++ b/code/modules/crafting/recipes.dm
@@ -258,8 +258,8 @@
 	tools = list(TOOL_SCREWDRIVER,
 				TOOL_MSRELOADER)
 
-/datum/crafting_recipe/50mg/makeshift
-	name = "Makeshift .50MG ammo rack"
+/datum/crafting_recipe/a50mg/makeshift
+	name = "Makeshift 50MG ammo rack"
 	reqs = list(/obj/item/stack/sheet/metal = 10)
 	tools = list(TOOL_SCREWDRIVER,
 				TOOL_MSRELOADER)
@@ -304,8 +304,8 @@
 	category = CAT_WEAPONRY
 	subcategory = CAT_AMMO
 
-/datum/crafting_recipe/50mg
-	name = ".50MG ammo rack"
+/datum/crafting_recipe/a50mg
+	name = "50MG ammo rack"
 	result = /obj/item/ammo_box/a50MG
 	reqs = list(/obj/item/stack/sheet/metal = 7)
 	tools = list(TOOL_SCREWDRIVER,


### PR DESCRIPTION
## Description
Adds in .50MG and .45-70 to ammo crafting + fixes .357 not showing up at all. Also removes Gauss Rifle from loot drops because it is super buggy and it's ammo **literally** doesn't exist.

## Motivation and Context
Ammo is missing and Gauss is buggy.

## How Has This Been Tested?
Only really small copy + paste tweaks and a deletion.

## Screenshots (if appropriate):

## Changelog (neccesary)
:cl:

add: .50MG and 45-70 to ammo crafting

del: Removes Gauss rifle from loot drops

fix: Fixes .357 speed strips not being craftable

/:cl:
