### PR TITLE
Fluff changes - Armor Balancing - Naming Consistency

### DIFF
--- a/code/game/objects/items/devices/radio/headset.dm
+++ b/code/game/objects/items/devices/radio/headset.dm
@@ -238,7 +238,7 @@
 	item_state = "com_headset_alt"
 
 /obj/item/radio/headset/headset_ncr
-	name = "ncr radio headset"
+	name = "NCR radio headset"
 	desc = "This is used by the new california republic.\nTo access the NCR channel, use :w."
 	icon_state = "mine_headset"
 	keyslot = new /obj/item/encryptionkey/headset_ncr
@@ -268,7 +268,7 @@
 	AddComponent(/datum/component/wearertargeting/earprotection, list(SLOT_EARS))
 
 /obj/item/radio/headset/headset_den
-	name = "den radio headset"
+	name = "kebab radio headset"
 	desc = "This is used by the den.\nTo access the den channel, use :f."
 	icon_state = "mine_headset"
 	keyslot = new /obj/item/encryptionkey/headset_den

--- a/code/game/objects/items/storage/belt.dm
+++ b/code/game/objects/items/storage/belt.dm
@@ -332,13 +332,13 @@
 	item_state = "legion_belt"
 
 /obj/item/storage/belt/military/assault/ncr
-	name = "NCR duty belt"
+	name = "NCR patrol belt"
 	desc = "A standard issue robust duty belt for the NCR."
 	icon_state = "ncr_belt"
 	item_state = "ncr_belt"
 
 /obj/item/storage/belt/military/reconbandolier
-	name = "recon ranger bandolier"
+	name = "NCR recon ranger bandolier"
 	desc = "A belt with many pockets, now at an angle."
 	icon_state = "reconbandolier"
 	item_state = "reconbandolier"
@@ -349,7 +349,7 @@
 	STR.max_w_class = WEIGHT_CLASS_SMALL
 
 /obj/item/storage/belt/military/NCR_Bandolier
-	name = "NCR Bandolier"
+	name = "NCR bandolier"
 	desc = "A standard issue NCR bandolier."
 	icon_state = "ncr_bandolier"
 	item_state = "ncr_bandolier"
@@ -699,3 +699,17 @@
 /obj/item/storage/belt/sabre/PopulateContents()
 	new /obj/item/melee/sabre(src)
 	update_icon()
+
+/obj/item/storage/belt/sabre/legion
+	name = "machete sheath"
+	desc = "A leather sheath designed to hold machetes"
+	icon_state = "sheath"
+	item_state = "sheath"
+	w_class = WEIGHT_CLASS_BULKY
+
+/obj/item/storage/belt/sabre/legion/pouch
+	name = "pouched machete sheath"
+	desc = "A leather sheath designed to hold machetes. This one has a small pouch on the outside of it, allowing it to hold a few small items"
+	icon_state = "sheath"
+	item_state = "sheath"
+	w_class = WEIGHT_CLASS_BULKY

--- a/code/game/objects/items/twohanded.dm
+++ b/code/game/objects/items/twohanded.dm
@@ -898,8 +898,8 @@
 	icon_state = "bmprsword0"
 	desc = "A heavy makeshift sword fashioned out of a car bumper."
 	lefthand_file = 'icons/mob/inhands/weapons/polearms_lefthand.dmi'
-	righthand_file = 'icons/mob/inhands/weapons/polearms_righthand.dmi
-	slot_flags = ITEM_SLOT_BACK'
+	righthand_file = 'icons/mob/inhands/weapons/polearms_righthand.dmi'
+	slot_flags = ITEM_SLOT_BACK
 
 /obj/item/twohanded/fireaxe/bmprsword/update_icon()
 	name = "bumper sword"

--- a/code/game/objects/items/twohanded.dm
+++ b/code/game/objects/items/twohanded.dm
@@ -461,7 +461,7 @@
 	w_class = WEIGHT_CLASS_BULKY
 	slot_flags = ITEM_SLOT_BACK
 	force_unwielded = 20
-	force_wielded = 56
+	force_wielded = 25
 	throwforce = 20
 	throw_speed = 4
 	embedding = list("embedded_impact_pain_multiplier" = 3)

--- a/code/game/objects/items/twohanded.dm
+++ b/code/game/objects/items/twohanded.dm
@@ -461,7 +461,7 @@
 	w_class = WEIGHT_CLASS_BULKY
 	slot_flags = ITEM_SLOT_BACK
 	force_unwielded = 20
-	force_wielded = 25
+	force_wielded = 56
 	throwforce = 20
 	throw_speed = 4
 	embedding = list("embedded_impact_pain_multiplier" = 3)
@@ -561,6 +561,7 @@
 	righthand_file = 'icons/mob/inhands/64x64_righthand.dmi'
 	inhand_x_dimension = 64
 	inhand_y_dimension = 64
+	slot_flags = ITEM_SLOT_BACK
 	force = 10
 	var/force_on = 72
 	w_class = WEIGHT_CLASS_HUGE
@@ -897,10 +898,10 @@
 	icon_state = "bmprsword0"
 	desc = "A heavy makeshift sword fashioned out of a car bumper."
 	lefthand_file = 'icons/mob/inhands/weapons/polearms_lefthand.dmi'
-	righthand_file = 'icons/mob/inhands/weapons/polearms_righthand.dmi'
+	righthand_file = 'icons/mob/inhands/weapons/polearms_righthand.dmi
+	slot_flags = ITEM_SLOT_BACK'
 
 /obj/item/twohanded/fireaxe/bmprsword/update_icon()
 	name = "bumper sword"
 	desc = "A heavy makeshift sword fashioned out of a car bumper."
 	icon_state = "bmprsword[wielded]"
-

--- a/code/game/objects/items/weaponry.dm
+++ b/code/game/objects/items/weaponry.dm
@@ -517,7 +517,7 @@ for further reading, please see: https://github.com/tgstation/tgstation/pull/301
 	righthand_file = 'icons/mob/inhands/weapons/chainsaw_righthand.dmi'
 	item_flags = NODROP | ABSTRACT | DROPDEL
 	w_class = WEIGHT_CLASS_HUGE
-	force = 56
+	force = 72 // makes it equal with a two handed chainsaw. it going on your arm has no bearing on it still being a chainsaw
 	throwforce = 0
 	throw_range = 0
 	throw_speed = 0

--- a/code/modules/clothing/glasses/f13.dm
+++ b/code/modules/clothing/glasses/f13.dm
@@ -10,8 +10,8 @@
 	item_state = "biker"
 
 /obj/item/clothing/glasses/legiongoggles
-	name = "Legion goggles"
-	desc = "Standard issue goggles for Caesar's Legion."
+	name = "sandstorm goggles"
+	desc = "Post-war makeshift goggles fasioned together inside Legion camps. Standard issue to most legionarys."
 	icon_state = "legion"
 	item_state = "legion"
 

--- a/code/modules/clothing/gloves/f13.dm
+++ b/code/modules/clothing/gloves/f13.dm
@@ -26,8 +26,8 @@
 	max_heat_protection_temperature = GLOVES_MAX_TEMP_PROTECT
 
 /obj/item/clothing/gloves/f13/leather/ncr_officer
-	name = "NCR Officer gloves"
-	desc = "Strong leather gloves issued to NCR officers."
+	name = "NCR officer gloves"
+	desc = "Tight fitting black leather gloves with mesh along the finger tips and padding along the palm. The craftsmanship indicates it was made for a officer."
 
 /obj/item/clothing/gloves/f13/military
 	name = "military gloves"
@@ -43,7 +43,7 @@
 	max_heat_protection_temperature = GLOVES_MAX_TEMP_PROTECT
 
 /obj/item/clothing/gloves/f13/ncr
-	name = "NCR Gloves"
+	name = "NCR patrol gloves"
 	desc = "Large leather gloves commonly worn by NCR personnel."
 	icon_state = "ncr_gloves"
 	item_state = "ncr_gloves"

--- a/code/modules/clothing/gloves/miscellaneous.dm
+++ b/code/modules/clothing/gloves/miscellaneous.dm
@@ -12,7 +12,7 @@
 	min_cold_protection_temperature = GLOVES_MIN_TEMP_PROTECT
 
 /obj/item/clothing/gloves/rifleman
-	name = "rifleman's gloves"
+	name = "rifleman gloves"
 	desc = "A pair of rifleman's gloves. The thumb and finger have been removed to not impair the wearer's shooting ability."
 	icon_state = "rifleman"
 	item_state = "rifleman"
@@ -83,7 +83,7 @@
 	transfer_prints = FALSE
 
 /obj/item/clothing/gloves/Biker
-	name = "Future Gloves"
+	name = "future gloves"
 	desc = "Gloves in a futuristic color."
 	icon_state = "biker_gloves"
 	item_state = "biker_gloves"

--- a/code/modules/clothing/head/helmet.dm
+++ b/code/modules/clothing/head/helmet.dm
@@ -425,7 +425,7 @@
 	desc = "It's a leather legion helmet that's been reinforced with stronger leather patches and anointed with a array of red and dark red feathers."
 	icon_state = "legdecan"
 	item_state = "legdecan"
-	armor = list("melee" = 60, "bullet" = 40, "laser" = 25, "energy" = 15, "bomb" = 25, "bio" = 50, "rad" = 0, "fire" = 70, "acid" = 0)
+	armor = list("melee" = 40, "bullet" = 25, "laser" = 10, "energy" = 10, "bomb" = 16, "bio" = 30, "rad" = 0, "fire" = 50, "acid" = 0)
 	flags_inv = HIDEEARS|HIDEHAIR
 	strip_delay = 50
 	resistance_flags = LAVA_PROOF | FIRE_PROOF
@@ -436,7 +436,7 @@
 	name = "legion prime decanus helmet"
 	desc = "It's a leather legion helmet that's been reinforced with stronger leather patches and anointed with a array of red and dark red feathers. This one has a few small white feathers woven inside of it aswell."
 	item_state = "legdecanprime"
-	armor = list("melee" = 60, "bullet" = 40, "laser" = 25, "energy" = 15, "bomb" = 25, "bio" = 50, "rad" = 0, "fire" = 70, "acid" = 0)
+	armor = list("melee" = 50, "bullet" = 35, "laser" = 15, "energy" = 15, "bomb" = 25, "bio" = 40, "rad" = 0, "fire" = 60, "acid" = 0)
 
 /obj/item/clothing/head/helmet/f13/legion/legdecan/vet
 	name = "legion veteran decanus helmet"

--- a/code/modules/clothing/head/helmet.dm
+++ b/code/modules/clothing/head/helmet.dm
@@ -269,10 +269,10 @@
 /obj/item/clothing/head/helmet/riot/vaultsec
 	name = "security helmet"
 	desc = "A standard issue vault security helmet, pretty robust."
-	
+
 //Remnants
 /obj/item/clothing/head/donor/enclave
-	name = "Remnant Cap"
+	name = "enclave forage cap"
 	desc = "A resistant, black forage cap issued to Enclave soldiers."
 	icon_state = "enclave_cap"
 	item_state = "enclave_cap"
@@ -332,7 +332,7 @@
 
 /obj/item/clothing/head/helmet/f13/combat
 	name = "combat helmet"
-	desc = "An old military grade pre-war combat helmet."
+	desc = "A pre-war ceramic and kevlar helmet designed to absorb kinetic impacts and stop projectiles from entering the users skull. Has the words BORN TO KILL written on the outside in chalk."
 	icon_state = "combat_helmet"
 	item_state = "combat_helmet"
 	armor = list("melee" = 45, "bullet" = 30, "laser" = 30, "energy" = 60, "bomb" = 25, "bio" = 60, "rad" = 60, "fire" = 60, "acid" = 0)
@@ -346,7 +346,7 @@
 
 /obj/item/clothing/head/helmet/f13/combat/mk2
 	name = "reinforced combat helmet"
-	desc = "An reinforced combat helmet based off the original pre-war model."
+	desc = "An advanced pre-war titanium plated, ceramic coated, kevlar, padded helmet designed to withstand extreme punishment of all forms."
 	icon_state = "combat_helmet_mk2"
 	item_state = "combat_helmet_mk2"
 	armor = list("melee" = 50, "bullet" = 39, "laser" = 25, "energy" = 25, "bomb" = 39, "bio" = 0, "rad" = 0, "fire" = 0, "acid" = 20)
@@ -422,10 +422,10 @@
 
 /obj/item/clothing/head/helmet/f13/legion/legdecan
 	name = "legion recruit decanus helmet"
-	desc = "It's leather legion recruit decan helmet."
+	desc = "It's a leather legion helmet that's been reinforced with stronger leather patches and anointed with a array of red and dark red feathers."
 	icon_state = "legdecan"
 	item_state = "legdecan"
-	armor = list("melee" = 40, "bullet" = 25, "laser" = 10, "energy" = 10, "bomb" = 16, "bio" = 30, "rad" = 0, "fire" = 50, "acid" = 0)
+	armor = list("melee" = 60, "bullet" = 40, "laser" = 25, "energy" = 15, "bomb" = 25, "bio" = 50, "rad" = 0, "fire" = 70, "acid" = 0)
 	flags_inv = HIDEEARS|HIDEHAIR
 	strip_delay = 50
 	resistance_flags = LAVA_PROOF | FIRE_PROOF
@@ -434,13 +434,13 @@
 
 /obj/item/clothing/head/helmet/f13/legion/legdecan/vet/prime
 	name = "legion prime decanus helmet"
-	desc = "It's a helmet belonging to a prime decanus, it looks sturdier than the normal decanus helmet."
+	desc = "It's a leather legion helmet that's been reinforced with stronger leather patches and anointed with a array of red and dark red feathers. This one has a few small white feathers woven inside of it aswell."
 	item_state = "legdecanprime"
-	armor = list("melee" = 50, "bullet" = 35, "laser" = 15, "energy" = 15, "bomb" = 25, "bio" = 40, "rad" = 0, "fire" = 60, "acid" = 0)
+	armor = list("melee" = 60, "bullet" = 40, "laser" = 25, "energy" = 15, "bomb" = 25, "bio" = 50, "rad" = 0, "fire" = 70, "acid" = 0)
 
 /obj/item/clothing/head/helmet/f13/legion/legdecan/vet
 	name = "legion veteran decanus helmet"
-	desc = "It's leather legion veteran decan helmet."
+	desc = "It's a leather legion helmet that's been reinforced with stronger leather patches and anointed with a array of red and dark red feathers. This one has several large white and black feathers sewn along side the rest of the feathers aswell."
 	icon_state = "legdecanvet"
 	item_state = "legdecanvet"
 	armor = list("melee" = 60, "bullet" = 40, "laser" = 25, "energy" = 15, "bomb" = 25, "bio" = 50, "rad" = 0, "fire" = 70, "acid" = 0)
@@ -452,7 +452,7 @@
 
 /obj/item/clothing/head/helmet/f13/legion/legcenturion
 	name = "legion centurion helmet"
-	desc = "It's metal legion centurion helmet."
+	desc = "It's a large forged and case hardened bronze helmet with a steel insert around the skull and back of the neck. It has a large plume of red horse hair across the top of it going horizontally, symbolizing the position of a Centurion."
 	icon_state = "legcenturion"
 	item_state = "legcenturion"
 	armor = list("melee" = 75, "bullet" = 50, "laser" = 35, "energy" = 35, "bomb" = 39, "bio" = 60, "rad" = 0, "fire" = 80, "acid" = 0)
@@ -463,7 +463,7 @@
 
 /obj/item/clothing/head/helmet/f13/legion/leglegat
 	name = "legion legate helmet"
-	desc = "It's metal legion legat helmet."
+	desc = "A custom forged steel full helmet complete with abstract points and arches. The face is extremely intimidating, as it was meant to be. This particular one was ordered to be forged by Caesar, given to his second legate in exchange for his undying loyalty to Caesar."
 	icon_state = "leglegat"
 	item_state = "leglegat"
 	armor = list("melee" = 85, "bullet" = 60, "laser" = 40, "energy" = 40, "bomb" = 45, "bio" = 60, "rad" = 60, "fire" = 80, "acid" = 0)
@@ -599,7 +599,7 @@
 	lighting_alpha = LIGHTING_PLANE_ALPHA_LOWLIGHT_VISION
 
 /obj/item/clothing/head/helmet/power_armor/t45b
-	name = "Salvaged T-45b helmet"
+	name = "salvaged T-45b helmet"
 	desc = "It's a salvaged power armor helmet."
 	icon_state = "t45bhelmet"
 	item_state = "t45bhelmet"
@@ -608,14 +608,14 @@
 	lighting_alpha = null
 
 /obj/item/clothing/head/helmet/power_armor/advanced
-	name = "Advanced power helmet"
+	name = "advanced power helmet"
 	desc = "It's an advanced power armor Mk I helmet, typically used by the Enclave. It looks somewhat threatening."
 	icon_state = "advhelmet1"
 	item_state = "advhelmet1"
 	armor = list("melee" = 90, "bullet" = 75, "laser" = 60, "energy" = 75, "bomb" = 72, "bio" = 100, "rad" = 100, "fire" = 90, "acid" = 0)
 
 /obj/item/clothing/head/helmet/power_armor/advanced/mk2
-	name = "Advanced power helmet MK2"
+	name = "advanced power helmet MKII"
 	desc = "It's an improved model of advanced power armor used exclusively by the Enclave military forces, developed after the Great War.<br>Like its older brother, the standard advanced power armor, it's matte black with a menacing appearance, but with a few significant differences - it appears to be composed entirely of lightweight ceramic composites rather than the usual combination of metal and ceramic plates.<br>Additionally, like the T-51b power armor, it includes a recycling system that can convert human waste into drinkable water, and an air conditioning system for it's user's comfort."
 	icon_state = "advhelmet2"
 	item_state = "advhelmet2"
@@ -707,7 +707,7 @@
 	return ..()
 
 /obj/item/clothing/head/helmet/proc/toggle_helmlight()
-	set name = "Toggle Helmetlight"
+	set name = "Toggle Helmet Light"
 	set category = "Object"
 	set desc = "Click to toggle your helmet's attached flashlight."
 

--- a/code/modules/clothing/head/jobs.dm
+++ b/code/modules/clothing/head/jobs.dm
@@ -1,4 +1,3 @@
-
 //Chef
 /obj/item/clothing/head/chefhat
 	name = "chef's hat"

--- a/code/modules/clothing/head/ncr.dm
+++ b/code/modules/clothing/head/ncr.dm
@@ -43,14 +43,14 @@
 					sleep(15)
 
 /obj/item/clothing/head/beret/ncr
-	name = "NCR Officer's Beret"
+	name = "NCR officer beret"
 	desc = "A green beret, standard issue for all commissioned NCR Officers."
 	icon_state = "ncr_officer_beret"
 	item_state = "ncr_officer_beret"
 	armor = list("melee" = 30, "bullet" = 30, "laser" = 20, "energy" = 20, "bomb" = 25, "bio" = 30, "rad" = 20, "fire" = 60, "acid" = 0)
 
 /obj/item/clothing/head/beret/ncr_recon
-	name = "NCR Recon Beret"
+	name = "NCR 1st Recon beret"
 	desc = "A red beret, issued to members of NCR First Recon."
 	icon_state = "ncr_recon_beret"
 	item_state = "ncr_recon_beret"

--- a/code/modules/clothing/head/ncr.dm
+++ b/code/modules/clothing/head/ncr.dm
@@ -7,7 +7,7 @@
 	strip_delay = 50
 
 /obj/item/clothing/head/f13/ncr/goggles
-	name = "Goggled NCR Helmet"
+	name = "NCR storm helmet"
 	desc = "A standard issue NCR Infantry helmet, with a pair of goggles attached to it."
 	icon_state = "ncr_goggles_helmet"
 	item_state = "ncr_goggles_helmet"

--- a/code/modules/clothing/masks/hailer.dm
+++ b/code/modules/clothing/masks/hailer.dm
@@ -21,7 +21,7 @@
 	var/safety = TRUE
 
 /obj/item/clothing/mask/gas/sechailer/swat
-	name = "\improper SWAT mask"
+	name = "tactical gasmask"
 	desc = "A close-fitting tactical mask with an especially aggressive Compli-o-nator 3000."
 	actions_types = list(/datum/action/item_action/halt)
 	icon_state = "swat"

--- a/code/modules/clothing/masks/miscellaneous.dm
+++ b/code/modules/clothing/masks/miscellaneous.dm
@@ -37,7 +37,7 @@
 //NCR Facewrap
 
 /obj/item/clothing/mask/ncr_facewrap
-	name = "Facewrap"
+	name = "desert facewrap"
 	desc = "A facewrap commonly employed by NCR troops in the Mojave."
 	icon_state = "ncr_facewrap"
 	item_state = "ncr_facewrap"
@@ -316,7 +316,7 @@
 	icon_state = "bandred"
 
 /obj/item/clothing/mask/bandana/legprime
-	name = "prime  bandana"
+	name = "prime bandana"
 	desc = "A fine prime bandana"
 	icon_state = "legdecan"
 

--- a/code/modules/clothing/shoes/f13.dm
+++ b/code/modules/clothing/shoes/f13.dm
@@ -83,38 +83,38 @@
 	armor = list(melee = 20, bullet = 10, laser = 10, energy = 10, bomb = 10, bio = 0, rad = 0, fire = 0, acid = 0)
 	cold_protection = FEET
 	min_cold_protection_temperature = SHOES_MIN_TEMP_PROTECT
-	
+
 /obj/item/clothing/shoes/f13/military/ncr
-	name = "NCR Boots"
+	name = "NCR patrol boots"
 	desc = "A pair of standard issue NCR brown boots, with a puttee."
 	icon_state = "ncr_boots"
 	item_state = "ncr"
 	armor = list(melee = 10, bullet = 10, laser = 0, energy = 0, bomb = 10, bio = 0, rad = 0, fire = 10, acid = 0)
 
 /obj/item/clothing/shoes/f13/military/ncr_officer
-	name = "NCR Officer Boots"
-	desc = "A pair of brown leather boots, issued to NCR Officers."
+	name = "NCR officer boots"
+	desc = "A pair of calf high black, highly polished, leather boot that have been tightly laced. These definitely belong to a officer."
 	icon_state = "ncr_officer_boots"
 	item_state = "explorer"
 	armor = list(melee = 10, bullet = 10, laser = 0, energy = 0, bomb = 10, bio = 0, rad = 0, fire = 10, acid = 0)
 
 /obj/item/clothing/shoes/f13/military/legionleather
 	name = "leather boots"
-	desc = "A pair of leather boots commonly worn by the Caesar's Legion recruits."
+	desc = "A pair of leather boots that appear to be mostly intact and lightly used. These belong to a Recruit Legionary of Caesar's Legion"
 	icon_state = "legionleather"
 	item_state = "legionleather"
 	armor = list(melee = 10, bullet = 10, laser = 0, energy = 0, bomb = 10, bio = 0, rad = 0, fire = 10, acid = 0)
 
 /obj/item/clothing/shoes/f13/military/legionmetal
-	name = "metal boots"
-	desc = "A pair of metal boots commonly worn by Caesar's Legion veterans."
+	name = "plated metal boots"
+	desc = "A pair of leather boots that have been patched heavily and reinforced with light metal plates around the heel and ankles to protect the user. These belong to a Veteran of Caesar's Legion.""
 	icon_state = "legionmetal"
 	item_state = "legionmetal"
 	armor = list(melee = 20, bullet = 20, laser = 10, energy = 10, bomb = 20, bio = 0, rad = 0, fire = 20, acid = 0)
 
 /obj/item/clothing/shoes/f13/military/legionlegate
-	name = "legate boots"
-	desc = "A pair of heavy boots worn by the Caesar's Legion Legate."
+	name = "legion legate boots"
+	desc = "A pair of heavy leather boots with overlapping steel plates affixed to the front, sides, and back of them, in size 14. These belong to a Legatus of Caesar's Legion."
 	icon_state = "legionlegate"
 	item_state = "legionlegate"
 	armor = list(melee = 30, bullet = 30, laser = 20, energy = 20, bomb = 30, bio = 0, rad = 10, fire = 30, acid = 10)

--- a/code/modules/clothing/shoes/f13.dm
+++ b/code/modules/clothing/shoes/f13.dm
@@ -107,7 +107,7 @@
 
 /obj/item/clothing/shoes/f13/military/legionmetal
 	name = "plated metal boots"
-	desc = "A pair of leather boots that have been patched heavily and reinforced with light metal plates around the heel and ankles to protect the user. These belong to a Veteran of Caesar's Legion.""
+	desc = "A pair of leather boots that have been patched heavily and reinforced with light metal plates around the heel and ankles to protect the user. These belong to a Veteran of Caesar's Legion."
 	icon_state = "legionmetal"
 	item_state = "legionmetal"
 	armor = list(melee = 20, bullet = 20, laser = 10, energy = 10, bomb = 20, bio = 0, rad = 0, fire = 20, acid = 0)

--- a/code/modules/clothing/shoes/miscellaneous.dm
+++ b/code/modules/clothing/shoes/miscellaneous.dm
@@ -116,7 +116,7 @@
 	pocket_storage_component_path = /datum/component/storage/concrete/pockets/shoes
 
 /obj/item/clothing/shoes/laced
-	name = "laced boots"
+	name = "desert patrol boots"
 	desc = "A pair of laced, heavy-duty boots, adopted by NCR veteran rangers following the Ranger Unification Treaty."
 	icon_state = "laced"
 	item_state = "laced"
@@ -344,13 +344,13 @@
 	pocket_storage_component_path = /datum/component/storage/concrete/pockets/shoes
 
 /obj/item/clothing/shoes/combat/swat //overpowered boots for death squads
-	name = "\improper SWAT boots"
+	name = "assault boots"
 	desc = "High speed, no drag combat boots."
 	permeability_coefficient = 0.01
 
 /obj/item/clothing/shoes/combat/plate
 	name = "plated combat boots"
-	desc = "A pair of boots with armored plates on them"
+	desc = "A pair of heavily worn leather boots with armored plates strapped around them, protecting the users feet from low flying shrapnel or projectiles."
 	icon_state = "legionmetal"
 	item_state = "legionmetal"
 	item_color = "cult"

--- a/code/modules/clothing/suits/armor.dm
+++ b/code/modules/clothing/suits/armor.dm
@@ -116,7 +116,7 @@
 	body_parts_covered = CHEST|GROIN|LEGS|FEET|ARMS|HANDS
 	cold_protection = CHEST|GROIN|LEGS|FEET|ARMS|HANDS
 	heat_protection = CHEST|GROIN|LEGS|FEET|ARMS|HANDS
-	armor = list("melee" = 60, "bullet" = 25, "laser" = 16, "energy" = 16, "bomb" = 25, "bio" = 0, "rad" = 0, "fire" = 80, "acid" = 80)
+	armor = list("melee" = 60, "bullet" = 35, "laser" = 16, "energy" = 16, "bomb" = 25, "bio" = 0, "rad" = 0, "fire" = 80, "acid" = 80)
 	strip_delay = 80
 	equip_delay_other = 60
 
@@ -379,7 +379,7 @@
 	resistance_flags = LAVA_PROOF | FIRE_PROOF | ACID_PROOF
 
 /obj/item/clothing/suit/armor/f13/brokenpa/t45b
-	name = "salvaged power armor"
+	name = "salvaged T-45b power armor"
 	desc = "It's a set of T-45b power armor with a custom air conditioning module and stripped out servomotors."
 	icon_state = "t45bpowerarmor"
 	item_state = "t45bpowerarmor"
@@ -387,7 +387,7 @@
 
 /obj/item/clothing/suit/armor/f13/brokenpa/ncr
 	name = "salvaged NCR power armor"
-	desc = "A standard set of salvaged power armor marked by the NCR, issued to their Heavy Troopers."
+	desc = "It's a set of T-45b power armor with a air conditioning module installed, it however lacks servomotors to enhance the users strength. This one has brown paint trimmed along the edge and a two headed bear painted onto the chestplate."
 	icon_state = "ncrpowerarmor"
 	item_state = "ncrpowerarmor"
 	armor = list("melee" = 75, "bullet" = 60, "laser" = 30, "energy" = 50, "bomb" = 48, "bio" = 60, "rad" = 50, "fire" = 80, "acid" = 0)
@@ -435,6 +435,7 @@
 	desc = "A captured set of T-51b power armor put into use by the NCR, it's been heavily modified and decorated with the head of a bear and intricate gold trimming. A two headed bear is scorched into the breastplate."
 	icon_state = "sierra"
 	item_state = "sierra"
+	armor = list("melee" = 90, "bullet" = 80, "laser" = 70, "energy" = 70, "bomb" = 72, "bio" = 100, "rad" = 100, "fire" = 90, "acid" = 0)
 
 /obj/item/clothing/suit/armor/f13/power_armor/advanced
 	name = "advanced power armor"
@@ -571,46 +572,46 @@
 	armor = list("melee" = 70, "bullet" = 60, "laser" = 40, "energy" = 60, "bomb" = 55, "bio" = 60, "rad" = 60, "fire" = 90, "acid" = 0)
 
 /obj/item/clothing/suit/armor/f13/ncrarmor
-	name = "NCR Infantry vest"
+	name = "NCR patrol vest"
 	desc = "A standard issue NCR Infantry vest."
 	icon_state = "ncr_infantry_vest"
 	item_state = "ncr_infantry_vest"
 	body_parts_covered = CHEST|GROIN|ARMS|LEGS
 	armor = list("melee" = 30, "bullet" = 30, "laser" = 20, "energy" = 20, "bomb" = 25, "bio" = 30, "rad" = 20, "fire" = 60, "acid" = 0)
 	strip_delay = 60
-	
+
 /obj/item/clothing/suit/armor/f13/ncrarmor/mantle
-	name = "NCR Mantle Vest"
+	name = "NCR mantle vest"
 	desc = "A standard issue NCR Infantry vest with a mantle on the shoulder."
 	icon_state = "ncr_standard_mantle"
 	item_state = "ncr_standard_mantle"
 	armor = list("melee" = 50, "bullet" = 40, "laser" = 30, "energy" = 20, "bomb" = 25, "bio" = 30, "rad" = 20, "fire" = 60, "acid" = 0)
 
 /obj/item/clothing/suit/armor/f13/ncrarmor/reinforced
-	name = "NCR Reinforced Vest"
+	name = "NCR reinforced patrol vest"
 	desc = "A standard issue NCR Infantry vest reinforced with a groinpad."
 	icon_state = "ncr_reinforced_vest"
 	item_state = "ncr_reinforced_vest"
 	armor = list("melee" = 50, "bullet" = 40, "laser" = 30, "energy" = 20, "bomb" = 25, "bio" = 30, "rad" = 20, "fire" = 60, "acid" = 0)
-	
+
 /obj/item/clothing/suit/armor/f13/ncrarmor/mantle/reinforced
-	name = "NCR Reinforced Mantle Vest"
+	name = "NCR reinforced mantle vest"
 	desc = "A standard issue NCR Infantry vest reinforced with a groinpad and a mantle."
 	icon_state = "ncr_reinforced_mantle"
 	item_state = "ncr_reinforced_mantle"
 	armor = list("melee" = 55, "bullet" = 45, "laser" = 35, "energy" = 20, "bomb" = 30, "bio" = 30, "rad" = 20, "fire" = 60, "acid" = 0)
 
 /obj/item/clothing/suit/armor/f13/ncrarmor/labcoat
-	name = "NCR Medical Officer's Labcoat"
-	desc = "A labcoat typically issued to NCR Medical Officers."
+	name = "NCR medical labcoat"
+	desc = "A labcoat typically issued to NCR Medical Officers. It's a standard white labcoat with the Medical Officer's name stitched into the breast and a two headed bear sewn into the shoulder."
 	icon_state = "ncr_labcoat"
 	item_state = "ncr_labcoat"
 	armor = list("melee" = 0, "bullet" = 0, "laser" = 10, "energy" = 10, "bomb" = 0, "bio" = 10, "rad" = 10, "fire" = 10, "acid" = 10)
 	allowed = list(/obj/item/analyzer, /obj/item/stack/medical, /obj/item/dnainjector, /obj/item/reagent_containers/dropper, /obj/item/reagent_containers/syringe, /obj/item/reagent_containers/hypospray, /obj/item/healthanalyzer, /obj/item/flashlight/pen, /obj/item/reagent_containers/glass/bottle, /obj/item/reagent_containers/glass/beaker, /obj/item/reagent_containers/pill, /obj/item/storage/pill_bottle, /obj/item/paper, /obj/item/melee/classic_baton/telescopic, /obj/item/soap, /obj/item/sensor_device, /obj/item/tank/internals/emergency_oxygen, /obj/item/tank/internals/plasmaman)
 
 /obj/item/clothing/suit/armor/f13/ncrarmor/captain
-	name = "NCR Captain's Armour"
-	desc = "A heavily reinforced set of NCR infantry armour, with a large mantle attached to it."
+	name = "NCR reinforced officer vest"
+	desc = "A heavily reinforced set of NCR mantle armour, the armor has been heavily patched and given ceramic inserts in vital areas to protect the wearer. The design indicates it belongs to a high ranking NCR officer."
 	icon_state = "ncr_captain_armour"
 	item_state = "ncr_captain_armour"
 	armor = list("melee" = 60, "bullet" = 50, "laser" = 40, "energy" = 20, "bomb" = 50, "bio" = 30, "rad" = 20, "fire" = 60, "acid" = 0)

--- a/code/modules/clothing/suits/cloaks.dm
+++ b/code/modules/clothing/suits/cloaks.dm
@@ -57,16 +57,16 @@
 	icon_state = "hopcloak"
 
 /obj/item/clothing/suit/hooded/cloak/goliath
-	name = "goliath cloak"
+	name = "kevlar cloak"
 	icon_state = "goliath_cloak"
-	desc = "A staunch, practical cape made out of numerous monster materials, it is coveted amongst exiles & hermits."
+	desc = "A hood made out of weaved kevlar to offer the user some form of protection against small arms fire."
 	allowed = list(/obj/item/flashlight, /obj/item/tank/internals, /obj/item/pickaxe, /obj/item/twohanded/spear, /obj/item/twohanded/bonespear, /obj/item/organ/regenerative_core/legion, /obj/item/kitchen/knife/combat/bone, /obj/item/kitchen/knife/combat/survival)
 	armor = list("melee" = 35, "bullet" = 10, "laser" = 25, "energy" = 10, "bomb" = 25, "bio" = 0, "rad" = 0, "fire" = 60, "acid" = 60) //a fair alternative to bone armor, requiring alternative materials and gaining a suit slot
 	hoodtype = /obj/item/clothing/head/hooded/cloakhood/goliath
 	body_parts_covered = CHEST|GROIN|ARMS
 
 /obj/item/clothing/head/hooded/cloakhood/goliath
-	name = "goliath cloak hood"
+	name = "kevlar cloak hood"
 	icon_state = "golhood"
 	desc = "A protective & concealing hood."
 	armor = list("melee" = 35, "bullet" = 10, "laser" = 25, "energy" = 10, "bomb" = 25, "bio" = 0, "rad" = 0, "fire" = 60, "acid" = 60)

--- a/code/modules/clothing/under/f13.dm
+++ b/code/modules/clothing/under/f13.dm
@@ -34,14 +34,14 @@
 //NCR
 
 /obj/item/clothing/under/f13/ncr
-	name = "ncr fatigues"
+	name = "NCR fatigues"
 	desc = "A set of standard issue New California Republic trooper fatigues."
 	icon_state = "ncr_uniform"
 	item_state = "ncr_uniform"
 	item_color = "ncr_uniform"
 
 /obj/item/clothing/under/f13/ncr/officer
-	name = "officer fatigues"
+	name = "NCR officer fatigues"
 	desc = "A set of NCR officer fatigues"
 
 /obj/item/clothing/under/f13/caravaneer
@@ -105,8 +105,8 @@
 	item_color = "ranger"
 
 /obj/item/clothing/under/f13/patrolranger
-	name = "patrol ranger underclothes"
-	desc = "A pair of brown slacks and a breathable shirt, meant to be worn under N.C.R. patrol ranger armour."
+	name = "patrol ranger outfit"
+	desc = "A pair of brown slacks and a breathable shirt, meant to be worn under NCR patrol ranger armour."
 	icon_state = "patrolranger"
 	item_state = "patrolranger"
 	item_color = "patrolranger"
@@ -315,7 +315,7 @@
 //Remnants
 
 /obj/item/clothing/under/f13/enclave_officer
-	name = "Remnant Officer Uniform"
+	name = "enclave officer uniform"
 	desc = "A standard Enclave officer uniform.<br>The outer layer is made of a sturdy material designed to withstand the harsh conditions of the wasteland."
 	icon_state = "enclave_o"
 	item_state = "bl_suit"
@@ -408,7 +408,7 @@
 	can_adjust = 0
 
 /obj/item/clothing/under/f13/bdu //WalterJe military standarts.
-	name = "BDU"
+	name = "battle dress uniform"
 	desc = "A standard military Battle Dress Uniform."
 	icon_state = "bdu"
 	item_state = "xenos_suit"
@@ -418,7 +418,7 @@
 	can_adjust = 1
 
 /obj/item/clothing/under/f13/dbdu
-	name = "DBDU"
+	name = "desert battle dress uniform"
 	desc = "A military Desert Battle Dress Uniform."
 	icon_state = "dbdu"
 	item_state = "brownjsuit"
@@ -452,7 +452,7 @@
 	can_adjust = 0
 
 /obj/item/clothing/under/f13/relaxedwear
-	name = "pre-War male relaxedwear"
+	name = "pre-war male relaxedwear"
 	desc = "A dirty long-sleeve blue shirt with a greenish brown sweater-vest and slacks."
 	icon_state = "relaxedwear_m"
 	item_state = "g_suit"
@@ -460,7 +460,7 @@
 	can_adjust = 0
 
 /obj/item/clothing/under/f13/spring
-	name = "pre-War male spring outfit"
+	name = "pre-war male spring outfit"
 	desc = "A dirty long-sleeve beige shirt with a red sweater-vest and brown trousers."
 	icon_state = "spring_m"
 	item_state = "brownjsuit"
@@ -468,7 +468,7 @@
 	can_adjust = 0
 
 /obj/item/clothing/under/f13/formal
-	name = "pre-War male formal wear"
+	name = "pre-war male formal wear"
 	desc = "A black jacket with an old white shirt and dirty dark purple trousers.<br>Traditionally worn by the richest of the post-War world."
 	icon_state = "formal_m"
 	item_state = "judge"


### PR DESCRIPTION
## Description
- Improves naming / capitalization consistency across the board, particularly for NCR equipment.
- Indirectly creates a tier system in NCR equipment.
 _( NCR Patrol{+R} < NCR Mantle{+R} < NCR Officer{+R} < NCR Ranger < NCR Veteran Ranger )_
- Equalizes the damage protection stats of all three Legion Decanus helmets. They're now all Legion Veteran helmets in terms of protection. The three Decanus positions are the three highest positions right below centurion and regardless of circumstance are deserving of at least marginally better helmets.
- Allows you to put Thermic Lances on your back
- Buffs the riot suit slightly to indirectly buff plate armor. It's rarely seen but had very low bullet protection. Riot armor currently isn't in the game.
- Adds fluffier descriptions and removes references to SWAT.
- Adds preparation for making use of the Captains Sabre sheathe in coming PR.

## How Has This Been Tested?
- Compiles
- Passes Checks
- In game testing shows all the items took the names respectively, the thermic lance does indeed go on your back, it has no on back sprite yet. Sabre sheath only takes the captains sword.

## Changelog (neccesary)
:cl:
tweak: Minor grammar and fluff changes
balance: Legion Decanii now have helmets that are all equivalent to Legion Veteran helmets.
/:cl:
