### PR TITLE
Heavy Trooper Helmet Fix

### DIFF
--- a/code/modules/jobs/job_types/ncr.dm
+++ b/code/modules/jobs/job_types/ncr.dm
@@ -342,7 +342,7 @@ Heavy Trooper
 	uniform =  		/obj/item/clothing/under/f13/ncr
 	accessory =     /obj/item/clothing/accessory/ncr/SGT
 	suit = 			/obj/item/clothing/suit/armor/f13/brokenpa/t45b
-	head = 			/obj/item/clothing/head/helmet/f13/brokenpa/t45b
+	head = 			/obj/item/clothing/head/helmet/power_armor/t45b
 	glasses = 		/obj/item/clothing/glasses/sunglasses/big
 	shoes =         /obj/item/clothing/shoes/combat/swat
 	suit_store = 	/obj/item/gun/ballistic/shotgun/riot


### PR DESCRIPTION
## Description
The object path for the correct salvaged PA helmet does not match the armor path, the person who made the loadout must not have realized this because they gave the HT the incorrect, totally broken helmet, instead of the actual salvaged helmet.

## Motivation and Context
Fixing a mistake.

## Changelog (neccesary)
:cl:
fix: The Heavy Trooper now spawns with the correct salvaged helmet.
/:cl:
