### PR TITLE
Allows despawn of mobs

### DIFF
--- a/code/datums/datacore.dm
+++ b/code/datums/datacore.dm
@@ -281,3 +281,22 @@
 	if(C)
 		P = C.prefs
 	return get_flat_human_icon(null, J, P, DUMMY_HUMAN_SLOT_MANIFEST, show_directions)
+
+
+/datum/datacore/proc/get_record_by_name(username)
+	for(var/i in general)
+		var/datum/data/record/to_check = i
+		if(username != to_check.fields["name"])
+			continue
+		return to_check
+
+
+/datum/datacore/proc/remove_record_by_name(username)
+	for(var/datacore_list in list(general, medical, security, locked))
+		for(var/j in datacore_list)
+			var/datum/data/record/to_remove = j
+			if(username != to_remove.fields["name"])
+				continue
+			datacore_list -= to_remove
+			qdel(to_remove)
+			break

--- a/code/modules/fallout/turf/walls.dm
+++ b/code/modules/fallout/turf/walls.dm
@@ -188,7 +188,7 @@
 		return
 	if(alert("Are you sure you want to [departing_mob == user ? "depart the area for good (you" : "send this person away (they"] will be removed from the current round, the job slot freed)?", "Departing the Mojave", "Confirm", "Cancel") != "Confirm")
 		return
-	log_admin("[key_name(user)] as [user] has despawned [departing_mob == user ? "themselves" : departing_mob] at [AREACOORD(src)].")
+	log_admin("[key_name(user)] as [user] has despawned [departing_mob == user ? "themselves" : departing_mob], job [departing_mob.job], at [AREACOORD(src)].")
 	departing_mob.visible_message("<span class='notice'>[departing_mob == user ? "Out of their own volition, " : "Ushered by [user], "][departing_mob] crosses the border and departs the Mojave.</span>")
 	departing_mob.despawn()
 

--- a/code/modules/fallout/turf/walls.dm
+++ b/code/modules/fallout/turf/walls.dm
@@ -173,6 +173,26 @@
 	desc = "<font color='#6eaa2c'>You suddenly realize the truth - there is no spoon.<br>Digital simulation ends here.</font>"
 	icon_state = "matrix"
 
+/turf/closed/indestructible/f13/matrix/MouseDrop_T(atom/dropping, mob/user)
+	. = ..()
+	if(!isliving(user) || user.incapacitated())
+		return //No ghosts or incapacitated folk allowed to do this.
+	if(!ishuman(dropping))
+		return //Only humans have job slots to be freed.
+	var/mob/living/carbon/human/departing_mob = dropping
+	if(departing_mob.stat == DEAD)
+		to_chat(user, "<span class='warning'>This one kicked the bucket. Won't be traveling anywhere.</span>")
+		return
+	if(departing_mob != user && departing_mob.client)
+		to_chat(user, "<span class='warning'>This one retains their free will. It's their choice if they want to depart or not.</span>")
+		return
+	if(alert("Are you sure you want to [departing_mob == user ? "depart the area for good (you" : "send this person away (they"] will be removed from the current round, the job slot freed)?", "Departing the Mojave", "Confirm", "Cancel") != "Confirm")
+		return
+	log_admin("[key_name(user)] as [user] has despawned [departing_mob == user ? "themselves" : departing_mob] at [AREACOORD(src)].")
+	departing_mob.visible_message("<span class='notice'>[departing_mob == user ? "Out of their own volition, " : "Ushered by [user], "][departing_mob] crosses the border and departs the Mojave.</span>")
+	departing_mob.despawn()
+
+
 /turf/closed/indestructible/f13/obsidian //Just like that one game studio that worked on the original game, or that block in Minecraft!
 	name = "obsidian"
 	desc = "No matter what you do with this rock, there's not even a scratch left on its surface.<br><font color='#7e0707'>You shall not pass!!!</font>"

--- a/code/modules/mob/dead/new_player/new_player.dm
+++ b/code/modules/mob/dead/new_player/new_player.dm
@@ -134,6 +134,11 @@
 				SSticker.queued_players += usr
 				to_chat(usr, "<span class='notice'>You have been added to the queue to join the game. Your position in queue is [SSticker.queued_players.len].</span>")
 			return
+
+		if(GLOB.data_core.get_record_by_name(client.prefs.real_name))
+			alert(src, "This character name is already in use. Choose another.")
+			return
+
 		LateChoices()
 
 	if(href_list["manifest"])

--- a/code/modules/mob/living/carbon/human/human.dm
+++ b/code/modules/mob/living/carbon/human/human.dm
@@ -895,6 +895,15 @@
 		. = ..(M,force,check_loc)
 		stop_pulling()
 
+
+/mob/living/carbon/human/proc/despawn()
+	var/datum/job/job_to_free = SSjob.GetJob(job)
+	job_to_free?.current_positions--
+	GLOB.data_core.remove_record_by_name(real_name)
+	log_game("[key_name(src)] has despawned as [src] in [AREACOORD(src)]")
+	qdel(src)
+
+
 /mob/living/carbon/human/do_after_coefficent()
 	. = ..()
 	. *= physiology.do_after_speed

--- a/code/modules/mob/living/carbon/human/human.dm
+++ b/code/modules/mob/living/carbon/human/human.dm
@@ -900,7 +900,7 @@
 	var/datum/job/job_to_free = SSjob.GetJob(job)
 	job_to_free?.current_positions--
 	GLOB.data_core.remove_record_by_name(real_name)
-	log_game("[key_name(src)] has despawned as [src] in [AREACOORD(src)]")
+	log_game("[key_name(src)] has despawned as [src], job [job], in [AREACOORD(src)]")
 	qdel(src)
 
 


### PR DESCRIPTION
## Description
* Characters can walk to one of the green/matrix border tiles and clickdrag themselves or someone else (as long as they are alive and clientless) to despawn, freeing up the job slot and cleaning the name from the crew manifest. It is a mob proc, so it can be added to other machines or as an admin verb.
* Characters that attempt to join with a name already existing in the crew manifest will be told that is not possible and refused.

## Motivation and Context
Reduce admin work and allow people who joined with a wrong char to fix it.

## How Has This Been Tested?
Locally.

## Screenshots (if appropriate):
![`](https://user-images.githubusercontent.com/42041276/60767810-682e1d00-a093-11e9-8a49-1944bd08049f.png)
![2](https://user-images.githubusercontent.com/42041276/60767811-6cf2d100-a093-11e9-977d-835de0934fcd.png)
![3](https://user-images.githubusercontent.com/42041276/60767813-711eee80-a093-11e9-8e1d-7efacc62e9fc.png)

## Changelog (neccesary)
:cl:
add: You can despawn yourself or others, freeing up the job slot and your name from the crew manifest, by heading to one of the green/matrix borders on the limits of some roads and clickdragging yourself or the other person into it.
fix: You can no longer join with an existing name in the crew manifest. Nor that you could before rules-wise, but now it's mechanically-enforced.
/:cl: