### PR TITLE
Fixes donator save slots (HOTFIX)

### DIFF
--- a/code/modules/client/preferences.dm
+++ b/code/modules/client/preferences.dm
@@ -163,7 +163,7 @@ GLOBAL_LIST_EMPTY(preferences_datums)
 			load_path(C.ckey)
 			unlock_content = C.IsByondMember()
 			if(unlock_content)
-				max_save_slots = 8
+				max_save_slots = 13
 	var/loaded_preferences_successfully = load_preferences()
 	if(loaded_preferences_successfully)
 		if(load_character())


### PR DESCRIPTION
## Description
Bug Fix, the 7 to 12 PR forgot to update the donator slot number. This PR gives them 13 slots.

## Motivation and Context
I want to make Nappist proud.

## How Has This Been Tested?
It hasn't been

## Changelog (neccesary)
:cl:
fix: Donator save slots
/:cl:
