### PR TITLE
Mob spawner destruction fix

### DIFF
--- a/code/modules/mob/living/simple_animal/spawner.dm
+++ b/code/modules/mob/living/simple_animal/spawner.dm
@@ -21,7 +21,7 @@
 	maxbodytemp = 350
 	layer = BELOW_MOB_LAYER
 	sentience_type = SENTIENCE_BOSS
-
+	del_on_death = TRUE
 
 /mob/living/simple_animal/hostile/spawner/Destroy()
 	for(var/mob/living/simple_animal/L in spawned_mobs)
@@ -124,8 +124,6 @@
 	spawn_time = 150
 	mob_types = list(/mob/living/simple_animal/hostile/radroach)
 	faction = list("gecko")
-
-/mob/living/simple_animal/hostile/spawner/radroach
 
 /mob/living/simple_animal/hostile/spawner/mining
 	name = "monster den"


### PR DESCRIPTION
<!-- Thanks for choosing to take the time to contribute to our project! We have a few things below that we'd like you to fill out -->
<!-- The more detail you can give us, the faster we can code review, test, and merge your changes -->

<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->

This PR fixes a bug with a mob spawners(such as ghoul pits), where upon mob spawner destruction, it was not properly deleted. This caused it to be still visible on closer examine, and blocked certain interactions, like closing locker over the tile where mob spawner was destroyed. This is fixed now and upon destruction, mob spawner is properly deleted. Also removes empty duplicit radroach spawner, which I guess was an oversight.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

Less bugs.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- This helps us replicate your tests, to speed up review. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->

Locally without any problem.

## Changelog (neccesary)
:cl: Arkatos
fix: Mob spawners, such as ghoul pits, are now properly deleted after their destruction.
/:cl:
