### PR TITLE
Removes monkey cubes from the biogenerator

### DIFF
--- a/code/modules/research/designs/biogenerator_designs.dm
+++ b/code/modules/research/designs/biogenerator_designs.dm
@@ -51,14 +51,6 @@
 	make_reagents = list()
 	category = list("initial","Food")
 
-/datum/design/monkey_cube
-	name = "Monkey Cube"
-	id = "mcube"
-	build_type = BIOGENERATOR
-	materials = list(MAT_BIOMASS = 250)
-	build_path = /obj/item/reagent_containers/food/snacks/monkeycube
-	category = list("initial", "Food")
-
 /datum/design/ez_nut
 	name = "E-Z Nutrient"
 	id = "ez_nut"


### PR DESCRIPTION
## Description
See title.

## Motivation and Context
Putting peoples brains inside monkeys is dumb, and immersion breaking. They also move super fast. This PR removes the only way to get monkeys in the wasteland currently.

## How Has This Been Tested?
It hasnt been, but its a simple edit.
