### PR TITLE
Wasteland category clothes, poncho buff and recipie changes

### DIFF
--- a/code/__DEFINES/construction.dm
+++ b/code/__DEFINES/construction.dm
@@ -92,6 +92,7 @@
 #define CAT_MEDICAL	"Medical"
 #define CAT_ASSEM  	"Assemblies"
 #define CAT_CLOTHING	"Clothing"
+#define CAT_WASTELAND	"Wasteland Clothing"
 #define CAT_FOOD	"Foods"
 #define CAT_BREAD	"Breads"
 #define CAT_BURGER	"Burgers"

--- a/code/game/objects/items/stacks/sheets/leather.dm
+++ b/code/game/objects/items/stacks/sheets/leather.dm
@@ -163,18 +163,31 @@ GLOBAL_LIST_INIT(xeno_recipes, list ( \
 GLOBAL_LIST_INIT(leather_recipes, list ( \
 	new/datum/stack_recipe("wallet", /obj/item/storage/wallet, 1), \
 	new/datum/stack_recipe("muzzle", /obj/item/clothing/mask/muzzle, 2), \
-	new/datum/stack_recipe("botany gloves", /obj/item/clothing/gloves/botanic_leather, 3), \
 	new/datum/stack_recipe("toolbelt", /obj/item/storage/belt/utility, 4), \
+	null, \
+	new/datum/stack_recipe("leather gloves", /obj/item/clothing/gloves/f13/leather, 3), \
+	new/datum/stack_recipe("leather shoes", /obj/item/clothing/shoes/f13/brownie, 4), \
 	new/datum/stack_recipe("leather satchel", /obj/item/storage/backpack/satchel/leather, 5), \
-	new/datum/stack_recipe("bandolier", /obj/item/storage/belt/bandolier, 5), \
-	new/datum/stack_recipe("leather jacket", /obj/item/clothing/suit/jacket/leather, 7), \
-	new/datum/stack_recipe("leather shoes", /obj/item/clothing/shoes/laceup, 2), \
-	new/datum/stack_recipe("leather overcoat", /obj/item/clothing/suit/jacket/leather/overcoat, 10), \
+	new/datum/stack_recipe("tanned vest", /obj/item/clothing/suit/f13/vest, 4), \
+	null, \
+	new/datum/stack_recipe("leather armor", /obj/item/clothing/suit/armor/f13/leatherarmor, 13), \
 ))
 
 /obj/item/stack/sheet/leather/Initialize(mapload, new_amount, merge = TRUE)
 	recipes = GLOB.leather_recipes
 	return ..()
+
+/obj/item/stack/sheet/leather/twenty
+	amount = 20
+
+/obj/item/stack/sheet/leather/fifteen
+	amount = 15
+
+/obj/item/stack/sheet/leather/ten
+	amount = 10
+
+/obj/item/stack/sheet/leather/five
+	amount = 5
 
 /*
  * Sinew

--- a/code/modules/clothing/suits/miscellaneous.dm
+++ b/code/modules/clothing/suits/miscellaneous.dm
@@ -204,6 +204,10 @@
 	desc = "Your classic, non-racist poncho."
 	icon_state = "classicponcho"
 	item_state = "classicponcho"
+	body_parts_covered = CHEST
+	armor = list(melee = 10, bullet = 0, laser = 0, energy = 0, bomb = 0, bio = 0, rad = 0, fire = 0, acid = 0)
+	allowed = list(/obj/item/pen,/obj/item/paper,/obj/item/stamp,/obj/item/reagent_containers/food/drinks/flask,/obj/item/storage/box/matches,/obj/item/lighter,/obj/item/clothing/mask/cigarette,/obj/item/storage/fancy/cigarettes,/obj/item/flashlight,/obj/item/gun,/obj/item/ammo_box,/obj/item/ammo_casing)
+
 
 /obj/item/clothing/suit/poncho/green
 	name = "green poncho"

--- a/code/modules/crafting/craft.dm
+++ b/code/modules/crafting/craft.dm
@@ -37,8 +37,10 @@
 							CAT_SANDWICH,
 							CAT_SOUP,
 							CAT_SPAGHETTI),
-                        CAT_CLOTHING, //Clothing subcategories
-                        CAT_NONE)
+						list(	//Clothing subcategories
+							CAT_CLOTHING,
+							CAT_WASTELAND),
+						CAT_NONE)
 
 	var/datum/action/innate/crafting/button
 	var/display_craftable_only = FALSE

--- a/code/modules/crafting/tailoring.dm
+++ b/code/modules/crafting/tailoring.dm
@@ -5,6 +5,7 @@
 				/obj/item/stack/sheet/leather = 4)
 	time = 50
 	category = CAT_CLOTHING
+	subcategory = CAT_CLOTHING
 
 /datum/crafting_recipe/durathread_helmet
 	name = "Makeshift Helmet"
@@ -13,6 +14,7 @@
 				/obj/item/stack/sheet/leather = 5)
 	time = 40
 	category = CAT_CLOTHING
+	subcategory = CAT_CLOTHING
 
 /datum/crafting_recipe/fannypack
 	name = "Fannypack"
@@ -21,7 +23,18 @@
 				/obj/item/stack/sheet/leather = 1)
 	time = 20
 	category = CAT_CLOTHING
+	subcategory = CAT_CLOTHING
 
+	/datum/crafting_recipe/bandolier
+	name = "Bandolier"
+	result = /obj/item/storage/belt/bandolier
+	reqs = list(/obj/item/stack/sheet/hay = 3,
+				/obj/item/stack/sheet/leather = 4)
+	time = 40
+	category = CAT_CLOTHING
+	subcategory = CAT_CLOTHING
+
+/* - Commented out for now, these are particularly rare without rnd anyway and dont fit all sunglasses types.
 /datum/crafting_recipe/hudsunsec
 	name = "Security HUDsunglasses"
 	result = /obj/item/clothing/glasses/hud/security/sunglasses
@@ -31,6 +44,7 @@
 				  /obj/item/clothing/glasses/sunglasses = 1,
 				  /obj/item/stack/cable_coil = 5)
 	category = CAT_CLOTHING
+	subcategory = CAT_CLOTHING
 
 /datum/crafting_recipe/hudsunsecremoval
 	name = "Security HUD removal"
@@ -39,6 +53,7 @@
 	tools = list(TOOL_SCREWDRIVER, TOOL_WIRECUTTER)
 	reqs = list(/obj/item/clothing/glasses/hud/security/sunglasses = 1)
 	category = CAT_CLOTHING
+	subcategory = CAT_CLOTHING
 
 /datum/crafting_recipe/hudsunmed
 	name = "Medical HUDsunglasses"
@@ -49,6 +64,7 @@
 				  /obj/item/clothing/glasses/sunglasses = 1,
 				  /obj/item/stack/cable_coil = 5)
 	category = CAT_CLOTHING
+	subcategory = CAT_CLOTHING
 
 /datum/crafting_recipe/hudsunmedremoval
 	name = "Medical HUD removal"
@@ -57,6 +73,8 @@
 	tools = list(TOOL_SCREWDRIVER, TOOL_WIRECUTTER)
 	reqs = list(/obj/item/clothing/glasses/hud/health/sunglasses = 1)
 	category = CAT_CLOTHING
+	subcategory = CAT_CLOTHING
+
 
 /datum/crafting_recipe/beergoggles
 	name = "Beer Goggles"
@@ -67,6 +85,7 @@
 				  /obj/item/clothing/glasses/sunglasses = 1,
 				  /obj/item/stack/cable_coil = 5)
 	category = CAT_CLOTHING
+	subcategory = CAT_CLOTHING
 
 /datum/crafting_recipe/beergogglesremoval
 	name = "Beer Goggles removal"
@@ -75,6 +94,8 @@
 	tools = list(TOOL_SCREWDRIVER, TOOL_WIRECUTTER)
 	reqs = list(/obj/item/clothing/glasses/sunglasses/reagent = 1)
 	category = CAT_CLOTHING
+	subcategory = CAT_CLOTHING
+*/
 
 /datum/crafting_recipe/ghostsheet
 	name = "Ghost Sheet"
@@ -83,6 +104,7 @@
 	tools = list(TOOL_WIRECUTTER)
 	reqs = list(/obj/item/bedsheet = 1)
 	category = CAT_CLOTHING
+	subcategory = CAT_CLOTHING
 
 //f13 additions
 /datum/crafting_recipe/metalarmor
@@ -94,6 +116,8 @@
 	tools = list(TOOL_SCREWDRIVER, TOOL_WIRECUTTER)
 	time = 120
 	category = CAT_CLOTHING
+	subcategory = CAT_CLOTHING
+
 
 /datum/crafting_recipe/Imetalarmor
 	name = "improved metal armor"
@@ -105,6 +129,7 @@
 	tools = list(TOOL_SCREWDRIVER, TOOL_WIRECUTTER)
 	time = 120
 	category = CAT_CLOTHING
+	subcategory = CAT_CLOTHING
 
 /datum/crafting_recipe/IImetalarmor
 	name = "upgrading metal armor"
@@ -115,3 +140,76 @@
 	tools = list(TOOL_SCREWDRIVER, TOOL_WIRECUTTER)
 	time = 120
 	category = CAT_CLOTHING
+	subcategory = CAT_CLOTHING
+
+/datum/crafting_recipe/settler
+	name = "Settler Outfit"
+	result = /obj/item/clothing/under/f13/settler
+	reqs = list(/obj/item/stack/sheet/leather = 1,
+				/obj/item/stack/sheet/cloth = 3)
+	time = 15
+	category = CAT_CLOTHING
+	subcategory = CAT_WASTELAND
+
+/datum/crafting_recipe/merchant
+	name = "Merchant Outfit"
+	result = /obj/item/clothing/under/f13/merchant
+	reqs = list(/obj/item/stack/sheet/hay = 2,
+				/obj/item/stack/sheet/cloth = 3)
+	time = 15
+	category = CAT_CLOTHING
+	subcategory = CAT_WASTELAND
+
+/datum/crafting_recipe/mercenary
+	name = "Mercenary Outfit"
+	result = /obj/item/clothing/under/f13/merca
+	reqs = list(/obj/item/stack/sheet/hay = 2,
+				/obj/item/stack/sheet/cloth = 3)
+	time = 15
+	category = CAT_CLOTHING
+	subcategory = CAT_WASTELAND
+
+/datum/crafting_recipe/cowboyhat
+	name = "Wide Brim Cowboy Hat"
+	result = /obj/item/clothing/head/f13/cowboy
+	reqs = list(/obj/item/stack/sheet/leather = 2,
+				/obj/item/stack/sheet/cloth = 1)
+	time = 15
+	category = CAT_CLOTHING
+	subcategory = CAT_WASTELAND
+
+/datum/crafting_recipe/cowboyboots
+	name = "Cowboy Boots"
+	result = /obj/item/clothing/shoes/f13/cowboy
+	reqs = list(/obj/item/stack/sheet/leather = 2,
+				/obj/item/stack/sheet/cloth = 2)
+	time = 15
+	category = CAT_CLOTHING
+	subcategory = CAT_WASTELAND
+
+/datum/crafting_recipe/poncho
+	name = "Poncho"
+	result = /obj/item/clothing/suit/poncho
+	reqs = list(/obj/item/stack/sheet/cloth = 3,
+				/obj/item/stack/sheet/hay = 2)
+	time = 15
+	category = CAT_CLOTHING
+	subcategory = CAT_WASTELAND
+
+/datum/crafting_recipe/sombrero
+	name = "Sombrero"
+	result = /obj/item/clothing/head/sombrero
+	reqs = list(/obj/item/stack/sheet/hay = 4)
+	time = 15
+	category = CAT_CLOTHING
+	subcategory = CAT_WASTELAND
+
+/datum/crafting_recipe/duster
+	name = "Duster"
+	result = /obj/item/clothing/suit/f13/duster
+	reqs = list(/obj/item/stack/sheet/hay = 3,
+				/obj/item/stack/sheet/cloth = 3,
+				/obj/item/stack/sheet/leather = 6)
+	time = 40
+	category = CAT_CLOTHING
+	subcategory = CAT_WASTELAND


### PR DESCRIPTION


<!-- Thanks for choosing to take the time to contribute to our project! We have a few things below that we'd like you to fill out -->
<!-- The more detail you can give us, the faster we can code review, test, and merge your changes -->

<!--- Provide a general summary of your changes in the Title above -->

## Description
Changes multiple aspects of crafting to conform with consistency in setting and help ease into getting RP outfits too, for some relatively low tier starting armors and utility. Now everyone can dress up like Clint Eastwood, or if you're neither intimidating and/or square jawed + morally ambigious : Preston Garvey.
## Motivation and Context
The original content had a lot of hold-over from SS13's station equipment, this new gear will help people with only base raw materials from scratch create a image without infringing on unique costume pieces and get some usefulness out of it. 

Poncho buff additionally helps add some meat to a popular bandit item clothing choice in the wasteland that's more flavorful than combat armor. Spawned leather stack of 20 is mainly because I found it very annoying to generate leather for my live dream-daemon playtests.

## How Has This Been Tested?
Some revisions had been made before publshing to iron out faults i could find, its been tested in dreamweaver and all of the items work as standard, new crafting category is functional. (Pictured)
## Screenshots (if appropriate):
![rooty tooty western town](http://puu.sh/DUjgi/b5b620c404.png)
## Changelog (neccesary)
:cl: Desert walking Moonman
add: A new category for clothesmaking referred to as 'Wasteland'  has been introduced, many of the recipies here require hay (gathered from wasteland grass and dried farm-grass) leather or cloth, for a arrangement of stylish and practical clothes.
add: Existing BD leather game objects have replaced objects upon the leather crafting list, featuring the tan vest, brown shoes (with inventory), leather gloves and leather armor.
del: Commented out the beer goggles, sechud and medhud's from the clothing category.
tweak: The poncho has recieved a buff to the minor protective value level of a tan vest, but now can also hold a weapon and other objects like non-civilian vests, perfect for novices or showboating bandito's.
tweak: The bandolier has been moved to the clothing category for crafting from leather sheets, it requires a small amout of hay but has had its leather cost reduced.
code: stacks of 20 leather are now availible for the debug spawn verb for convenience.
/:cl:
