### PR TITLE
changes the rangemaster to a trail carbine for legion explorers

### DIFF
--- a/code/modules/jobs/job_types/legion.dm
+++ b/code/modules/jobs/job_types/legion.dm
@@ -437,11 +437,11 @@ Legionary
 	suit = 		/obj/item/clothing/suit/armor/f13/legrecruit/vet
 	head = 		/obj/item/clothing/head/helmet/f13/legion/explorer
 	glasses = null
-	suit_store = /obj/item/gun/ballistic/shotgun/automatic/hunting
+	suit_store = /obj/item/gun/ballistic/shotgun/automatic/hunting/trail
 	backpack_contents = list(
 		/obj/item/restraints/legcuffs/bola=1, \
 		/obj/item/claymore/machete/gladius=1, \
-		/obj/item/ammo_box/a762/doublestacked=2, \
+		/obj/item/ammo_box/tube/m44=2, \
 		/obj/item/reagent_containers/pill/patch/healingpowder=2, \
 		/obj/item/flashlight/flare/torch=1, \
 		/obj/item/storage/bag/money/small/legenlisted)


### PR DESCRIPTION
changes the rangemaster to a trail carbine for legion explorers

<!--- Provide a general summary of your changes in the Title above -->

## Description
changes the rangemaster to a trail carbine for legion explorers

## Motivation and Context
I got asked to do this by Daniel.

## How Has This Been Tested?
It compiles and you spawn in with one.

## Screenshots (if appropriate):
