### PR TITLE
Remains update

### DIFF
--- a/code/game/objects/effects/decals/remains.dm
+++ b/code/game/objects/effects/decals/remains.dm
@@ -2,6 +2,7 @@
 	name = "remains"
 	gender = PLURAL
 	icon = 'icons/effects/blood.dmi'
+	var/drop_amount = 0
 
 /obj/effect/decal/remains/acid_act()
 	visible_message("<span class='warning'>[src] dissolve[gender==PLURAL?"":"s"] into a puddle of sizzling goop!</span>")
@@ -9,9 +10,24 @@
 	new /obj/effect/decal/cleanable/greenglow(drop_location())
 	qdel(src)
 
+/obj/effect/decal/remains/attack_hand(mob/user)
+	visible_message("<span class='notice'>[user] begins to clean up [src].</span>")
+	if(do_after(user, 40, target = src))
+		make_debris()
+		qdel(src)
+	else
+		..()
+
+/obj/effect/decal/remains/proc/make_debris()
+	if(drop_amount == 0)
+		return
+	else
+		new /obj/item/stack/sheet/bone(get_turf(src), drop_amount)
+
 /obj/effect/decal/remains/human
 	desc = "They look like human remains. They have a strange aura about them."
 	icon_state = "remains"
+	drop_amount = 1
 
 /obj/effect/decal/remains/plasma
 	icon_state = "remainsplasma"
@@ -19,9 +35,11 @@
 /obj/effect/decal/remains/xeno
 	desc = "They look like the remains of something... alien. They have a strange aura about them."
 	icon_state = "remainsxeno"
+	drop_amount = 2
 
 /obj/effect/decal/remains/xeno/larva
 	icon_state = "remainslarva"
+	drop_amount = 1
 
 /obj/effect/decal/remains/robot
 	desc = "They look like the remains of something mechanical. They have a strange aura about them."

--- a/code/game/objects/effects/decals/remains.dm
+++ b/code/game/objects/effects/decals/remains.dm
@@ -13,6 +13,7 @@
 /obj/effect/decal/remains/attack_hand(mob/user)
 	visible_message("<span class='notice'>[user] begins to clean up [src].</span>")
 	if(do_after(user, 40, target = src))
+		to_chat(user, "<span class='notice'>You clean up [src].</span>")
 		make_debris()
 		qdel(src)
 	else

--- a/code/game/objects/items/stacks/sheets/sheet_types.dm
+++ b/code/game/objects/items/stacks/sheets/sheet_types.dm
@@ -573,7 +573,7 @@ GLOBAL_LIST_INIT(bronze_recipes, list ( \
 	item_state = "sheet-greatergem"
 	novariants = TRUE
 
-	/*
+/*
  * Bones
  */
 /obj/item/stack/sheet/bone


### PR DESCRIPTION
<!-- Thanks for choosing to take the time to contribute to our project! We have a few things below that we'd like you to fill out -->
<!-- The more detail you can give us, the faster we can code review, test, and merge your changes -->

<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->

This PR adds an ability to clean up bone remains that are spawned on the map by clicking on them with an empty hand and standing still for a little while. This cleans up a remains and yields a bone resource, which can be used in various recipes.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

Ability to clean them and get a useful resource in process.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- This helps us replicate your tests, to speed up review. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->

Locally.

## Changelog (neccesary)
:cl: Arkatos
add: Added an ability to clean up remains by clicking on them with an empty hand. This might yield bone resources.
/:cl:
