### PR TITLE
Return back crafting of leather clothes

### DIFF
--- a/code/game/objects/items/stacks/sheets/leather.dm
+++ b/code/game/objects/items/stacks/sheets/leather.dm
@@ -169,6 +169,8 @@ GLOBAL_LIST_INIT(leather_recipes, list ( \
 	new/datum/stack_recipe("leather shoes", /obj/item/clothing/shoes/f13/brownie, 4), \
 	new/datum/stack_recipe("leather satchel", /obj/item/storage/backpack/satchel/leather, 5), \
 	new/datum/stack_recipe("tanned vest", /obj/item/clothing/suit/f13/vest, 4), \
+	new/datum/stack_recipe("leather jacket", /obj/item/clothing/suit/jacket/leather, 7), \
+	new/datum/stack_recipe("leather overcoat", /obj/item/clothing/suit/jacket/leather/overcoat, 10), \
 	null, \
 	new/datum/stack_recipe("leather armor", /obj/item/clothing/suit/armor/f13/leatherarmor, 13), \
 ))


### PR DESCRIPTION
A changeset https://github.com/BadDeathclaw/TG-Claw/commit/d1b30676aac4dcf78c4bec05465f5a736e3e28d0 removed ability to craft leather jacket and overcoat. I have pointed this in issue https://github.com/BadDeathclaw/TG-Claw/issues/1132 . 

Now I am bringing those craft recipes back, because these clothing look great in game.

<!-- Thanks for choosing to take the time to contribute to our project! We have a few things below that we'd like you to fill out -->
<!-- The more detail you can give us, the faster we can code review, test, and merge your changes -->

<!--- Provide a general summary of your changes in the Title above -->

## Description
Return back crafting of leather jacket and overcoat

## Motivation and Context
I liked how the leather jacket and leather overcoat look, but the recipes were deliberately removed by civ-tailoring commit and pullrequest. I have pointed this in https://github.com/BadDeathclaw/TG-Claw/issues/1132 . Since I mostly choose farming activity, keeping those expensive items would add more interest in farming and keeping livestock for hides

## How Has This Been Tested?
This should 100% work!

## Screenshots (if appropriate):
nope
## Changelog (neccesary)
:cl:
fix: return back crafting recipes for leather overcoat and leather jacket
/:cl:
