### PR TITLE
Adds projectile speed implementation for guns (Round Two)

### DIFF
--- a/code/modules/projectiles/ammunition/_firing.dm
+++ b/code/modules/projectiles/ammunition/_firing.dm
@@ -1,8 +1,8 @@
-/obj/item/ammo_casing/proc/fire_casing(atom/target, mob/living/user, params, distro, quiet, zone_override, spread, extra_damage, extra_penetration)
+/obj/item/ammo_casing/proc/fire_casing(atom/target, mob/living/user, params, distro, quiet, zone_override, spread, extra_damage, extra_penetration, projectile_speed)
 	distro += variance
 	for (var/i = max(1, pellets), i > 0, i--)
 		var/targloc = get_turf(target)
-		ready_proj(target, user, quiet, zone_override, extra_damage, extra_penetration)
+		ready_proj(target, user, quiet, zone_override, extra_damage, extra_penetration, projectile_speed)
 		if(distro) //We have to spread a pixel-precision bullet. throw_proj was called before so angles should exist by now...
 			if(randomspread)
 				spread = round((rand() - 0.5) * distro)
@@ -20,7 +20,7 @@
 	update_icon()
 	return 1
 
-/obj/item/ammo_casing/proc/ready_proj(atom/target, mob/living/user, quiet, zone_override = "", extra_damage = 0, extra_penetration = 0)
+/obj/item/ammo_casing/proc/ready_proj(atom/target, mob/living/user, quiet, zone_override = "", extra_damage = 0, extra_penetration = 0, projectile_speed = 0.8)
 	if (!BB)
 		return
 	BB.original = target
@@ -32,6 +32,7 @@
 	BB.suppressed = quiet
 	BB.damage += extra_damage
 	BB.armour_penetration += extra_penetration
+	BB.speed = projectile_speed
 	if(reagents && BB.reagents)
 		reagents.trans_to(BB, reagents.total_volume) //For chemical darts/bullets
 		qdel(reagents)

--- a/code/modules/projectiles/gun.dm
+++ b/code/modules/projectiles/gun.dm
@@ -39,6 +39,7 @@
 	var/distro = 0						//Affects distance between shotgun pellets, ignore unless you're altering shotguns
 	var/extra_damage = 0				//Number to add to individual bullets.
 	var/extra_penetration = 0			//Number to add to armor penetration of individual bullets.
+	var/projectile_speed = 0.8			//Speed of the projectiles shot from gun in deciseconds per 1 tile
 
 	lefthand_file = 'icons/mob/inhands/weapons/guns_lefthand.dmi'
 	righthand_file = 'icons/mob/inhands/weapons/guns_righthand.dmi'
@@ -236,7 +237,7 @@
 		else //Smart spread
 			sprd = round((((rand_spr/burst_size) * iteration) - (0.5 + (rand_spr * 0.25))) * (randomized_gun_spread + randomized_bonus_spread))
 
-		if(!chambered.fire_casing(target, user, params, distro,suppressed, zone_override, sprd, extra_damage, extra_penetration))
+		if(!chambered.fire_casing(target, user, params, distro,suppressed, zone_override, sprd, extra_damage, extra_penetration, projectile_speed))
 			shoot_with_empty_chamber(user)
 			firing_burst = FALSE
 			return FALSE
@@ -284,7 +285,7 @@
 					to_chat(user, "<span class='notice'> [src] is lethally chambered! You don't want to risk harming anyone...</span>")
 					return
 			sprd = round((rand() - 0.5) * DUALWIELD_PENALTY_EXTRA_MULTIPLIER * (randomized_gun_spread + randomized_bonus_spread))
-			if(!chambered.fire_casing(target, user, params, distro, suppressed, zone_override, sprd, extra_damage, extra_penetration))
+			if(!chambered.fire_casing(target, user, params, distro, suppressed, zone_override, sprd, extra_damage, extra_penetration, projectile_speed))
 				shoot_with_empty_chamber(user)
 				return
 			else
@@ -423,15 +424,15 @@
 		azoom.Grant(user)
 	if(alight)
 		alight.Grant(user)
-	
-		
+
+
 /obj/item/gun/equipped(mob/living/user, slot)
 	. = ..()
 	if(user.get_active_held_item() != src) //we can only stay zoomed in if it's in our hands	//yeah and we only unzoom if we're actually zoomed using the gun!!
 		zoom(user, FALSE)
 		if(zoomable == TRUE)
 			azoom.Remove(user)
-	
+
 /obj/item/gun/dropped(mob/user)
 	. = ..()
 	if(zoomed)
@@ -440,7 +441,7 @@
 		azoom.Remove(user)
 	if(alight)
 		alight.Remove(user)
-	
+
 /obj/item/gun/proc/handle_suicide(mob/living/carbon/human/user, mob/living/carbon/human/target, params)
 	if(!ishuman(user) || !ishuman(target))
 		return
@@ -578,7 +579,7 @@
 	..()
 	if(wielded)
 		addZoom(user)
-	
+
 
 /obj/item/twohanded/binocs/dropped(mob/user)
 	..()


### PR DESCRIPTION
## Description
Retry at adding custom projectile speed to guns, allowing for varied projectile speeds for each weapon. All guns start with the base projectile speed of 0.8 deciseconds per tile, though it can be changed by setting the projectile_speed value for a weapon or weapon group. Setting this value for each weapon or weapon group will directly set the speed in the deciseconds per tile units, rather than my workaround in the previous implementation with a modifier. Hopefully this makes the projectile speed MUCH easier to use and understand in context.

## Motivation and Context
Adds a deeper layer to the gameplay. Allows for more customization in future updates.

## How Has This Been Tested?
Manually checked that variables were added correctly to weapons, and tested different speeds for various guns

## Changelog (neccesary)
:cl:
add: Added the basic projectile speed functionality
/:cl: