### PR TITLE
Radiation reborn

### DIFF
--- a/code/__HELPERS/radiation.dm
+++ b/code/__HELPERS/radiation.dm
@@ -9,7 +9,6 @@
 		var/static/list/ignored_things = typecacheof(list(
 			/mob/dead,
 			/mob/camera,
-			/obj/effect,
 			/obj/docking_port,
 			/atom/movable/lighting_object,
 			/obj/item/projectile

--- a/code/controllers/subsystem/radiation.dm
+++ b/code/controllers/subsystem/radiation.dm
@@ -1,6 +1,6 @@
 PROCESSING_SUBSYSTEM_DEF(radiation)
 	name = "Radiation"
-	flags = SS_NO_INIT | SS_BACKGROUND
+	flags = SS_BACKGROUND
 
 	var/list/warned_atoms = list()
 
@@ -13,5 +13,5 @@ PROCESSING_SUBSYSTEM_DEF(radiation)
 	warned_atoms[ref] = TRUE
 	var/atom/master = contamination.parent
 	SSblackbox.record_feedback("tally", "contaminated", 1, master.type)
-	var/msg = "has become contamintaed with enough radiation to contaminate other objects. || Source: [contamination.source] || Strength: [contamination.strength]"
+	var/msg = "has become contaminated with enough radiation to contaminate other objects. || Source: [contamination.source] || Strength: [contamination.strength]"
 	master.investigate_log(msg, INVESTIGATE_RADIATION)

--- a/code/datums/components/radioactive.dm
+++ b/code/datums/components/radioactive.dm
@@ -71,7 +71,7 @@
 		if(RAD_AMOUNT_HIGH to INFINITY) //At this level the object can contaminate other objects
 			out += "[out ? " and it " : "[master] "]hurts to look at."
 		else
-			out += "."
+			out += ""
 	to_chat(user, out.Join())
 
 /datum/component/radioactive/proc/rad_attack(atom/movable/target, mob/living/user)

--- a/code/datums/weather/weather_types/acid_rain.dm
+++ b/code/datums/weather/weather_types/acid_rain.dm
@@ -37,15 +37,14 @@
 	if(is_acidrain_immune(L))
 		return
 	var/resist = L.getarmor(null, "acid")
-	if(prob(max(0,100-resist)))
+	if(prob(max(0, 100 - resist)))
 		L.acid_act(10, 10)
 
 /datum/weather/acid_rain/weather_act_turf(turf/T)
-	SEND_SIGNAL(T, COMSIG_COMPONENT_CLEAN_ACT, CLEAN_MEDIUM)
-	for(var/obj/effect/O in T)
+	for(var/obj/effect/O in T) //Clean cleanable decals in affected areas
 		if(is_cleanable(O))
 			qdel(O)
-	for(var/obj/item/ammo_casing/C in T)
+	for(var/obj/item/ammo_casing/C in T) //Clean ammo casings in affected areas
 		qdel(C)
 
 /datum/weather/acid_rain/proc/is_acidrain_immune(atom/L)

--- a/code/datums/weather/weather_types/rain.dm
+++ b/code/datums/weather/weather_types/rain.dm
@@ -36,7 +36,6 @@
 		H.wash_cream()
 
 /datum/weather/rain/weather_act_turf(turf/T)
-	SEND_SIGNAL(T, COMSIG_COMPONENT_CLEAN_ACT, CLEAN_MEDIUM)
-	for(var/obj/effect/O in T)
+	for(var/obj/effect/O in T) //Clean cleanable decals in affected areas
 		if(is_cleanable(O))
 			qdel(O)

--- a/code/game/machinery/computer/terminal.dm
+++ b/code/game/machinery/computer/terminal.dm
@@ -161,26 +161,25 @@
 		var/datum/terminal/document/N = new file_in_memory
 		doc_title_1 = "[N.title]"
 		doc_content_1 = "[N.content]"
-	if (2)
+	if (doc_title_2)
 		var/file_in_memory = text2path("/datum/terminal/document/[doc_title_2]")
 		var/datum/terminal/document/N = new file_in_memory
 		doc_title_2 = "[N.title]"
 		doc_content_2 = "[N.content]"
-	if (3)
+	if (doc_title_3)
 		var/file_in_memory = text2path("/datum/terminal/document/[doc_title_3]")
 		var/datum/terminal/document/N = new file_in_memory
 		doc_title_3 = "[N.title]"
 		doc_content_3 = "[N.content]"
-	if (4)
+	if (doc_title_4)
 		var/file_in_memory = text2path("/datum/terminal/document/[doc_title_4]")
 		var/datum/terminal/document/N = new file_in_memory
 		doc_title_4 = "[N.title]"
 		doc_content_4 = "[N.content]"
-	if (5)
+	if (doc_title_5)
 		var/file_in_memory = text2path("/datum/terminal/document/[doc_title_5]")
 		var/datum/terminal/document/N = new file_in_memory
 		doc_title_5 = "[N.title]"
 		doc_content_5 = "[N.content]"
 
 	return
-

--- a/code/modules/fallout/obj/decals.dm
+++ b/code/modules/fallout/obj/decals.dm
@@ -8,17 +8,13 @@
 	anchored = 1
 	layer = 2.1
 	light_color = LIGHT_COLOR_GREEN
-//	light_power = 0.5
-//	light_range = 3
-//	rad_heavy_range = 1
-//	rad_light_range = 4
-//	rad_severity = 10
+	light_power = 3
+	light_range = 3
 
 /obj/effect/decal/cleanable/waste/New()
 	..()
 	icon_state = "goo[rand(1,13)]"
-	START_PROCESSING(SSobj, src)
-	SSradiation.processing += src
+	AddComponent(/datum/component/radioactive, 50, src, 0) //half-life of 0 because we keep on going.
 
 /obj/effect/decal/marking
 	name = "road marking"

--- a/code/modules/fallout/obj/structures/barrel.dm
+++ b/code/modules/fallout/obj/structures/barrel.dm
@@ -15,15 +15,14 @@
 	icon_state = "dangerous"
 	tank_volume = 500
 	reagent_id = "radium"
-//	rad_heavy_range = 1
-//	rad_light_range = 4
-//	rad_severity = 10
+	light_color = LIGHT_COLOR_GREEN
+	light_power = 3
+	light_range = 3
 //	self_weight = 200
 
-/obj/structure/reagent_dispensers/barrel/dangerous/New()
-	..()
-	START_PROCESSING(SSobj, src)
-	SSradiation.processing += src
+/obj/structure/reagent_dispensers/barrel/dangerous/Initialize()
+	. = ..()
+	AddComponent(/datum/component/radioactive, 50, src, 0) //half-life of 0 because we keep on going.
 
 /obj/structure/reagent_dispensers/barrel/boom()
 	visible_message("<span class='danger'>\The [src] ruptures!</span>")

--- a/code/modules/mob/living/carbon/human/species_types/humans.dm
+++ b/code/modules/mob/living/carbon/human/species_types/humans.dm
@@ -36,7 +36,7 @@
 	..()
 
 /datum/species/human/spec_life(mob/living/carbon/human/H)
-	if (H.radiation>90 && prob(10))
+	if (H.radiation>2500 && prob(10))
 		to_chat(H, "<span class='danger'>You feel strange!</span>")
 		H.set_species(/datum/species/ghoul)
 		H.Stun(40)

--- a/code/modules/mob/living/simple_animal/hostile/ghoul.dm
+++ b/code/modules/mob/living/simple_animal/hostile/ghoul.dm
@@ -69,4 +69,4 @@
 	. = ..()
 	if(. && ishuman(target))
 		var/mob/living/carbon/human/H = target
-		H.apply_effect(5,EFFECT_IRRADIATE,0)
+		H.apply_effect(20, EFFECT_IRRADIATE, 0)


### PR DESCRIPTION
<!-- Thanks for choosing to take the time to contribute to our project! We have a few things below that we'd like you to fill out -->
<!-- The more detail you can give us, the faster we can code review, test, and merge your changes -->

<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->

This PR revives and brings back radiation to the server. Symptons may or may not include balding, mutations, fainting and eventually, death. Also contains minor fixes for weather and runtime fix for terminals.

Some possible sources of radiation:

- Glowing goo pools (glows green)
- Waste barrels (glows green)
- FEV virus
- Radium
- Glowing ghouls
- and others

Usage of a geiger scanner is recommended to find out irradiated people and objects.

Glory to Atom.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

Functioning radiation.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- This helps us replicate your tests, to speed up review. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->

Locally tested without any issue.

## Changelog (neccesary)
:cl: Arkatos
add: Radiation reborn.
/:cl:
