### PR TITLE
Safety checks for despawning

### DIFF
--- a/code/modules/fallout/turf/walls.dm
+++ b/code/modules/fallout/turf/walls.dm
@@ -188,9 +188,23 @@
 		return
 	if(alert("Are you sure you want to [departing_mob == user ? "depart the area for good (you" : "send this person away (they"] will be removed from the current round, the job slot freed)?", "Departing the Mojave", "Confirm", "Cancel") != "Confirm")
 		return
-	if(user.incapacitated() || QDELETED(departing_mob) || departing_mob.stat == DEAD || departing_mob.client || get_dist(src, dropping) > 2 || get_dist(src, user) > 2)
+	if(user.incapacitated() || QDELETED(departing_mob) || departing_mob.stat == DEAD || (departing_mob != user && departing_mob.client) || get_dist(src, dropping) > 2 || get_dist(src, user) > 2)
 		return //Things have changed since the alert happened.
-	log_admin("[key_name(user)] as [user] has despawned [departing_mob == user ? "themselves" : departing_mob], job [departing_mob.job], at [AREACOORD(src)].")
+	if(departing_mob.logout_time && departing_mob.logout_time + 5 MINUTES > world.time)
+		to_chat(user, "<span class='warning'>This mind has only recently departed. Better give it some more time before taking such a drastic measure.</span>")
+		return
+	var/dat = "[key_name(user)] has despawned [departing_mob == user ? "themselves" : departing_mob], job [departing_mob.job], at [AREACOORD(src)]. Contents despawned along:"
+	if(!length(departing_mob.contents))
+		dat += " none."
+	else
+		var/atom/movable/content = departing_mob.contents[1]
+		dat += " [content.name]"
+		for(var/i in 2 to length(departing_mob.contents))
+			content = departing_mob.contents[i]
+			dat += ", [content.name]"
+		dat += "."
+	message_admins(dat)
+	log_admin(dat)
 	departing_mob.visible_message("<span class='notice'>[departing_mob == user ? "Out of their own volition, " : "Ushered by [user], "][departing_mob] crosses the border and departs the Mojave.</span>")
 	departing_mob.despawn()
 

--- a/code/modules/fallout/turf/walls.dm
+++ b/code/modules/fallout/turf/walls.dm
@@ -188,6 +188,8 @@
 		return
 	if(alert("Are you sure you want to [departing_mob == user ? "depart the area for good (you" : "send this person away (they"] will be removed from the current round, the job slot freed)?", "Departing the Mojave", "Confirm", "Cancel") != "Confirm")
 		return
+	if(user.incapacitated() || QDELETED(departing_mob) || departing_mob.stat == DEAD || departing_mob.client || get_dist(src, dropping) > 2 || get_dist(src, user) > 2)
+		return //Things have changed since the alert happened.
 	log_admin("[key_name(user)] as [user] has despawned [departing_mob == user ? "themselves" : departing_mob], job [departing_mob.job], at [AREACOORD(src)].")
 	departing_mob.visible_message("<span class='notice'>[departing_mob == user ? "Out of their own volition, " : "Ushered by [user], "][departing_mob] crosses the border and departs the Mojave.</span>")
 	departing_mob.despawn()

--- a/code/modules/mob/living/carbon/human/human.dm
+++ b/code/modules/mob/living/carbon/human/human.dm
@@ -897,6 +897,7 @@
 
 
 /mob/living/carbon/human/proc/despawn()
+	ghostize()
 	var/datum/job/job_to_free = SSjob.GetJob(job)
 	job_to_free?.current_positions--
 	GLOB.data_core.remove_record_by_name(real_name)

--- a/code/modules/mob/living/carbon/human/human.dm
+++ b/code/modules/mob/living/carbon/human/human.dm
@@ -897,11 +897,15 @@
 
 
 /mob/living/carbon/human/proc/despawn()
-	ghostize()
 	var/datum/job/job_to_free = SSjob.GetJob(job)
 	job_to_free?.current_positions--
 	GLOB.data_core.remove_record_by_name(real_name)
-	log_game("[key_name(src)] has despawned as [src], job [job], in [AREACOORD(src)]")
+	var/dat = "[key_name(src)] has despawned as [src], job [job], in [AREACOORD(src)]. Contents despawned along:"
+	for(var/i in contents)
+		var/atom/movable/content = i
+		dat += " [content.type]"
+	log_game(dat)
+	ghostize()
 	qdel(src)
 
 

--- a/code/modules/mob/login.dm
+++ b/code/modules/mob/login.dm
@@ -13,6 +13,7 @@
 		hud_used.show_hud(hud_used.hud_version)
 		hud_used.update_ui_style(ui_style2icon(client.prefs.UI_style))
 
+	logout_time = 0 //Zero it up, to allow the person to despawn at will after re-logging.
 	next_move = 1
 
 	..()

--- a/code/modules/mob/logout.dm
+++ b/code/modules/mob/logout.dm
@@ -3,7 +3,7 @@
 	SStgui.on_logout(src)
 	unset_machine()
 	GLOB.player_list -= src
-
+	logout_time = world.time
 	..()
 
 	if(loc)

--- a/code/modules/mob/mob_defines.dm
+++ b/code/modules/mob/mob_defines.dm
@@ -107,3 +107,4 @@
 	var/datum/click_intercept
 
 	var/timeofdeath = 0 /* moved here from mob/living for player respawn */
+	var/logout_time = 0 //for despawn and general logging


### PR DESCRIPTION
* Avoids people from triggering the alert and using it later under different circumstances.
* Makes sure the mob leaving is properly ghostize'd.
* Admins get notified about despawns, and given the list of contents in the mob that are being despawned along. Exact type paths stored in the game logs.
* 5 minute timer before someone SSD can be despawned.