### PR TITLE
NCR Hat Buff

### DIFF
--- a/code/modules/clothing/head/ncr.dm
+++ b/code/modules/clothing/head/ncr.dm
@@ -3,7 +3,7 @@
 	desc = "A standard issue NCR Infantry helmet."
 	icon_state = "ncr_infantry_helmet"
 	item_state = "ncr__infantry_helmet"
-	armor = list("melee" = 40, "bullet" = 35, "laser" = 20, "energy" = 20, "bomb" = 25, "bio" = 30, "rad" = 20, "fire" = 60, "acid" = 0)
+	armor = list("melee" = 40, "bullet" = 40, "laser" = 30, "energy" = 20, "bomb" = 25, "bio" = 30, "rad" = 20, "fire" = 60, "acid" = 0)
 	strip_delay = 50
 
 /obj/item/clothing/head/f13/ncr/goggles
@@ -61,4 +61,4 @@
 	desc = "An NCR ranger hat, standard issue amongst all but the most elite rangers."
 	icon_state = "drill_hat"
 	item_state = "drillhat"
-	armor = list("melee" = 40, "bullet" = 35, "laser" = 20, "energy" = 20, "bomb" = 25, "bio" = 30, "rad" = 20, "fire" = 60, "acid" = 0)
+	armor = list("melee" = 50, "bullet" = 40, "laser" = 30, "energy" = 40, "bomb" = 25, "bio" = 40, "rad" = 40, "fire" = 80, "acid" = 0)


### PR DESCRIPTION
<!-- Thanks for choosing to take the time to contribute to our project! We have a few things below that we'd like you to fill out -->
<!-- The more detail you can give us, the faster we can code review, test, and merge your changes -->

<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
NCR patrol/storm helmet:
40 melee / 35 bullet / 20 laser --> 40 melee / 40 bullet / 30 laser

Ranger campaign hat:
40 melee / 35 bullet / 20 laser -->50 melee / 40 bullet / 30 laser

Officer beret is unchanged.
## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Increases NCR helmet bullet resist to be on par with Legionary Veterans while still keeping melee resistances noticeably worse.  Laser resists were increased to remove the large hole in the NCR helmet's resistance profile.   Ranger campaign hat was also bumped to 50 melee to match the 50 melee of the patrol ranger armor.

This does lead to the rather strange case where recruits/trooper/recon rangers will have better head armor than suit armor, but also means the Lt/Captain roles still have noticeably weaker head armor should they swap from the beret.  Roles such as Corporal/Sergeant/Patrol Ranger simply have uniform resistances.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- This helps us replicate your tests, to speed up review. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->
Checked variables in Dream Maker.  Compiled.

## Screenshots (if appropriate):

## Changelog (neccesary)
:cl:
balance: Increased melee, bullet, and/or laser resists on the NCR helmet and ranger campaign hat
/:cl:
