### PR TITLE
Fixes being able to bury people/coffins who/which are no longer in the hole being filled.

### DIFF
--- a/code/modules/pits/pits.dm
+++ b/code/modules/pits/pits.dm
@@ -142,6 +142,10 @@ obj/dugpit/New(lnk)
 					gravecoffin = curcoffin
 					break
 			playsound(src, 'sound/effects/shovel_dig.ogg', 50, 1)
+			if(!(gravebody in loc)) // prevents burying yourself while not on the tile
+				gravebody = null
+			if(!gravecoffin in loc) // just sanity checking
+				gravecoffin = null
 			if (gravebody!=null)
 				user.show_message("<span class='notice'>You start covering the body in the hole with dirt...</span>", 1)
 				if (do_after(user, (50 * digging_speed), target=gravebody))


### PR DESCRIPTION
<!-- Thanks for choosing to take the time to contribute to our project! We have a few things below that we'd like you to fill out -->
<!-- The more detail you can give us, the faster we can code review, test, and merge your changes -->

<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
See PR title.
## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Because I accidentally buried myself with this glitch and want an adminheal.

## How Has This Been Tested?
It's a simple sanity check, and the code compiles.

## Screenshots (if appropriate):

## Changelog (neccesary)
:cl:
fix: You can no longer bury people or coffins who/which are no longer in the hole being filled.
/:cl:
