### PR TITLE
Allows dead people to be sent out of the wasteland

### DIFF
--- a/code/modules/fallout/turf/walls.dm
+++ b/code/modules/fallout/turf/walls.dm
@@ -180,9 +180,6 @@
 	if(!ishuman(dropping))
 		return //Only humans have job slots to be freed.
 	var/mob/living/carbon/human/departing_mob = dropping
-	if(departing_mob.stat == DEAD)
-		to_chat(user, "<span class='warning'>This one kicked the bucket. Won't be traveling anywhere.</span>")
-		return
 	if(departing_mob != user && departing_mob.client)
 		to_chat(user, "<span class='warning'>This one retains their free will. It's their choice if they want to depart or not.</span>")
 		return
@@ -205,7 +202,7 @@
 		dat += "."
 	message_admins(dat)
 	log_admin(dat)
-	departing_mob.visible_message("<span class='notice'>[departing_mob == user ? "Out of their own volition, " : "Ushered by [user], "][departing_mob] crosses the border and departs the Mojave.</span>")
+	departing_mob.visible_message("<span class='notice'>[departing_mob == user ? "Out of their own volition, " : "Ushered by [user], "][departing_mob] crosses the border and departs the Mojave Wasteland.</span>")
 	departing_mob.despawn()
 
 


### PR DESCRIPTION
## Description
This allows dead people to be sent out of the wasteland.

Fundamentally, the purpose of this is to incentivize factions collecting their corpses of important job slots, and allows the job slots to be freed up in the event a faction is beginning to make a come back, this also prevents faction positions from being removed entirely during the course of a round.

Same name rules still apply. It's logged.

## Motivation and Context
Killing a centurion or a captain basically ensures that the extent of the leadership will be run by a lower bracket in that faction or that someone will have to pick up that persons gear, which sometimes results in arguments about who deserves it and overall facilitates a unrealistic portion of command, that being that he who wears the fancy hat controls the faction.

RP wise, this basically represents that the body was taken back to -x off map faction main base- and buried, and then the faction later on (whenever a player selects the open job slot) sent a new one back onto the map.

This doesn't occur unless someone takes the time to drag the body to a matrix wall and send them back, and its not guaranteed to fill the slot anyways, as someone still has to go into it.

## Changelog (neccesary)
:cl:
tweak: Tweaks respawning bodies at matrix walls.
/:cl:
