### PR TITLE
Minor adjustments to guns

### DIFF
--- a/code/game/objects/effects/spawners/f13lootdrop.dm
+++ b/code/game/objects/effects/spawners/f13lootdrop.dm
@@ -785,67 +785,57 @@
 /obj/effect/spawner/lootdrop/f13/weapon/gun/tier3 //TIER 3 GUN
 	name = "tier 3 gun"
 	lootcount = 3
+
 	var/loot1 = list(
-				/obj/item/gun/ballistic/shotgun/automatic/hunting,
-				/obj/item/ammo_box/a762/doublestacked,
-				/obj/item/ammo_box/a762/doublestacked
-				)
-				//remember gangs gamemode? haha
-	var/loot2 = list(
 				/obj/item/gun/ballistic/automatic/mini_uzi,
 				/obj/item/ammo_box/magazine/uzim9mm,
 				/obj/item/ammo_box/magazine/uzim9mm
 				)
 
-	var/loot3 = list(
+	var/loot2 = list(
 				/obj/item/gun/ballistic/automatic/smg10mm,
 				/obj/item/ammo_box/magazine/m10mm_auto,
 				/obj/item/ammo_box/magazine/m10mm_auto
 				)
 
-	var/loot4 = list(
+	var/loot3 = list(
 				/obj/item/gun/ballistic/automatic/greasegun,
 				/obj/item/ammo_box/magazine/greasegun,
 				/obj/item/ammo_box/magazine/greasegun
 				)
 
-	var/loot5 = list(
-				/obj/item/gun/ballistic/automatic/smg10mm,
-				/obj/item/ammo_box/magazine/m10mm_auto,
-				/obj/item/ammo_box/magazine/m10mm_auto
-				)
-
-	var/loot6 = list(
+	var/loot4 = list(
 				/obj/item/gun/ballistic/shotgun/riot,
 				/obj/item/storage/box/lethalshot,
 				/obj/item/storage/box/rubbershot/beanbag
 				)
 
-	var/loot7 = list(
+	var/loot5 = list(
 				/obj/item/gun/energy/laser/pistol,
 				/obj/item/stock_parts/cell/ammo/ec,
 				""
 				)
 
-	var/loot8 = list(
+	var/loot6 = list(
 				/obj/item/gun/ballistic/revolver/needler,
 				/obj/item/ammo_box/needle,
 				/obj/item/ammo_box/needle
 				)
 
-	var/loot9 = list(
+	var/loot7 = list(
 				/obj/item/gun/ballistic/shotgun/automatic/hunting/trail,
 			    /obj/item/ammo_box/tube/m44,
 				/obj/item/ammo_box/tube/m44
 				)
-	var/loot10 = list(
+	
+	var/loot8 = list(
 				/obj/item/gun/ballistic/shotgun/automatic/hunting/trail/scoped,
 				/obj/item/ammo_box/tube/m44,
 				/obj/item/ammo_box/tube/m44
 				)
 
 /obj/effect/spawner/lootdrop/f13/weapon/gun/tier3/Initialize(mapload) //on mapload, pick what shit to spawn
-	loot = pick(loot1, loot2, loot3, loot4, loot5, loot6, loot7, loot8, loot9, loot10)
+	loot = pick(loot1, loot2, loot3, loot4, loot5, loot6, loot7, loot8)
 	. = ..()
 
 /obj/effect/spawner/lootdrop/f13/weapon/gun/tier4 //TIER 4 GUN
@@ -866,7 +856,7 @@
 	var/loot3 = list(
 				/obj/item/gun/ballistic/automatic/pistol/deagle,
 				/obj/item/ammo_box/magazine/m50,
-				""
+				/obj/item/ammo_box/magazine/m50
 				)
 
 	var/loot4 = list(
@@ -915,8 +905,20 @@
 				 /obj/item/ammo_box/a50MG
 				 )
 
+	var/loot12 = list(
+				/obj/item/gun/ballistic/automatic/smg10mm,
+				/obj/item/ammo_box/magazine/m10mm_auto,
+				/obj/item/ammo_box/magazine/m10mm_auto
+				)
+
+	var/loot13 = list(
+				/obj/item/gun/ballistic/shotgun/automatic/hunting,
+				/obj/item/ammo_box/a762/doublestacked,
+				/obj/item/ammo_box/a762/doublestacked
+				)
+
 /obj/effect/spawner/lootdrop/f13/weapon/gun/tier4/Initialize(mapload) //on mapload, pick what shit to spawn
-	loot = pick(loot1, loot2, loot3, loot4, loot5, loot6, loot7, loot8, loot9, loot10, loot11)
+	loot = pick(loot1, loot2, loot3, loot4, loot5, loot6, loot7, loot8, loot9, loot10, loot11, loot12, loot13)
 	. = ..()
 
 /obj/effect/spawner/lootdrop/f13/weapon/gun/tier5 //TIER 5 GUN
@@ -1010,7 +1012,6 @@
 				/obj/item/ammo_box/magazine/greasegun,
 				/obj/item/ammo_box/needle,
 				/obj/item/ammo_box/magazine/tommygunm45,
-				/obj/item/ammo_box/magazine/m10mm_auto,
 				/obj/item/ammo_box/magazine/m9mm,
 				/obj/item/ammo_box/tube/m44
 				)
@@ -1031,6 +1032,8 @@
 				/obj/item/ammo_box/c4570,
 				/obj/item/ammo_box/tube/c4570,
 				/obj/item/ammo_box/a50MG,
+				/obj/item/ammo_box/magazine/m10mm_auto,
+				/obj/item/ammo_box/a762/doublestacked
 				)
 
 /obj/effect/spawner/lootdrop/f13/weapon/gun/ammo/tier4/Initialize(mapload) //on mapload, pick how many shit to spawn

--- a/code/modules/projectiles/guns/ballistic/automatic.dm
+++ b/code/modules/projectiles/guns/ballistic/automatic.dm
@@ -7,6 +7,7 @@
 	burst_size = 3
 	fire_delay = 2
 	actions_types = list(/datum/action/item_action/toggle_firemode)
+	force = 20
 
 /obj/item/gun/ballistic/automatic/proto
 	name = "compact submachine gun"
@@ -348,6 +349,7 @@
 	zoom_out_amt = 13
 	slot_flags = ITEM_SLOT_BACK
 	actions_types = list()
+	force = 25
 
 
 /obj/item/gun/ballistic/automatic/sniper_rifle/update_icon()
@@ -415,6 +417,7 @@
 	burst_size = 2
 	extra_damage = 20
 	extra_penetration = 10
+	force = 15
 
 /obj/item/gun/ballistic/automatic/tommygun
 	name = "\improper Thompson SMG"
@@ -445,6 +448,7 @@
 	extra_damage = 20
 	extra_penetration = 15
 	can_suppress = FALSE //we dont have sprites therefore cease
+	force = 15
 
 /obj/item/gun/ballistic/automatic/assault_rifle
 	name = "R91 assault rifle"
@@ -475,6 +479,7 @@
 	zoom_out_amt = 13
 	fire_sound = 'sound/weapons/Gunshot_large_silenced.ogg'
 	weapon_weight = WEAPON_HEAVY
+	force = 15
 
 /obj/item/gun/ballistic/automatic/marksman
 	name = "R94 marksman carbine"
@@ -573,6 +578,7 @@
 	fire_delay = 2
 	extra_damage = 20
 	extra_penetration = 10
+	force = 15
 
 /obj/item/gun/ballistic/automatic/bozar
 	name = "Bozar"

--- a/code/modules/projectiles/guns/ballistic/shotgun.dm
+++ b/code/modules/projectiles/guns/ballistic/shotgun.dm
@@ -4,7 +4,7 @@
 	icon_state = "Itaca"
 	item_state = "huntingshotgun"
 	w_class = WEIGHT_CLASS_BULKY
-	force = 25
+	force = 20
 	flags_1 =  CONDUCT_1
 	slot_flags = ITEM_SLOT_BACK
 	mag_type = /obj/item/ammo_box/magazine/internal/shot
@@ -394,7 +394,7 @@
 	w_class = WEIGHT_CLASS_BULKY
 	weapon_weight = WEAPON_HEAVY
 	fire_delay = 5
-	extra_damage = 45
+	extra_damage = 50
 	extra_penetration = 15
 
 
@@ -410,7 +410,7 @@
 	zoom_out_amt = 13
 	w_class = WEIGHT_CLASS_BULKY
 	weapon_weight = WEAPON_HEAVY
-	fire_delay = 9
+	fire_delay = 6
 	extra_damage = 50
 	extra_penetration = 15
 
@@ -422,7 +422,7 @@
 	desc = "An common over-under double barreled shotgun."
 	icon_state = "caravan_shotgun"
 	item_state = "dshotgun1"
-	force = 25
+	force = 20
 	mag_type = /obj/item/ammo_box/magazine/internal/shot/dual
 	sawn_desc = "Omar's coming!"
 	fire_sound = 'sound/f13weapons/caravan_shotgun.ogg'
@@ -445,7 +445,7 @@
 	desc = "A dirt cheap single shot shotgun."
 	icon_state = "single_shotgun"
 	item_state = "singleshot"
-	force = 15
+	force = 20
 	mag_type = /obj/item/ammo_box/magazine/internal/shot/improvised
 	sawn_desc = "At this point, you're basically holding an individual shotgun shell as it goes off."
 	fire_sound = 'sound/f13weapons/caravan_shotgun.ogg'


### PR DESCRIPTION
## Description
Gives a melee force to automatic weapons and slightly nerfs the melee force of shotguns to not be on par with a knife so that knives are rendered entirely useless. Now they are only mildly useless. Moves rangemaster and 10mm SMG to T4 as both are very solid weapons deserving of the spot and reverts a bit of the nerfs to the Brushguns, they should be in a fine spot now.

## Motivation and Context
Rifles should have a melee force, 25 shotgun force negates knives, Rangemaster and 10mm SMG are really strong, Brushgun could do with some love so as to not be a worse Rangemaster despite being on the same tier.

## How Has This Been Tested?
Compiled fine.

## Screenshots (if appropriate):

## Changelog (neccesary)
:cl:

CL is description again.

/:cl:
