### PR TITLE
Comments out a couple traits

### DIFF
--- a/code/datums/traits/good.dm
+++ b/code/datums/traits/good.dm
@@ -156,11 +156,10 @@
 //////FL13 weapons traits!
 ///DO NOT USE IMPLANTS.
 ///Grenades
-/*
 /datum/quirk/grenadesloot
 	name = "Party Favor"
 	desc = "Who knows what's inside."
-	value = 1
+	value = 3
 	var/obj/item/heirloom ///SPAGETH CODE DON'T LEAVE TO REMOVE THE NAME.
 	var/where
 
@@ -189,7 +188,6 @@
 	if(where == "in your backpack")
 		var/mob/living/carbon/human/H = quirk_holder
 		SEND_SIGNAL(H.back, COMSIG_TRY_STORAGE_SHOW, H) //GOD BLESS SPAGETHY CODE!
-*/
 ///TO DO: TEST IT WITH BOXES LIKE MEDKITS/NORMALS BOXES.
 ///ADD MORE EQUIPMENT TRAITS REEEE
 ///IMPROVE MY ENGLISH

--- a/code/datums/traits/good.dm
+++ b/code/datums/traits/good.dm
@@ -78,7 +78,7 @@
 	value = 1
 	mob_trait = TRAIT_JOLLY
 	mood_quirk = TRUE
-
+/*
 /datum/quirk/hard_yards
 	name = "Hard Yards"
 	desc = "You've put them in, now reap the rewards."
@@ -87,7 +87,7 @@
 	mob_trait = TRAIT_HARD_YARDS
 	gain_text = "<span class='notice'>Rain or shine, nothing slows you down.</span>"
 	lose_text = "<span class='danger'>You walk with a less sure gait, the ground seeming less firm somehow.</span>"
-
+*/
 /datum/quirk/lifegiver
 	name = "Lifegiver"
 	desc = "You embody wellness! Instantly gain +15 maximum Health"
@@ -156,6 +156,7 @@
 //////FL13 weapons traits!
 ///DO NOT USE IMPLANTS.
 ///Grenades
+/*
 /datum/quirk/grenadesloot
 	name = "Party Favor"
 	desc = "Who knows what's inside."
@@ -188,7 +189,7 @@
 	if(where == "in your backpack")
 		var/mob/living/carbon/human/H = quirk_holder
 		SEND_SIGNAL(H.back, COMSIG_TRY_STORAGE_SHOW, H) //GOD BLESS SPAGETHY CODE!
-
+*/
 ///TO DO: TEST IT WITH BOXES LIKE MEDKITS/NORMALS BOXES.
 ///ADD MORE EQUIPMENT TRAITS REEEE
 ///IMPROVE MY ENGLISH

--- a/code/datums/traits/good.dm
+++ b/code/datums/traits/good.dm
@@ -133,7 +133,7 @@
 /datum/quirk/skittish
 	name = "Skittish"
 	desc = "You can conceal yourself in danger. Ctrl-shift-click a closed locker to jump into it, as long as you have access."
-	value = 2
+	value = 1
 	mob_trait = TRAIT_SKITTISH
 
 /datum/quirk/spiritual

--- a/code/datums/traits/negative.dm
+++ b/code/datums/traits/negative.dm
@@ -16,7 +16,7 @@
 		quirk_holder.blood_volume -= 0.275
 
 
-
+/*
 /datum/quirk/depression
 	name = "Depression"
 	desc = "You sometimes just hate life."
@@ -28,69 +28,6 @@
 	mood_quirk = TRUE
 
 
-
-/datum/quirk/family_heirloom
-	name = "Family Heirloom"
-	desc = "You are the current owner of an heirloom, passed down for generations. You have to keep it safe!"
-	value = -1
-	mood_quirk = TRUE
-	var/obj/item/heirloom
-	var/where
-
-/datum/quirk/family_heirloom/on_spawn()
-	var/mob/living/carbon/human/H = quirk_holder
-	var/obj/item/heirloom_type
-	switch(quirk_holder.mind.assigned_role)
-		if("Clown")
-			heirloom_type = /obj/item/bikehorn/golden
-		if("Mime")
-			heirloom_type = /obj/item/reagent_containers/food/snacks/baguette
-		if("Lawyer")
-			heirloom_type = /obj/item/gavelhammer
-		if("Janitor")
-			heirloom_type = /obj/item/mop
-		if("Security Officer")
-			heirloom_type = /obj/item/book/manual/wiki/security_space_law
-		if("Scientist")
-			heirloom_type = /obj/item/toy/plush/slimeplushie
-		if("Assistant")
-			heirloom_type = /obj/item/storage/toolbox/mechanical/old/heirloom
-	if(!heirloom_type)
-		heirloom_type = pick(
-		/obj/item/toy/cards/deck,
-		/obj/item/lighter,
-		/obj/item/dice/d20)
-	heirloom = new heirloom_type(get_turf(quirk_holder))
-	var/list/slots = list(
-		"in your left pocket" = SLOT_L_STORE,
-		"in your right pocket" = SLOT_R_STORE,
-		"in your backpack" = SLOT_IN_BACKPACK
-	)
-	where = H.equip_in_one_of_slots(heirloom, slots, FALSE) || "at your feet"
-
-/datum/quirk/family_heirloom/post_add()
-	if(where == "in your backpack")
-		var/mob/living/carbon/human/H = quirk_holder
-		SEND_SIGNAL(H.back, COMSIG_TRY_STORAGE_SHOW, H)
-
-	to_chat(quirk_holder, "<span class='boldnotice'>There is a precious family [heirloom.name] [where], passed down from generation to generation. Keep it safe!</span>")
-	var/list/family_name = splittext(quirk_holder.real_name, " ")
-	heirloom.name = "\improper [family_name[family_name.len]] family [heirloom.name]"
-
-/datum/quirk/family_heirloom/on_process()
-	if(heirloom in quirk_holder.GetAllContents())
-		SEND_SIGNAL(quirk_holder, COMSIG_CLEAR_MOOD_EVENT, "family_heirloom_missing")
-		SEND_SIGNAL(quirk_holder, COMSIG_ADD_MOOD_EVENT, "family_heirloom", /datum/mood_event/family_heirloom)
-	else
-		SEND_SIGNAL(quirk_holder, COMSIG_CLEAR_MOOD_EVENT, "family_heirloom")
-		SEND_SIGNAL(quirk_holder, COMSIG_ADD_MOOD_EVENT, "family_heirloom_missing", /datum/mood_event/family_heirloom_missing)
-
-/datum/quirk/family_heirloom/clone_data()
-	return heirloom
-
-/datum/quirk/family_heirloom/on_clone(data)
-	heirloom = data
-
 /datum/quirk/heavy_sleeper
 	name = "Heavy Sleeper"
 	desc = "You sleep like a rock! Whenever you're put to sleep, you sleep for a little bit longer."
@@ -99,7 +36,7 @@
 	gain_text = "<span class='danger'>You feel sleepy.</span>"
 	lose_text = "<span class='notice'>You feel awake again.</span>"
 	medical_record_text = "Patient has abnormal sleep study results and is difficult to wake up."
-
+*/
 /datum/quirk/brainproblems
 	name = "Brain Tumor"
 	desc = "You have a little friend in your brain that is slowly destroying it. Better bring some mannitol!"
@@ -136,7 +73,7 @@
 /datum/quirk/nyctophobia
 	name = "Nyctophobia"
 	desc = "As far as you can remember, you've always been afraid of the dark. While in the dark without a light source, you instinctually act careful, and constantly feel a sense of dread."
-	value = -1
+	value = -2
 
 /datum/quirk/nyctophobia/on_process()
 	var/mob/living/carbon/human/H = quirk_holder
@@ -157,7 +94,7 @@
 /datum/quirk/nonviolent
 	name = "Pacifist"
 	desc = "The thought of violence makes you sick. So much so, in fact, that you can't hurt anyone."
-	value = -2
+	value = -3
 	mob_trait = TRAIT_PACIFISM
 	gain_text = "<span class='danger'>You feel repulsed by the thought of violence!</span>"
 	lose_text = "<span class='notice'>You think you can defend yourself again.</span>"
@@ -173,7 +110,7 @@
 /datum/quirk/poor_aim
 	name = "Poor Aim"
 	desc = "You're terrible with guns and can't line up a straight shot to save your life. Dual-wielding is right out."
-	value = -1
+	value = -2
 	mob_trait = TRAIT_POOR_AIM
 	medical_record_text = "Patient possesses a strong tremor in both hands."
 
@@ -185,40 +122,6 @@
 	value = -1
 	mob_trait = TRAIT_PROSOPAGNOSIA
 	medical_record_text = "Patient suffers from prosopagnosia and cannot recognize faces."
-
-
-
-/datum/quirk/prosthetic_limb
-	name = "Prosthetic Limb"
-	desc = "An accident caused you to lose one of your limbs. Because of this, you now have a random prosthetic!"
-	value = -1
-	var/slot_string = "limb"
-
-/datum/quirk/prosthetic_limb/on_spawn()
-	var/limb_slot = pick(BODY_ZONE_L_ARM, BODY_ZONE_R_ARM, BODY_ZONE_L_LEG, BODY_ZONE_R_LEG)
-	var/mob/living/carbon/human/H = quirk_holder
-	var/obj/item/bodypart/old_part = H.get_bodypart(limb_slot)
-	var/obj/item/bodypart/prosthetic
-	switch(limb_slot)
-		if(BODY_ZONE_L_ARM)
-			prosthetic = new/obj/item/bodypart/l_arm/robot/surplus(quirk_holder)
-			slot_string = "left arm"
-		if(BODY_ZONE_R_ARM)
-			prosthetic = new/obj/item/bodypart/r_arm/robot/surplus(quirk_holder)
-			slot_string = "right arm"
-		if(BODY_ZONE_L_LEG)
-			prosthetic = new/obj/item/bodypart/l_leg/robot/surplus(quirk_holder)
-			slot_string = "left leg"
-		if(BODY_ZONE_R_LEG)
-			prosthetic = new/obj/item/bodypart/r_leg/robot/surplus(quirk_holder)
-			slot_string = "right leg"
-	prosthetic.replace_limb(H)
-	qdel(old_part)
-	H.regenerate_icons()
-
-/datum/quirk/prosthetic_limb/post_add()
-	to_chat(quirk_holder, "<span class='boldannounce'>Your [slot_string] has been replaced with a surplus prosthetic. It is fragile and will easily come apart under duress. Additionally, \
-	you need to use a welding tool and cables to repair it, instead of bruise packs and ointment.</span>")
 
 
 
@@ -252,7 +155,7 @@
 /datum/quirk/social_anxiety
 	name = "Social Anxiety"
 	desc = "Talking to people is very difficult for you, and you often stutter or even lock up."
-	value = -1
+	value = -2
 	gain_text = "<span class='danger'>You start worrying about what you're saying.</span>"
 	lose_text = "<span class='notice'>You feel easier about talking again.</span>" //if only it were that easy!
 	medical_record_text = "Patient is usually anxious in social encounters and prefers to avoid them."

--- a/code/datums/traits/neutral.dm
+++ b/code/datums/traits/neutral.dm
@@ -69,6 +69,100 @@
 		species.liked_food = initial(species.liked_food)
 		species.disliked_food = initial(species.disliked_food)
 
+/datum/quirk/prosthetic_limb
+	name = "Prosthetic Limb"
+	desc = "An accident caused you to lose one of your limbs. Because of this, you now have a random prosthetic!"
+	value = 0
+	var/slot_string = "limb"
+
+/datum/quirk/prosthetic_limb/on_spawn()
+	var/limb_slot = pick(BODY_ZONE_L_ARM, BODY_ZONE_R_ARM, BODY_ZONE_L_LEG, BODY_ZONE_R_LEG)
+	var/mob/living/carbon/human/H = quirk_holder
+	var/obj/item/bodypart/old_part = H.get_bodypart(limb_slot)
+	var/obj/item/bodypart/prosthetic
+	switch(limb_slot)
+		if(BODY_ZONE_L_ARM)
+			prosthetic = new/obj/item/bodypart/l_arm/robot/surplus(quirk_holder)
+			slot_string = "left arm"
+		if(BODY_ZONE_R_ARM)
+			prosthetic = new/obj/item/bodypart/r_arm/robot/surplus(quirk_holder)
+			slot_string = "right arm"
+		if(BODY_ZONE_L_LEG)
+			prosthetic = new/obj/item/bodypart/l_leg/robot/surplus(quirk_holder)
+			slot_string = "left leg"
+		if(BODY_ZONE_R_LEG)
+			prosthetic = new/obj/item/bodypart/r_leg/robot/surplus(quirk_holder)
+			slot_string = "right leg"
+	prosthetic.replace_limb(H)
+	qdel(old_part)
+	H.regenerate_icons()
+
+/datum/quirk/prosthetic_limb/post_add()
+	to_chat(quirk_holder, "<span class='boldannounce'>Your [slot_string] has been replaced with a surplus prosthetic. It is fragile and will easily come apart under duress. Additionally, \
+	you need to use a welding tool and cables to repair it, instead of bruise packs and ointment.</span>")
+
+/datum/quirk/family_heirloom
+	name = "Family Heirloom"
+	desc = "You are the current owner of an heirloom, passed down for generations. You have to keep it safe!"
+	value = 0
+	mood_quirk = TRUE
+	var/obj/item/heirloom
+	var/where
+
+/datum/quirk/family_heirloom/on_spawn()
+	var/mob/living/carbon/human/H = quirk_holder
+	var/obj/item/heirloom_type
+	switch(quirk_holder.mind.assigned_role)
+		if("Clown")
+			heirloom_type = /obj/item/bikehorn/golden
+		if("Mime")
+			heirloom_type = /obj/item/reagent_containers/food/snacks/baguette
+		if("Lawyer")
+			heirloom_type = /obj/item/gavelhammer
+		if("Janitor")
+			heirloom_type = /obj/item/mop
+		if("Security Officer")
+			heirloom_type = /obj/item/book/manual/wiki/security_space_law
+		if("Scientist")
+			heirloom_type = /obj/item/toy/plush/slimeplushie
+		if("Assistant")
+			heirloom_type = /obj/item/storage/toolbox/mechanical/old/heirloom
+	if(!heirloom_type)
+		heirloom_type = pick(
+		/obj/item/toy/cards/deck,
+		/obj/item/lighter,
+		/obj/item/dice/d20)
+	heirloom = new heirloom_type(get_turf(quirk_holder))
+	var/list/slots = list(
+		"in your left pocket" = SLOT_L_STORE,
+		"in your right pocket" = SLOT_R_STORE,
+		"in your backpack" = SLOT_IN_BACKPACK
+	)
+	where = H.equip_in_one_of_slots(heirloom, slots, FALSE) || "at your feet"
+
+/datum/quirk/family_heirloom/post_add()
+	if(where == "in your backpack")
+		var/mob/living/carbon/human/H = quirk_holder
+		SEND_SIGNAL(H.back, COMSIG_TRY_STORAGE_SHOW, H)
+
+	to_chat(quirk_holder, "<span class='boldnotice'>There is a precious family [heirloom.name] [where], passed down from generation to generation. Keep it safe!</span>")
+	var/list/family_name = splittext(quirk_holder.real_name, " ")
+	heirloom.name = "\improper [family_name[family_name.len]] family [heirloom.name]"
+
+/datum/quirk/family_heirloom/on_process()
+	if(heirloom in quirk_holder.GetAllContents())
+		SEND_SIGNAL(quirk_holder, COMSIG_CLEAR_MOOD_EVENT, "family_heirloom_missing")
+		SEND_SIGNAL(quirk_holder, COMSIG_ADD_MOOD_EVENT, "family_heirloom", /datum/mood_event/family_heirloom)
+	else
+		SEND_SIGNAL(quirk_holder, COMSIG_CLEAR_MOOD_EVENT, "family_heirloom")
+		SEND_SIGNAL(quirk_holder, COMSIG_ADD_MOOD_EVENT, "family_heirloom_missing", /datum/mood_event/family_heirloom_missing)
+
+/datum/quirk/family_heirloom/clone_data()
+	return heirloom
+
+/datum/quirk/family_heirloom/on_clone(data)
+	heirloom = data
+
 /datum/quirk/monochromatic
 	name = "Monochromacy"
 	desc = "You suffer from full colorblindness, and perceive nearly the entire world in blacks and whites."


### PR DESCRIPTION
## Description
Basically the title, comments out Hard Yards because it is now pointless and comments out Party Favor due to it being a 1 point trait that gives you a random assortment of grenades and even potentially C4 at spawn.

## Motivation and Context
Hard Yards is pointless for now and Party Favor is way too strong, I would "fix" these traits but I'd rather just work on an entire perk overhaul soon than try to fix and inherently broken system.

## How Has This Been Tested?
Booted up a test to ensure that the traits did not show up in selection and everything compiled properly. 

## Screenshots (if appropriate):

## Changelog (neccesary)
:cl:

del: Comments out Hard Yards and Party Favor

/:cl:
