### PR TITLE
Adds 12 character slots, up from 7

### DIFF
--- a/code/modules/client/preferences.dm
+++ b/code/modules/client/preferences.dm
@@ -9,7 +9,7 @@ GLOBAL_LIST_EMPTY(preferences_datums)
 	//doohickeys for savefiles
 	var/path
 	var/default_slot = 1				//Holder so it doesn't default to slot 1, rather the last one used
-	var/max_save_slots = 7 // lucky number
+	var/max_save_slots = 12 // lucky number
 
 	//non-preference stuff
 	var/muted = 0


### PR DESCRIPTION
## Description
Per request of agent, adds 5 additional character slots

## Motivation and Context
For individuals with multiple characters [ in excess of 7 ] allows for quick changing

## How Has This Been Tested?
![bbfee18dba5a54a59d64cd7fb71a1871](https://user-images.githubusercontent.com/16493725/61584572-f1bfff00-ab17-11e9-948f-414efa31a013.png)

## Screenshots (if appropriate):
![bbfee18dba5a54a59d64cd7fb71a1871](https://user-images.githubusercontent.com/16493725/61584573-f5538600-ab17-11e9-8623-7464b63f44fd.png)

## Changelog (neccesary)
:cl:
add: Added 5 more character slots
/:cl:
