### PR TITLE
Keychain fix

### DIFF
--- a/code/modules/fallout/obj/door_keys.dm
+++ b/code/modules/fallout/obj/door_keys.dm
@@ -70,7 +70,7 @@
 /obj/item/storage/keys_set/ComponentInitialize()
 	. = ..()
 	GET_COMPONENT(STR, /datum/component/storage)
-	STR.can_hold = list(/obj/item/door_key)
+	STR.can_hold = typecacheof(list(/obj/item/door_key))
 	STR.max_combined_w_class = 35
 
 /obj/item/storage/keys_set/update_icon()


### PR DESCRIPTION
<!-- Thanks for choosing to take the time to contribute to our project! We have a few things below that we'd like you to fill out -->
<!-- The more detail you can give us, the faster we can code review, test, and merge your changes -->

<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->

This PR resolves a bug where you were unable to put door keys in the keychain, making whole keychain item useless.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

Usable keychains.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- This helps us replicate your tests, to speed up review. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->

Tested locally without any problems, keychain functionality as a whole is also working.

## Changelog (neccesary)
:cl: Arkatos
fix: You can now put door keys in the keychain.
/:cl:
