### PR TITLE
Update travis to xenial

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -15,6 +15,7 @@ matrix:
           packages:
             - python3
             - python3-pip
+            - python3-setuptools
       cache:
         directories:
           - tgui/node_modules

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,6 @@
 language: generic
 sudo: true
+dist: xenial
 branches:
   except:
   - ___TGS3TempBranch
@@ -43,7 +44,8 @@ matrix:
             - gcc-multilib
             - g++-7
             - g++-7-multilib
-            - libmariadbclient-dev:i386
+            - libmariadb-client-lgpl-dev:i386
+            - libmariadbd-dev
       cache:
         directories:
           - $HOME/.cargo

--- a/tools/travis/install_build_tools.sh
+++ b/tools/travis/install_build_tools.sh
@@ -4,10 +4,8 @@ set -e
 source dependencies.sh
 
 if [ "$BUILD_TOOLS" = true ]; then
-      rm -rf ~/.nvm
-	  git clone https://github.com/creationix/nvm.git ~/.nvm
-	  cd ~/.nvm && git checkout `git describe --abbrev=0 --tags`
-	  source ~/.nvm/nvm.sh && nvm install $NODE_VERSION
+	  source ~/.nvm/nvm.sh
+	  nvm install $NODE_VERSION
       pip3 install --user PyYaml
       pip3 install --user beautifulsoup4
 fi;

--- a/tools/travis/install_build_tools.sh
+++ b/tools/travis/install_build_tools.sh
@@ -4,7 +4,10 @@ set -e
 source dependencies.sh
 
 if [ "$BUILD_TOOLS" = true ]; then
-      rm -rf ~/.nvm && git clone https://github.com/creationix/nvm.git ~/.nvm && (cd ~/.nvm && git checkout `git describe --abbrev=0 --tags`) && source ~/.nvm/nvm.sh && nvm install $NODE_VERSION
-      pip3 install --user PyYaml -q
-      pip3 install --user beautifulsoup4 -q
+      rm -rf ~/.nvm
+	  git clone https://github.com/creationix/nvm.git ~/.nvm
+	  cd ~/.nvm && git checkout `git describe --abbrev=0 --tags`
+	  source ~/.nvm/nvm.sh && nvm install $NODE_VERSION
+      pip3 install --user PyYaml
+      pip3 install --user beautifulsoup4
 fi;


### PR DESCRIPTION
Forced travis to use the ubuntu xenial build
updated mariadb get
removed node version manager fetch - included by travis by default
- outside of this, also fixed the travis integration, it wasn't connecting properly
- have emailed travis support to get migrated to travis-ci.com instead of .org, we are on the legacy services integration