### PR TITLE
re-adds Desert slowdown and hard yards

### DIFF
--- a/code/datums/traits/good.dm
+++ b/code/datums/traits/good.dm
@@ -78,7 +78,7 @@
 	value = 1
 	mob_trait = TRAIT_JOLLY
 	mood_quirk = TRUE
-/*
+
 /datum/quirk/hard_yards
 	name = "Hard Yards"
 	desc = "You've put them in, now reap the rewards."
@@ -87,7 +87,7 @@
 	mob_trait = TRAIT_HARD_YARDS
 	gain_text = "<span class='notice'>Rain or shine, nothing slows you down.</span>"
 	lose_text = "<span class='danger'>You walk with a less sure gait, the ground seeming less firm somehow.</span>"
-*/
+
 /datum/quirk/lifegiver
 	name = "Lifegiver"
 	desc = "You embody wellness! Instantly gain +15 maximum Health"

--- a/code/game/objects/items/melee/misc.dm
+++ b/code/game/objects/items/melee/misc.dm
@@ -18,7 +18,7 @@
 	righthand_file = 'icons/mob/inhands/weapons/melee_righthand.dmi'
 	flags_1 = CONDUCT_1
 	slot_flags = ITEM_SLOT_BELT
-	force = 10
+	force = 15
 	throwforce = 7
 	w_class = WEIGHT_CLASS_NORMAL
 	attack_verb = list("flogged", "whipped", "lashed", "disciplined")
@@ -409,13 +409,6 @@
 	w_class = WEIGHT_CLASS_NORMAL
 	attack_verb = list("flogged", "whipped", "lashed", "disciplined")
 	hitsound = 'sound/weapons/whip.ogg'
-
-/obj/item/melee/curator_whip/afterattack(target, mob/user, proximity_flag)
-	. = ..()
-	if(ishuman(target) && proximity_flag)
-		var/mob/living/carbon/human/H = target
-		H.drop_all_held_items()
-		H.visible_message("<span class='danger'>[user] disarms [H]!</span>", "<span class='userdanger'>[user] disarmed you!</span>")
 
 /obj/item/melee/roastingstick
 	name = "advanced roasting stick"

--- a/code/modules/fallout/turf/ground.dm
+++ b/code/modules/fallout/turf/ground.dm
@@ -67,7 +67,7 @@
 //	step_sounds = list("human" = "dirtfootsteps")
 //	allowed_plants = list(/obj/item/seeds/poppy/broc, /obj/item/seeds/xander, /obj/item/seeds/mutfruit, \
 	/obj/item/seeds/feracactus, /obj/item/seeds/corn,/obj/item/seeds/shroom, /obj/item/seeds/agave)
-	slowdown = 0.1
+	slowdown = 1
 	flags_1 = CAN_HAVE_NATURE | ADJACENCIES_OVERLAY
 	var/dug = FALSE				//FALSE = has not yet been dug, TRUE = has already been dug
 	var/pit_sand = 2

--- a/code/modules/jobs/job_types/legion.dm
+++ b/code/modules/jobs/job_types/legion.dm
@@ -99,10 +99,6 @@ Centurion
 	outfit = /datum/outfit/job/CaesarsLegion/Legionnaire/f13centurion
 
 
-/datum/job/CaesarsLegion/Legionnaire/f13centurion/after_spawn(mob/living/carbon/human/H, mob/M)
-	H.add_quirk("Hard Yards")
-
-
 /datum/outfit/job/CaesarsLegion/Legionnaire/f13centurion
 	name = "Legion Centurion"
 	jobtype = /datum/job/CaesarsLegion/Legionnaire/f13centurion
@@ -139,10 +135,6 @@ Veteran Decan
 	exp_requirements = 1500
 
 	outfit = /datum/outfit/job/CaesarsLegion/Legionnaire/f13vetdecan
-
-
-/datum/job/CaesarsLegion/Legionnaire/f13vetdecan/after_spawn(mob/living/carbon/human/H, mob/M)
-	H.add_quirk("Hard Yards")
 
 
 /datum/outfit/job/CaesarsLegion/Legionnaire/f13vetdecan
@@ -262,10 +254,6 @@ Vexillarius
 	outfit = /datum/outfit/job/CaesarsLegion/Legionnaire/f13vexillarius
 
 
-/datum/job/CaesarsLegion/Legionnaire/f13vexillarius/after_spawn(mob/living/carbon/human/H, mob/M)
-	H.add_quirk("Hard Yards")
-
-
 /datum/outfit/job/CaesarsLegion/Legionnaire/f13vexillarius
 	name = "Legion Vexillarius"
 	jobtype = /datum/job/CaesarsLegion/Legionnaire/f13vexillarius
@@ -301,10 +289,6 @@ Veteran
 	exp_requirements = 720
 
 	outfit = /datum/outfit/job/CaesarsLegion/Legionnaire/f13vetlegion
-
-
-/datum/job/CaesarsLegion/Legionnaire/f13vetlegion/after_spawn(mob/living/carbon/human/H, mob/M)
-	H.add_quirk("Hard Yards")
 
 
 /datum/outfit/job/CaesarsLegion/Legionnaire/f13vetlegion


### PR DESCRIPTION
## Description

Re-adds the 1 slowdown to desert tiles and also re-enables hard yards while reducing the total amount of Hard Yards that Legion has.


## Motivation and Context
Desert slowdown is good and Ghost asked me to.

## How Has This Been Tested?
Tested in game, compiled fine and speed seemed to be fine, along with hard yards working good.

## Screenshots (if appropriate):

## Changelog (neccesary)
:cl:

CL is just description, again.

/:cl:
