### PR TITLE
Laser weapons that should require two hands now require two hands.

### DIFF
--- a/code/modules/hydroponics/biogenerator.dm
+++ b/code/modules/hydroponics/biogenerator.dm
@@ -304,6 +304,8 @@
 
 	else if(href_list["create"])
 		var/amount = (text2num(href_list["amount"]))
+		//Can't be outside these (if you change this keep a sane limit)
+		amount = CLAMP(amount, 1, 10)
 		var/datum/design/D = locate(href_list["create"])
 		create_product(D, amount)
 		updateUsrDialog()

--- a/code/modules/projectiles/guns/energy/laser.dm
+++ b/code/modules/projectiles/guns/energy/laser.dm
@@ -147,6 +147,7 @@
 	ammo_type = list(/obj/item/ammo_casing/energy/laser/scatter)
 	cell_type = /obj/item/stock_parts/cell/ammo/ecp
 	w_class = WEIGHT_CLASS_HUGE
+	weapon_weight = WEAPON_HEAVY
 
 /obj/item/gun/energy/laser/aer9
 	name = "AER9 laser rifle"
@@ -157,6 +158,7 @@
 	ammo_type = list(/obj/item/ammo_casing/energy/laser/lasgun)
 	cell_type = /obj/item/stock_parts/cell/ammo/mfc
 	w_class = WEIGHT_CLASS_BULKY
+	weapon_weight = WEAPON_HEAVY
 
 /obj/item/gun/energy/laser/pistol
 	name = "AEP7 laser pistol"
@@ -176,6 +178,7 @@
 	ammo_type = list(/obj/item/ammo_casing/energy/laser/scatter)
 	cell_type = /obj/item/stock_parts/cell/ammo/mfc
 	w_class = WEIGHT_CLASS_BULKY
+	weapon_weight = WEAPON_HEAVY
 
 /obj/item/gun/energy/laser/plasma
 	name ="plasma rifle"
@@ -186,6 +189,7 @@
 	ammo_type = list(/obj/item/ammo_casing/energy/plasma)
 	cell_type = /obj/item/stock_parts/cell/ammo/mfc
 	w_class = WEIGHT_CLASS_BULKY
+	weapon_weight = WEAPON_HEAVY
 
 /obj/item/gun/energy/laser/plasma/scatter
 	name = "multiplas Rifle"
@@ -195,6 +199,7 @@
 	desc = "A modified A3-20 plasma caster built by REPCONN equipped with a multicasting kit that creates multiple weaker clots."
 	ammo_type = list(/obj/item/ammo_casing/energy/plasma/scatter)
 	cell_type = /obj/item/stock_parts/cell/ammo/mfc
+	weapon_weight = WEAPON_HEAVY
 
 /obj/item/gun/energy/laser/plasma/pistol
 	name ="plasma pistol"


### PR DESCRIPTION
## Description
Title basically, thanks Anything.

## Motivation and Context
Laser rifles should probably require two hands.

## How Has This Been Tested?
https://gyazo.com/a1da68fb6149b9f8daced92577ffa8d0

https://gyazo.com/08255061787a45599ea6f176aeb3a3cc

## Screenshots (if appropriate):

https://gyazo.com/a1da68fb6149b9f8daced92577ffa8d0

https://gyazo.com/08255061787a45599ea6f176aeb3a3cc

## Changelog (neccesary)
:cl:

fix: Laser rifles now require two hands to fire.

/:cl:
