### PR TITLE
Adds carpet and crayon production to the Biogenerator

### DIFF
--- a/code/modules/hydroponics/biogenerator.dm
+++ b/code/modules/hydroponics/biogenerator.dm
@@ -15,7 +15,7 @@
 	var/productivity = 0
 	var/max_items = 40
 	var/datum/techweb/stored_research
-	var/list/show_categories = list("Food", "Botany Chemicals", "Organic Materials", "Accessories")
+	var/list/show_categories = list("Food", "Botany Chemicals", "Organic Materials", "Accessories", "Misc")
 	var/list/timesFiveCategories = list("Food", "Botany Chemicals")
 
 /obj/machinery/biogenerator/Initialize()
@@ -304,6 +304,8 @@
 
 	else if(href_list["create"])
 		var/amount = (text2num(href_list["amount"]))
+		//Can't be outside these (if you change this keep a sane limit)
+		amount = CLAMP(amount, 1, 10)
 		var/datum/design/D = locate(href_list["create"])
 		create_product(D, amount)
 		updateUsrDialog()

--- a/code/modules/research/designs/biogenerator_designs.dm
+++ b/code/modules/research/designs/biogenerator_designs.dm
@@ -170,3 +170,19 @@
 	materials = list(MAT_BIOMASS = 300)
 	build_path = /obj/item/clothing/head/rice_hat
 	category = list("initial","Accessories")
+
+/datum/design/crayon_box
+	name = "Crayon Box"
+	id = "crayon_box"
+	build_type = BIOGENERATOR
+	materials = list(MAT_BIOMASS = 150)
+	build_path = /obj/item/storage/crayons
+	category = list("initial","Misc")
+
+/datum/design/carpet
+	name = "Synthetic Carpet"
+	id = "carpet"
+	build_type = BIOGENERATOR
+	materials = list(MAT_BIOMASS = 5)
+	build_path = /obj/item/stack/tile/carpet
+	category = list("initial","Misc")


### PR DESCRIPTION
This should give players more options to decore stuff, crayon can be grinded into powder that can be used to paint floors/items if sprayed and carpet can be used to replace the boring wood flooring. 

100% tested

![Stuff](https://user-images.githubusercontent.com/38330373/60780195-ca2e6700-a113-11e9-8424-788215111fe2.png)

Carpet biomass requirement is low because it only makes one tile. Clicking on 10x would make 10 tiles that would cost 50 biomass.