### PR TITLE
Patreon/Wiki Button fix.

### DIFF
--- a/interface/interface.dm
+++ b/interface/interface.dm
@@ -13,7 +13,7 @@
 	return
 
 /client/verb/discord()
-	set name = "discordurl"
+	set name = "discord"
 	set desc = "Visit the Discord."
 	set hidden = 1
 	var/discordurl = CONFIG_GET(string/discordurl)

--- a/interface/interface.dm
+++ b/interface/interface.dm
@@ -1,19 +1,19 @@
 //Please use mob or src (not usr) in these procs. This way they can be called in the same fashion as procs.
 /client/verb/wiki()
 	set name = "wiki"
-	set desc = "Opens the Patreon in your browser."
+	set desc = "Opens the Wiki in your browser."
 	set hidden = 1
 	var/wikiurl = CONFIG_GET(string/wikiurl)
 	if(wikiurl)
-		if(alert("This will open the Patreon in your browser. Are you sure?",,"Yes","No")!="Yes")
+		if(alert("This will open the Wiki in your browser. Are you sure?",,"Yes","No")!="Yes")
 			return
 		src << link(wikiurl)
 	else
-		to_chat(src, "<span class='danger'>The Patreon URL is not set in the server configuration.</span>")
+		to_chat(src, "<span class='danger'>The Wiki URL is not set in the server configuration.</span>")
 	return
 
 /client/verb/discord()
-	set name = "discord"
+	set name = "discordurl"
 	set desc = "Visit the Discord."
 	set hidden = 1
 	var/discordurl = CONFIG_GET(string/discordurl)

--- a/interface/skin.dmf
+++ b/interface/skin.dmf
@@ -211,7 +211,7 @@ window "infowindow"
 		text-color = #ffffff
 		background-color = #411d1e
 		saved-params = "is-checked"
-		text = "Patreon"
+		text = "Wiki"
 		command = "wiki"
 	elem "forum"
 		type = BUTTON


### PR DESCRIPTION
Compiled and tested with no issues.

Changed the button that says Patreon, over to Wiki since that's what it actually is.