### PR TITLE
Taking away benches

### DIFF
--- a/code/modules/crafting/guncrafting.dm
+++ b/code/modules/crafting/guncrafting.dm
@@ -51,18 +51,3 @@
 /obj/machinery/ammobench/makeshift/wrench_act(mob/living/user, obj/item/I)
 	default_unfasten_wrench(user, I, 10)
 	return TRUE
-
-
-/obj/machinery/ammobench/ncr
-	name = "NCR reloading bench"
-	desc = "A reloading bench used for inefficiently  crafting new ammunition out of scrap metal. There's a substantial supply of powder and primer. This one can be used to create most NCR rounds."
-	icon = 'icons/obj/recycling.dmi' //placeholder
-	icon_state = "grinder-b1" //placeholder
-	machine_tool_behaviour = TOOL_NCR
-
-/obj/machinery/ammobench/legion
-	name = "Legion reloading bench"
-	desc = "A reloading bench used for inefficiently crafting new ammunition out of scrap metal. There's a substantial supply of powder and primer. This one can be used to create most Legion rounds."
-	icon = 'icons/obj/recycling.dmi' //placeholder
-	icon_state = "grinder-b1" //placeholder
-	machine_tool_behaviour = TOOL_NCR


### PR DESCRIPTION
They're not used and will probably never be used.

I might go further and strip out the ammobench and constructionlathe in parump and replace it with the autolathe again.

The whole idea was to make it so that ammunition and gear eventually becomes scarce, despite initial up-front content for a newspawn character (so they don't end up utterly and arbitrarily screwed) and that the resource to spawn more of it becomes an obsession for BoS or whatever;

I can't say it makes sense for the BoS to steal an ammo bench but I *can* say it makes sense for them to take a magical wish machine that turns infinite amounts of material into an endless supply of grenade casings, bullets, gear, and other ammunition that is useful for waging mass war.

This is why constructionlathe/autolathe separation was made in the first place.

## Changelog (neccesary)
:cl:
del: Removed old things
/:cl:
