### PR TITLE
Removes wheelys from arcade drops

### DIFF
--- a/code/game/machinery/computer/arcade.dm
+++ b/code/game/machinery/computer/arcade.dm
@@ -50,7 +50,6 @@
 		/obj/item/extendohand/acme								= 1,
 		/obj/item/hot_potato/harmless/toy						= 1,
 		/obj/item/card/emagfake									= 1,
-		/obj/item/clothing/shoes/wheelys				= 2,
 		/obj/item/clothing/shoes/kindleKicks				= 2,
 		/obj/item/storage/belt/military/snack					= 2
 		)


### PR DESCRIPTION
## Description
Read the title

## Motivation and Context
Someone killed me using them

## How Has This Been Tested?
It hasnt

## Changelog (neccesary)
:cl:
del: Fun
tweak: Arcade drops
/:cl:
