### PR TITLE
Rebalance r82 & change NCR loadouts

### DIFF
--- a/code/modules/jobs/job_types/ncr.dm
+++ b/code/modules/jobs/job_types/ncr.dm
@@ -120,11 +120,11 @@ Lieutenant
 	head 		= /obj/item/clothing/head/beret/ncr
 	belt        = /obj/item/storage/belt/military/assault/ncr
 	glasses 	= /obj/item/clothing/glasses/sunglasses/big
-	suit_store 	= /obj/item/gun/ballistic/shotgun/automatic/hunting
+	suit_store 	= /obj/item/gun/ballistic/automatic/marksman/servicerifle/r82
 	shoes       = /obj/item/clothing/shoes/f13/military/ncr_officer
 	gloves      = /obj/item/clothing/gloves/f13/leather/ncr_officer
 	backpack_contents = list(
-		/obj/item/ammo_box/a762/doublestacked=2, \
+		/obj/item/ammo_box/magazine/automatic/r30=2, \
 		/obj/item/kitchen/knife/combat/survival=1, \
 		/obj/item/gun/ballistic/automatic/pistol/ninemil=1, \
 		/obj/item/melee/classic_baton/telescopic=1, \
@@ -204,12 +204,12 @@ Medic
 	suit = 			/obj/item/clothing/suit/armor/f13/ncrarmor/mantle
 	glasses = 		/obj/item/clothing/glasses/sunglasses/big
 	belt =          /obj/item/storage/belt/military/assault/ncr
-	suit_store = 	/obj/item/gun/ballistic/shotgun
+	suit_store = 	/obj/item/gun/ballistic/automatic/marksman/servicerifle/r82
 	head =          /obj/item/clothing/head/f13/ncr
 	shoes = 		/obj/item/clothing/shoes/f13/military/ncr
 	gloves =        /obj/item/clothing/gloves/f13/ncr
 	backpack_contents = list(
-		/obj/item/storage/box/lethalshot, \
+		/obj/item/ammo_box/magazine/automatic/r30=2, \
 		/obj/item/kitchen/knife/combat/survival=1, \
 		/obj/item/gun/ballistic/automatic/pistol/ninemil=1, \
 		/obj/item/reagent_containers/hypospray/medipen/stimpak=1, \
@@ -417,7 +417,7 @@ Heavy Trooper
 	shoes =         /obj/item/clothing/shoes/combat/swat
 	suit_store = 	/obj/item/gun/ballistic/automatic/lmg
 	backpack_contents = list(
-		/obj/item/ammo_box/magazine/lmg, \
+		/obj/item/ammo_box/magazine/lmg=2, \
 		/obj/item/reagent_containers/hypospray/medipen/stimpak=1, \
 		/obj/item/stack/medical/gauze=1, \
 		/obj/item/kitchen/knife/combat=1, \

--- a/code/modules/projectiles/guns/ballistic/automatic.dm
+++ b/code/modules/projectiles/guns/ballistic/automatic.dm
@@ -561,12 +561,13 @@
 /obj/item/gun/ballistic/automatic/marksman/servicerifle/r82
 	name = "R82 heavy service rifle"
 	desc = "A top of the line 5.56x45 semi-automatic service rifle manufactured by the NCR and issued to high ranking personnel."
-	fire_delay = 3
-	extra_damage = 25
+	fire_delay = 5
+	extra_damage = 30
 	extra_penetration = 10
+	mag_type = /obj/item/ammo_box/magazine/automatic/r30
 	icon_state = "R82"
 	item_state = "R82"
-	burst_size = 3
+	burst_size = 1
 /obj/item/gun/ballistic/automatic/marksman/servicerifle/varmint
 	name = "varmint rifle"
 	desc = "A low powered 5.56, easy to use rifle."


### PR DESCRIPTION
<!-- Thanks for choosing to take the time to contribute to our project! We have a few things below that we'd like you to fill out -->
<!-- The more detail you can give us, the faster we can code review, test, and merge your changes -->

<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
R82:
25/10 --> 30/10
3 burst -->1 burst
3 delay-->5 delay
Now comes with an r30 mag instead of the r20 mag.

Sergeant, Lt lose their primaries and get the new R82 in return.

HT gets one more box magazine

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Three burst of the R82 was not intended.  It will likely return in a special variant later on.

NCR loadouts are now a bit more standardized (and rangemaster is no longer in any loadout).

Ren asked for one more box mag for the HT.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- This helps us replicate your tests, to speed up review. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->
Compiled successfully.  Localhosted and checked loadouts in game.

## Screenshots (if appropriate):

## Changelog (neccesary)
:cl:
tweak: changed NCR loadouts
balance: rebalanced R82
/:cl:
