### PR TITLE
Adds spraycans and T2/T3 parts to trash loot piles

### DIFF
--- a/code/modules/fallout/obj/trash_stack.dm
+++ b/code/modules/fallout/obj/trash_stack.dm
@@ -117,7 +117,9 @@
 		/obj/item/clothing/shoes/f13/explorer, /obj/item/clothing/shoes/f13/military/diesel,
 		/obj/item/clothing/shoes/f13/military/female/diesel, /obj/item/clothing/gloves/f13/leather,
 		/obj/item/clothing/gloves/f13/military, /obj/item/clothing/gloves/f13/ncr,
-		/obj/item/gun/ballistic/shotgun/boltaction)
+		/obj/item/gun/ballistic/shotgun/boltaction, /obj/item/toy/crayon/spraycan, /obj/item/stock_parts/capacitor/adv,
+		/obj/item/stock_parts/scanning_module/adv, /obj/item/stock_parts/manipulator/nano, /obj/item/stock_parts/micro_laser/high,
+		/obj/item/stock_parts/matter_bin/adv, /obj/item/stock_parts/manipulator/pico, /obj/item/stock_parts/matter_bin/super)
 		var/I = new itemtype(src)
 		back += I
 	return back


### PR DESCRIPTION
Adds spraycans, all T2 and two T3 stock parts to the trash loot piles. If the stock parts addition isn't kosher, I can remove them and just leave the spraycan.