### PR TITLE
Changes the Anacea healing reaction to water instead

### DIFF
--- a/code/modules/reagents/chemistry/recipes/toxins.dm
+++ b/code/modules/reagents/chemistry/recipes/toxins.dm
@@ -115,9 +115,9 @@
 	required_reagents = list("radium" = 1, "mutetoxin" = 1, "nothing" = 1)
 
 /datum/chemical_reaction/healitemconflict1
-	name = "Anacea"
-	id = "anacea"
-	results = list("anacea" = 1)
+	name = "Water"
+	id = "water"
+	results = list("water" = 1)
 	required_reagents = list("stimpak"= 1, "healing_powder" = 1)
 
 

--- a/code/modules/reagents/chemistry/recipes/toxins.dm
+++ b/code/modules/reagents/chemistry/recipes/toxins.dm
@@ -122,33 +122,33 @@
 
 
 /datum/chemical_reaction/healitemconflict2
-	name = "Anacea"
-	id = "anacea"
-	results = list("anacea" = 1)
+	name = "Water"
+	id = "water"
+	results = list("water" = 1)
 	required_reagents = list("stimpak"= 1, "super_stimpak" = 1)
 
 /datum/chemical_reaction/healitemconflict3
-	name = "Anacea"
-	id = "anacea"
-	results = list("anacea" = 1)
+	name = "Water"
+	id = "water"
+	results = list("water" = 1)
 	required_reagents = list("stimpak"= 1, "healing_poultice" = 1)
 
 /datum/chemical_reaction/healitemconflict4
-	name = "Anacea"	
-	id = "anacea"
-	results = list("anacea" = 1)
+	name = "Water"	
+	id = "water"
+	results = list("water" = 1)
 	required_reagents = list("healing_powder"= 1, "healing_poultice" = 1)
 
 /datum/chemical_reaction/healitemconflict5
-	name = "Anacea"
-	id = "anacea"
-	results = list("anacea" = 1)
+	name = "Water"
+	id = "water"
+	results = list("water" = 1)
 	required_reagents = list("healing_powder"= 1, "super_stimpak" = 1)
 
 /datum/chemical_reaction/healitemconflict6
-	name = "Anacea"	
-	id = "anacea"
-	results = list("anacea" = 1)
+	name = "Water"	
+	id = "water"
+	results = list("water" = 1)
 	required_reagents = list("healing_poultice"= 1, "super_stimpak" = 1)
 
 


### PR DESCRIPTION
## Description
See title

## Motivation and Context
Because making it Anacea is dumb, see the long talk in the coding public channel. Having all the active healing removed for your system is bad enought, it doesnt need to deal toxin damage and remove any other healing chems in your system just dooming you.

## How Has This Been Tested?
It hasnt been

## Changelog (neccesary)
:cl:
balance: Healing reactions
/:cl:
