### PR TITLE
Forum url =/= Discord URL

### DIFF
--- a/code/controllers/configuration/entries/general.dm
+++ b/code/controllers/configuration/entries/general.dm
@@ -170,7 +170,7 @@
 /datum/config_entry/string/wikiurl
 	config_entry_value = "http://www.tgstation13.org/wiki"
 
-/datum/config_entry/string/forumurl
+/datum/config_entry/string/discordurl
 	config_entry_value = "http://tgstation13.org/phpBB/index.php"
 
 /datum/config_entry/string/rulesurl

--- a/config/config.txt
+++ b/config/config.txt
@@ -217,13 +217,13 @@ CHECK_RANDOMIZER
 # SERVER ss13.example.com:2506
 
 ## forum address
-FORUMURL https://discord.gg/BbsYDrR
+DISCORDURL https://discord.gg/TCj5cJN
 
 ## Wiki address
 WIKIURL https://bad-deathclaw.fandom.com/wiki/Bad_Deathclaw_Wiki
 
 ## Rules address
-RULESURL https://discord.gg/ppWGX2j
+RULESURL https://discord.gg/TCj5cJN
 
 
 ## Github address

--- a/interface/interface.dm
+++ b/interface/interface.dm
@@ -12,15 +12,15 @@
 		to_chat(src, "<span class='danger'>The Patreon URL is not set in the server configuration.</span>")
 	return
 
-/client/verb/forum()
-	set name = "forum"
+/client/verb/discord()
+	set name = "discord"
 	set desc = "Visit the Discord."
 	set hidden = 1
-	var/forumurl = CONFIG_GET(string/forumurl)
-	if(forumurl)
+	var/discordurl = CONFIG_GET(string/discordurl)
+	if(discordurl)
 		if(alert("This will open the Discord in your browser. Are you sure?",,"Yes","No")!="Yes")
 			return
-		src << link(forumurl)
+		src << link(discordurl)
 	else
 		to_chat(src, "<span class='danger'>The discord URL is not set in the server configuration.</span>")
 	return
@@ -38,7 +38,7 @@
 			src << link(rulesurl)
 		if("View here")
 			src << browse('html/rules.html', "window=changes")
-		
+
 
 /client/verb/github()
 	set name = "github"


### PR DESCRIPTION
Someone just renamed the forum button to the discord button in a few, but not all, places.

What a mess.

Anyway, it's been cleaned up.