### PR TITLE
Kebab renamings

### DIFF
--- a/code/controllers/subsystem/blackbox.dm
+++ b/code/controllers/subsystem/blackbox.dm
@@ -139,7 +139,7 @@ SUBSYSTEM_DEF(blackbox)
 		if(FREQ_ENCLAVE)
 			record_feedback("tally", "radio_usage", 1, "Enclave")
 		if(FREQ_DEN)
-			record_feedback("tally", "radio_usage", 1, "Den")
+			record_feedback("tally", "radio_usage", 1, "Kebab")
 		else
 			record_feedback("tally", "radio_usage", 1, "other")
 

--- a/code/game/area/Space_Station_13_areas.dm
+++ b/code/game/area/Space_Station_13_areas.dm
@@ -1441,7 +1441,7 @@ NOTE: there are two lists of areas in the end of this file: centcom and station 
 	ambientsounds = list('sound/f13ambience/enclave_vault.ogg')
 
 /area/f13/den
-	name = "Den"
+	name = "Kebab"
 	icon_state = "den"
 
 /area/f13/underground/overseer_office

--- a/code/game/communications.dm
+++ b/code/game/communications.dm
@@ -108,7 +108,7 @@ GLOBAL_LIST_INIT(radiochannels, list(
 	"NCR" = FREQ_NCR,
 	"BOS" = FREQ_BOS,
 	"Enclave" = FREQ_ENCLAVE,
-	"Den" = FREQ_DEN
+	"Kebab" = FREQ_DEN
 ))
 
 GLOBAL_LIST_INIT(reverseradiochannels, list(
@@ -129,7 +129,7 @@ GLOBAL_LIST_INIT(reverseradiochannels, list(
 	"[FREQ_NCR]" = "NCR",
 	"[FREQ_BOS]" = "BOS",
 	"[FREQ_ENCLAVE]" = "Enclave",
-	"[FREQ_DEN]" = "Den"
+	"[FREQ_DEN]" = "Kebab"
 ))
 
 /datum/radio_frequency

--- a/code/game/machinery/telecomms/machines/bus.dm
+++ b/code/game/machinery/telecomms/machines/bus.dm
@@ -63,7 +63,7 @@
 	id = "Bus 3"
 	network = "tcommsat"
 	freq_listening = list(FREQ_SECURITY, FREQ_COMMAND, FREQ_VAULT, FREQ_NCR, FREQ_BOS, FREQ_ENCLAVE, FREQ_DEN)
-	autolinkers = list("processor3", "security", "command", "vault", "ncr", "bos", "enclave", "den")
+	autolinkers = list("processor3", "security", "command", "vault", "ncr", "bos", "enclave", "kebab")
 
 /obj/machinery/telecomms/bus/preset_four
 	id = "Bus 4"

--- a/code/game/machinery/telecomms/machines/hub.dm
+++ b/code/game/machinery/telecomms/machines/hub.dm
@@ -38,6 +38,6 @@
 	id = "Hub"
 	network = "tcommsat"
 	autolinkers = list("hub", "relay", "s_relay", "m_relay", "r_relay", "h_relay", "science", "medical",
-	"supply", "service", "vault", "ncr", "bos", "enclave", "den", "common", "command", "engineering", "security",
+	"supply", "service", "vault", "ncr", "bos", "enclave", "kebab", "common", "command", "engineering", "security",
 	"receiverA", "receiverB", "broadcasterA", "broadcasterB")
 

--- a/code/game/machinery/telecomms/machines/server.dm
+++ b/code/game/machinery/telecomms/machines/server.dm
@@ -112,9 +112,9 @@
 	autolinkers = list("enclave")
 
 /obj/machinery/telecomms/server/presets/den
-	id = "Den Server"
+	id = "Kebab Server"
 	freq_listening = list(FREQ_DEN)
-	autolinkers = list("den")
+	autolinkers = list("kebab")
 
 /obj/machinery/telecomms/server/presets/common
 	id = "Common Server"

--- a/code/game/objects/effects/F13bilboards.dm
+++ b/code/game/objects/effects/F13bilboards.dm
@@ -74,8 +74,8 @@
 	icon_state = "ritas4"
 
 /obj/structure/sign/bilboards/den
-	name = "Den sign"
-	desc =  "A sprayed metal sheet that says \"The Den \"."
+	name = "Kebab sign"
+	desc =  "A sprayed metal sheet that says \"Kebab \"."
 	icon_state = "den"
 
 /obj/structure/sign/bilboards/klamat

--- a/code/game/objects/effects/landmarks.dm
+++ b/code/game/objects/effects/landmarks.dm
@@ -621,7 +621,7 @@ INITIALIZE_IMMEDIATE(/obj/effect/landmark/start/new_player)
 	icon_state = "Settler"
 
 /obj/effect/landmark/start/f13/dendoc
-	name = "Den Doctor"
+	name = "Kebab Doctor"
 
 // Wasteland
 

--- a/code/game/objects/items/devices/radio/encryptionkey.dm
+++ b/code/game/objects/items/devices/radio/encryptionkey.dm
@@ -146,27 +146,27 @@
 
 /obj/item/encryptionkey/headset_ncr
 	name = "NCR radio encryption key"
-	desc = "An encryption key for a radio headset.  To access the vault channel, use :w."
+	desc = "An encryption key for a radio headset.  To access the NCR channel, use :w."
 	icon_state = "cypherkey"
 	channels = list("NCR" = 1)
 
 /obj/item/encryptionkey/headset_bos
 	name = "Brotherhood radio encryption key"
-	desc = "An encryption key for a radio headset.  To access the vault channel, use :q."
+	desc = "An encryption key for a radio headset.  To access the Enclave channel, use :q."
 	icon_state = "cypherkey"
 	channels = list("BOS" = 1)
 
 /obj/item/encryptionkey/headset_enclave
 	name = "Enclave radio encryption key"
-	desc = "An encryption key for a radio headset.  To access the vault channel, use :z."
+	desc = "An encryption key for a radio headset.  To access the Brotherhood channel, use :z."
 	icon_state = "cypherkey"
 	channels = list("Enclave" = 1)
 
 /obj/item/encryptionkey/headset_den
-	name = "Den radio encryption key"
-	desc = "An encryption key for a radio headset.  To access the vault channel, use :f."
+	name = "Kebab radio encryption key"
+	desc = "An encryption key for a radio headset.  To access the Kebab channel, use :f."
 	icon_state = "cypherkey"
-	channels = list("Den" = 1)
+	channels = list("Kebab" = 1)
 
 /obj/item/encryptionkey/headset_cent
 	name = "\improper CentCom radio encryption key"

--- a/code/game/objects/items/devices/radio/headset.dm
+++ b/code/game/objects/items/devices/radio/headset.dm
@@ -269,7 +269,7 @@
 
 /obj/item/radio/headset/headset_den
 	name = "kebab radio headset"
-	desc = "This is used by the den.\nTo access the den channel, use :f."
+	desc = "This is used by the kebab town.\nTo access the kebab channel, use :f."
 	icon_state = "mine_headset"
 	keyslot = new /obj/item/encryptionkey/headset_den
 

--- a/code/modules/jobs/job_types/den.dm
+++ b/code/modules/jobs/job_types/den.dm
@@ -6,7 +6,7 @@ Mayor
 	title = "Mayor"
 	flag = F13MAYOR
 	department_flag = DEN
-	faction = "Den"
+	faction = "Kebab"
 	total_positions = 1
 	spawn_positions = 1
 	supervisors = "the people of the town"
@@ -41,7 +41,7 @@ Sheriff
 	flag = F13SHERIFF
 	department_flag = DEN
 	head_announce = list("Security")
-	faction = "Den"
+	faction = "Kebab"
 	total_positions = 1
 	spawn_positions = 1
 	supervisors = "the mayor"
@@ -91,7 +91,7 @@ Settler
 	title = "Settler"
 	flag = F13SETTLER
 	department_flag = DEN
-	faction = "Den"
+	faction = "Kebab"
 	total_positions = 6
 	spawn_positions = 6
 	supervisors = "the sheriff and the mayor"
@@ -128,10 +128,10 @@ Farmer
 	title = "Farmer"
 	flag = F13FARMER
 	department_flag = DEN
-	faction = "Den"
+	faction = "Kebab"
 	total_positions = 1
 	spawn_positions = 1
-	supervisors = "the mayor, the sheriff"
+	supervisors = "the sheriff and the mayor"
 	selection_color = "#dcba97"
 
 	outfit = /datum/outfit/job/den/f13settler
@@ -172,10 +172,10 @@ Prospector
 	title = "Prospector"
 	flag = F13PROSPECTOR
 	department_flag = DEN
-	faction = "Den"
+	faction = "Kebab"
 	total_positions = 1
 	spawn_positions = 1
-	supervisors = "the mayor, the sheriff"
+	supervisors = "the sheriff and the mayor"
 	selection_color = "#dcba97"
 
 	outfit = /datum/outfit/job/den/f13prospector
@@ -212,10 +212,10 @@ Deputy
 	title = "Deputy"
 	flag = F13DEPUTY
 	department_flag = DEN
-	faction = "Den"
+	faction = "Kebab"
 	total_positions = 2
 	spawn_positions = 2
-	supervisors = "the mayor, the sheriff"
+	supervisors = "the sheriff and the mayor"
 	selection_color = "#dcba97"
 	exp_requirements = 360
 	exp_type = EXP_TYPE_DEN
@@ -252,7 +252,7 @@ Preacher
 	department_head = list("Captain")
 	department_flag = DEN
 	head_announce = list("Security")
-	faction = "Den"
+	faction = "Kebab"
 	total_positions = 1
 	spawn_positions = 1
 	supervisors = "Your Master(s)."
@@ -356,24 +356,25 @@ Preacher
 		/obj/item/storage/bag/money/small/settler)
 
 /*
-Den Doctor
+Kebab Doctor
 */
 
 /datum/job/den/f13dendoc
-	title = "Den Doctor"
+	title = "Kebab Doctor"
 	flag = F13DENDOC
 	department_flag = DEN
-	faction = "Den"
+	faction = "Kebab"
 	total_positions = 2
 	spawn_positions = 2
-	description = "You are in charge of providing medical assistance to the inhabitants of the Den as needed."
+	description = "You are in charge of providing medical assistance to the inhabitants of the Kebab as needed."
+	supervisors = "the sheriff and the mayor"
 	selection_color = "#dcba97"
 	exp_requirements = 300
 
 	outfit = /datum/outfit/job/den/f13dendoc
 
 /datum/outfit/job/den/f13dendoc
-	name = "Den Doctor"
+	name = "Kebab Doctor"
 	jobtype = /datum/job/den/f13dendoc
 	chemwhiz = TRUE
 	uniform =  		/obj/item/clothing/under/f13/medic

--- a/code/modules/jobs/jobs.dm
+++ b/code/modules/jobs/jobs.dm
@@ -25,7 +25,7 @@ GLOBAL_LIST_INIT(brotherhood_positions, list(
 GLOBAL_LIST_INIT(den_positions, list(
 	"Mayor",
 	"Sheriff",
-	"Den Doctor",
+	"Kebab Doctor",
 	"Settler",
 	"Deputy",
 	"Farmer",

--- a/code/modules/mob/living/say.dm
+++ b/code/modules/mob/living/say.dm
@@ -23,7 +23,7 @@ GLOBAL_LIST_INIT(department_radio_keys, list(
 	"w" = "NCR",
 	"q" = "BOS",
 	"z" = "Enclave",
-	"f" = "Den",
+	"f" = "Kebab",
 
 	// Admin
 	"p" = "admin",

--- a/strings/hallucination.json
+++ b/strings/hallucination.json
@@ -159,7 +159,7 @@
 
 	"location": [
 		"the desert near @pick(sublocation)",
-		"the Den",
+		"Kebab",
 		"the mall",
 		"the market",
 		"the NCR base",
@@ -171,9 +171,9 @@
 		"the vault",
 		"the highway",
 		"inside @pick(sublocation)",
-		"Den hospital",
+		"Kebab hospital",
 		"brothel",
-		"Den bar",
+		"Kebab bar",
 		"the Legion base",
 		"a vault",
 		"the boxing ring",
@@ -190,7 +190,7 @@
 		"Klamat",
 		"the outpost",
 		"NCR base",
-		"the Den",
+		"Kebab",
 		"the power plant",
 		"the prison",
 		"the Legion tunnel",
@@ -200,11 +200,11 @@
 		"the hospital",
 		"the diner",
 		"the chapel",
-		"the Den bar",
+		"the Kebab bar",
 		"the Enclave base",
 		"the vault",
 		"the highway",
-		"the Den crossroads"
+		"the Kebab crossroads"
 	],
 
 	"advice": [


### PR DESCRIPTION
<!-- Thanks for choosing to take the time to contribute to our project! We have a few things below that we'd like you to fill out -->
<!-- The more detail you can give us, the faster we can code review, test, and merge your changes -->

<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->

This PR does a few remaining The Den -> Kebab name conversions, namely:

1) Den Doctor is now called Kebab Doctor
2) Den radio channel is now called Kebab radio channel
3) Den radio encryption key is now called Kebab radio encryption key, with proper description.
4) Various dreams and hallucinations will now refer to the Kebab instead of the Den.
5) Minor remaining renamings, like a small sign.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

Proper references to the Kebab town.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- This helps us replicate your tests, to speed up review. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->

Locally tested without any apparant issue.

## Changelog (neccesary)
:cl: Arkatos
spellcheck: The Den -> Kebab name conversions, namely a doctor job, radio channel and its encryption key, dream references and a sign.
/:cl:
