### PR TITLE
Fixes map configs

### DIFF
--- a/_maps/_basemap.dm
+++ b/_maps/_basemap.dm
@@ -4,8 +4,7 @@
 
 #ifndef LOWMEMORYMODE
 	#ifdef ALL_MAPS
-
-		#include "map_files\BoxStation\BoxStation.dmm"
+		#include "map_files\Pahrump\Pahrump.dmm"
 
 		#ifdef TRAVISBUILDING
 			#include "templates.dm"

--- a/config/maps.txt
+++ b/config/maps.txt
@@ -13,9 +13,13 @@ Format:
 	disabled (disables the map)
 endmap
 
-map boxstation
+map pahrump
 	default
+	votable
 endmap
 
-map pahrump
+map boxstation
+	disabled
+	#voteweight 0.5
+	votable
 endmap

--- a/config/maps.txt
+++ b/config/maps.txt
@@ -17,9 +17,3 @@ map pahrump
 	default
 	votable
 endmap
-
-map boxstation
-	disabled
-	#voteweight 0.5
-	votable
-endmap

--- a/tgstation.dme
+++ b/tgstation.dme
@@ -14,7 +14,6 @@
 
 // BEGIN_INCLUDE
 #include "_maps\_basemap.dm"
-#include "_maps\pahrump.dm"
 #include "code\_compile_options.dm"
 #include "code\world.dm"
 #include "code\__DEFINES\_globals.dm"


### PR DESCRIPTION
Currently boxmap is disabled because it hasn't been updated along with pahrump, and so breaks when you try to load it.