### PR TITLE
Adds items for pusher

### DIFF
--- a/code/modules/jobs/job_types/wasteland.dm
+++ b/code/modules/jobs/job_types/wasteland.dm
@@ -215,8 +215,7 @@ Pusher
 	backpack_contents = list(
 		/obj/item/reagent_containers/pill/patch/jet=3, \
 		/obj/item/reagent_containers/syringe/medx=2,\
-		/obj/item/reagent_containers/food/snacks/grown/cannabis=1,\
-		)
+		/obj/item/reagent_containers/food/snacks/grown/cannabis=1 )
 
 /*
 Punished Raider

--- a/code/modules/jobs/job_types/wasteland.dm
+++ b/code/modules/jobs/job_types/wasteland.dm
@@ -208,11 +208,15 @@ Pusher
 		/obj/item/flashlight/flare/torch, \
 		/obj/item/flashlight/flare)
 	l_pocket = /obj/item/storage/bag/money/small/wastelander
+	suit_store = pick( /obj/item/gun/ballistic/revolver/caravan_shotgun,\
+	    /obj/item/gun/ballistic/automatic/pistol/n99,\
+	    /obj/item/gun/ballistic/revolver/detective, \
+		/obj/item/gun/ballistic/shotgun/remington )
 	backpack_contents = list(
 		/obj/item/reagent_containers/pill/patch/jet=3, \
 		/obj/item/reagent_containers/syringe/medx=2,\
 		/obj/item/reagent_containers/food/snacks/grown/cannabis=1,\
-		/obj/item/gun/ballistic/automatic/pistol/n99)
+		)
 
 /*
 Punished Raider

--- a/code/modules/jobs/job_types/wasteland.dm
+++ b/code/modules/jobs/job_types/wasteland.dm
@@ -210,7 +210,9 @@ Pusher
 	l_pocket = /obj/item/storage/bag/money/small/wastelander
 	backpack_contents = list(
 		/obj/item/reagent_containers/pill/patch/jet=3, \
-		/obj/item/reagent_containers/syringe/medx=2)
+		/obj/item/reagent_containers/syringe/medx=2,\
+		/obj/item/reagent_containers/food/snacks/grown/cannabis=1,\
+		/obj/item/gun/ballistic/automatic/pistol/n99)
 
 /*
 Punished Raider


### PR DESCRIPTION
Adds a 10mm pistol for pusher and cannabis seed pack for pushers to their loadout.

<!-- Thanks for choosing to take the time to contribute to our project! We have a few things below that we'd like you to fill out -->
<!-- The more detail you can give us, the faster we can code review, test, and merge your changes -->

<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Pushers are helpless. And if random raider sees a just-spawned guy in Khan uniform, it is expectable to rob Khan. Khans used 10mm guns too in Fallout NV (they used 10mm and 9mm submachine guns, but they are rare here). Also people are rarely interested to get Jet from them. Pushers now may start their own cannabis farm, or sell seed pack to anyone interested in running such farm.
## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- This helps us replicate your tests, to speed up review. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->
It should work, I think
## Screenshots (if appropriate):
Nope
## Changelog (neccesary)
:cl:
add: 10mm pistol for pusher and cannabis seed pack for pushers to their loadout.
/:cl:
