### PR TITLE
Increases sand pit yield

### DIFF
--- a/code/modules/fallout/turf/ground.dm
+++ b/code/modules/fallout/turf/ground.dm
@@ -70,7 +70,7 @@
 	slowdown = 1
 	flags_1 = CAN_HAVE_NATURE | ADJACENCIES_OVERLAY
 	var/dug = FALSE				//FALSE = has not yet been dug, TRUE = has already been dug
-	var/pit_sand = 2
+	var/pit_sand = 1
 	var/storedindex = 0			//amount of stored items
 	var/mob/living/gravebody	//is there a body in the pit?
 	var/obj/structure/closet/crate/coffin/gravecoffin //or maybe a coffin?

--- a/code/modules/pits/pits.dm
+++ b/code/modules/pits/pits.dm
@@ -60,21 +60,13 @@ obj/dugpit/New(lnk)
 			usr.transferItemToLoc(W, mypit)
 			storedindex = storedindex+1
 
-		if(istype(W, /obj/item/stack/ore/glass) && pit_sand < 2 )
+		if(istype(W, /obj/item/stack/ore/glass) && pit_sand < 1 )
 			var/obj/item/stack/ore/glass/sand_target = W
 			usr.show_message("<span class='notice'>You fill the hole with sand</span>", 1)
 			if (pit_sand == 0)
-				if (sand_target.amount == 1)
+				if (sand_target.amount >= 1)
 					sand_target.amount = sand_target.amount - 1
 					pit_sand = pit_sand + 1
-				if (sand_target.amount >= 2)
-					sand_target.amount = sand_target.amount - 2
-					pit_sand = pit_sand + 2
-
-			else if (pit_sand == 1)
-				sand_target.amount = sand_target.amount - 1
-				pit_sand = pit_sand + 1
-
 			if (sand_target.amount == 0)
 				qdel(W)
 
@@ -126,7 +118,7 @@ obj/dugpit/New(lnk)
 		digging_speed = P.toolspeed
 
 	if (digging_speed)
-		if (pit_sand < 2)
+		if (pit_sand < 1)
 			usr.show_message("<span class='notice'>You need to fill the hole with sand!</span>", 1)
 			return
 		var/turf/T = user.loc
@@ -178,11 +170,15 @@ obj/dugpit/New(lnk)
 			playsound(src, 'sound/effects/shovel_dig.ogg', 50, 1) //FUCK YO RUSTLE I GOT'S THE DIGS SOUND HERE
 			if(do_after(user, (50 * digging_speed), target = src))
 				if(istype(src, /turf/open/indestructible/ground/outside/desert))
-					if(pit_sand < 2)
+					if(pit_sand < 1)
 						user.show_message("<span class='notice'>The ground has been already dug up!</span>", 1)
 						return
 					user.show_message("<span class='notice'>You dig a hole.</span>", 1)
 					gets_dug(user)
+					new /obj/item/stack/ore/glass(src)
+					new /obj/item/stack/ore/glass(src)
+					new /obj/item/stack/ore/glass(src)
+					new /obj/item/stack/ore/glass(src)
 					new /obj/item/stack/ore/glass(src)
 					new /obj/item/stack/ore/glass(src)
 					src.pit_sand = 0


### PR DESCRIPTION
## Description
Increases the amount of sand received from digging up sand pits to 6, up from 2. Decreases the amount of sand needed to re-bury to 1, down from 2.

## Motivation and Context
Without the fast digging exploit, it's now infeasible to make sandbags without digging up huge swathes of land and never filling them in. This is annoying and ugly.

## How Has This Been Tested?
- Tested digging multiple times, never got more than one "drop" of sand.
- Tested using sand on holes, which removed one sand from the stack.

## Changelog (neccesary)
:cl:
tweak: Increased the amount of sand received by digging to 6, from 2, and reduced the sand cost of burying to 1, from 2.
/:cl:
