### PR TITLE
MedX changes, associated minor chem nerfs

### DIFF
--- a/code/modules/crafting/recipes.dm
+++ b/code/modules/crafting/recipes.dm
@@ -741,6 +741,14 @@
 	tools = list(/obj/item/lighter, /obj/item/reagent_containers/glass/beaker)
 	category = CAT_DRUGS
 
+/datum/crafting_recipe/natural_painkiller
+	name = "Natural Painkiller"
+	result = /obj/item/reagent_containers/pill/patch/naturalpainkiller
+	time = 30
+	reqs = list(/obj/item/reagent_containers/food/snacks/grown/feracactus = 2, /obj/structure/flora/wasteplant/wild_agave = 1, /obj/item/reagent_containers/food/snacks/grown/fungus = 1)
+	tools = list(TOOL_FORGE)
+	category = CAT_DRUGS
+
 
 /datum/crafting_recipe/rags
 	name = "Cut clothing into rags"
@@ -780,6 +788,7 @@
 				/obj/item/reagent_containers/food/snacks/grown/fungus = 1)
 	time = 80
 	category = CAT_MEDICAL
+
 
 /datum/crafting_recipe/stimpak
 	name = "Stimpak"

--- a/code/modules/crafting/recipes.dm
+++ b/code/modules/crafting/recipes.dm
@@ -741,15 +741,6 @@
 	tools = list(/obj/item/lighter, /obj/item/reagent_containers/glass/beaker)
 	category = CAT_DRUGS
 
-/datum/crafting_recipe/natural_painkiller
-	name = "Natural Painkiller"
-	result = /obj/item/reagent_containers/pill/patch/naturalpainkiller
-	time = 30
-	reqs = list(/obj/item/reagent_containers/food/snacks/grown/feracactus = 2, /obj/structure/flora/wasteplant/wild_agave = 1, /obj/item/reagent_containers/food/snacks/grown/fungus = 1)
-	tools = list(TOOL_FORGE)
-	category = CAT_DRUGS
-
-
 /datum/crafting_recipe/rags
 	name = "Cut clothing into rags"
 	result = /obj/item/stack/sheet/cloth/three

--- a/code/modules/reagents/chemistry/reagents/medicine_reagents.dm
+++ b/code/modules/reagents/chemistry/reagents/medicine_reagents.dm
@@ -1393,7 +1393,7 @@ datum/reagent/medicine/super_stimpak/on_mob_life(mob/living/M)
 		var/mob/living/carbon/L = M
 		L.physiology.brute_mod *= 0.8
 		L.physiology.burn_mod *= 0.8
-		
+
 /datum/reagent/medicine/medx/on_mob_delete(mob/M)
 	if(isliving(M))
 		var/mob/living/carbon/L = M

--- a/code/modules/reagents/chemistry/reagents/medicine_reagents.dm
+++ b/code/modules/reagents/chemistry/reagents/medicine_reagents.dm
@@ -1380,7 +1380,7 @@ datum/reagent/medicine/super_stimpak/on_mob_life(mob/living/M)
 /datum/reagent/medicine/medx
 	name = "Med-X"
 	id = "medx"
-	description = "Med-X is a potent painkiller, allowing users to withstand high amounts of pain and continue functioning. Addictive and mildly toxic."
+	description = "Med-X is a potent painkiller, allowing users to withstand high amounts of pain and continue functioning. Addictive and mildly toxic, increases damage resistance."
 	reagent_state = LIQUID
 	color = "#6D6374"
 	metabolization_rate = 0.5 * REAGENTS_METABOLISM
@@ -1391,16 +1391,14 @@ datum/reagent/medicine/super_stimpak/on_mob_life(mob/living/M)
 	..()
 	if(isliving(M))
 		var/mob/living/carbon/L = M
-		L.hal_screwyhud = SCREWYHUD_HEALTHY
-		L.add_trait(TRAIT_NOHARDCRIT, id)
-		L.add_trait(TRAIT_NOSOFTCRIT, id)
-
+		L.physiology.brute_mod *= 0.8
+		L.physiology.burn_mod *= 0.8
+		
 /datum/reagent/medicine/medx/on_mob_delete(mob/M)
 	if(isliving(M))
 		var/mob/living/carbon/L = M
-		L.hal_screwyhud = SCREWYHUD_NONE
-		L.remove_trait(TRAIT_NOHARDCRIT, id)
-		L.remove_trait(TRAIT_NOSOFTCRIT, id)
+		L.physiology.burn_mod *= 1.25
+		L.physiology.brute_mod *= 1.25
 	..()
 
 /datum/reagent/medicine/medx/on_mob_life(mob/living/carbon/M)
@@ -1408,7 +1406,7 @@ datum/reagent/medicine/super_stimpak/on_mob_life(mob/living/M)
 	M.AdjustKnockdown(-30, 0)
 	M.AdjustUnconscious(-30, 0)
 	M.adjustStaminaLoss(-5, 0)
-	M.adjustToxLoss(1.5, 0)
+	M.adjustToxLoss(.5, 0)
 	..()
 	. = 1
 
@@ -1455,7 +1453,7 @@ datum/reagent/medicine/super_stimpak/on_mob_life(mob/living/M)
 /datum/reagent/medicine/legionmedx
 	name = "natural painkiller"
 	id = "legion_medx"
-	description = "Med-X is a potent painkiller, allowing users to withstand high amounts of pain and continue functioning. Weakens the body, causing it to take more damage, and is poisonous."
+	description = "Med-X is a potent painkiller, allowing users to withstand high amounts of pain and continue functioning."
 	reagent_state = LIQUID
 	color = "#6D6374"
 	metabolization_rate = 0.7 * REAGENTS_METABOLISM
@@ -1467,24 +1465,13 @@ datum/reagent/medicine/super_stimpak/on_mob_life(mob/living/M)
 	if(isliving(M))
 		var/mob/living/carbon/L = M
 		L.hal_screwyhud = SCREWYHUD_HEALTHY
-		L.add_trait(TRAIT_NOHARDCRIT, id)
-		L.add_trait(TRAIT_NOSOFTCRIT, id)
-		var/datum/physiology/phis = L.physiology
-		phis.brute_mod = 2
-		phis.burn_mod = 2
-		phis.oxy_mod = 1.5
+		L.add_trait(TRAIT_IGNOREDAMAGESLOWDOWN, id)
 
 /datum/reagent/medicine/legionmedx/on_mob_delete(mob/M)
 	if(isliving(M))
 		var/mob/living/carbon/L = M
 		L.hal_screwyhud = SCREWYHUD_NONE
-		L.remove_trait(TRAIT_NOHARDCRIT, id)
-		L.remove_trait(TRAIT_NOSOFTCRIT, id)
-		var/datum/physiology/phis = L.physiology
-		phis.brute_mod = 1
-		phis.burn_mod = 1
-		phis.oxy_mod = 1
-		vomit(L)
+		L.remove_trait(TRAIT_IGNOREDAMAGESLOWDOWN, id)
 	..()
 
 /datum/reagent/medicine/legionmedx/on_mob_life(mob/living/carbon/M)
@@ -1492,7 +1479,6 @@ datum/reagent/medicine/super_stimpak/on_mob_life(mob/living/M)
 	M.AdjustKnockdown(-20, 0)
 	M.AdjustUnconscious(-20, 0)
 	M.adjustStaminaLoss(-3, 0)
-	M.adjustToxLoss(2.5, 0)
 
 /datum/reagent/medicine/legionmedx/overdose_process(mob/living/M)
 	if(prob(33))

--- a/code/modules/reagents/reagent_containers/patch.dm
+++ b/code/modules/reagents/reagent_containers/patch.dm
@@ -62,9 +62,3 @@
 	desc = "A concoction of broc flower, cave fungus, agrave fruit and xander root."
 	list_reagents = list("healing_poultice" = 10)
 	icon_state = "bandaid_healingpoultice"
-
-/obj/item/reagent_containers/pill/patch/naturalpainkiller
-	name = "Natural painkiller"
-	desc = "A mixture of various plants used to numb severe pain, allowing the seriously wounded to continue fighting. Weakens the body, causing it to take more damage, and is poisonous."
-	list_reagents = list("legion_medx" = 15)
-	icon_state = "heal_powder"

--- a/code/modules/reagents/reagent_containers/patch.dm
+++ b/code/modules/reagents/reagent_containers/patch.dm
@@ -62,3 +62,9 @@
 	desc = "A concoction of broc flower, cave fungus, agrave fruit and xander root."
 	list_reagents = list("healing_poultice" = 10)
 	icon_state = "bandaid_healingpoultice"
+
+/obj/item/reagent_containers/pill/patch/naturalpainkiller
+	name = "Natural painkiller"
+	desc = "A mixture of various plants used to numb severe pain, allowing the seriously wounded to continue fighting. Weakens the body, causing it to take more damage, and is poisonous."
+	list_reagents = list("legion_medx" = 15)
+	icon_state = "heal_powder"


### PR DESCRIPTION
Ren's a retard so I just gave up and now med-x gives you 20% damage resistance to brute and burn while it's in your system it also does tiny amounts of toxin and it's addictive.

Legion medX has no changes.

Synthflesh now converts 66% of brute and burn to toxin damage if the mob it's used on is alive, to prevent synthflesh beakers being literally the absolute best healing chemical in the game.

Stypic and silver sulfadine no longer heal on touch at all, for much the same reason, but still heal over time.

Morphine has lost noslowdown for much the same reason-irrelevant since nothing uses it, but still. 

Ephedrine no longer speeds you up.
## Changelog (neccesary)
:cl:
del: Removed the effects of morphine and ephedrine
del: Removed stypic powder and silver sulfadine healing on touch (still heals over time)
tweak: Removed Synthflesh not converting 66% brute/burn into toxin when used on a LIVING person. Works the same as always for corpses. Still heals on touch.
balance: Med-X no longer removes slowdown. Instead, it increases damage resistance.
balance: Removed med-X not being instantly addictive, as it is now addictive no matter how much you take. It is also somewhat toxic.
/:cl:
