### PR TITLE
discord to ooc piping

### DIFF
--- a/code/controllers/configuration/entries/general.dm
+++ b/code/controllers/configuration/entries/general.dm
@@ -181,6 +181,8 @@
 
 /datum/config_entry/flag/using_discord
 
+/datum/config_entry/flag/using_discord_ooc
+
 /datum/config_entry/string/roundstatsurl
 
 /datum/config_entry/string/gamelogurl

--- a/code/datums/world_topic.dm
+++ b/code/datums/world_topic.dm
@@ -180,4 +180,16 @@
 		// Shuttle status, see /__DEFINES/stat.dm
 		.["shuttle_timer"] = SSshuttle.emergency.timeLeft()
 		// Shuttle timer, in seconds
-	
+
+/datum/world_topic/dooc
+	keyword = "dooc"
+	require_comms_key = TRUE
+
+/datum/world_topic/dooc/Run(list/input)
+	if(!CONFIG_GET(flag/using_discord_ooc))
+		return
+	log_ooc("DSCRD: [input["user"]]: [input["text"]]")
+	for(var/client/C in GLOB.clients)
+		if(C.prefs.chat_toggles & CHAT_OOC)
+			if(!(input["user"] in C.prefs.ignoring))
+				to_chat(C, "<font color='#9d00ff'><span class='ooc'><span class='prefix'>DSCRD:</span> <EM>[input["user"]]:</EM> <span class='message'>[input["message"]]</span></span></font>")

--- a/config/config.txt
+++ b/config/config.txt
@@ -29,6 +29,9 @@ HUB
 ## Uncomment and set the config in tools/discord/config.yml to enable sending stuff to discord's webhooks
 # USING_DISCORD
 
+## Uncomment to allow users to send discord messages to ooc, requires a bot and a comms_key
+# USING_DISCORD_OOC
+
 ## Lobby time: This is the amount of time between rounds that players have to setup their characters and be ready.
 LOBBY_COUNTDOWN 160
 ## initialization totaly factored in(TM)


### PR DESCRIPTION
<!-- Thanks for choosing to take the time to contribute to our project! We have a few things below that we'd like you to fill out -->
<!-- The more detail you can give us, the faster we can code review, test, and merge your changes -->

<!--- Provide a general summary of your changes in the Title above -->

## Description
You can speak in the #ooc-pipeline channel on discord, and have your messages be piped to ooc ingame.

You can also use `~oocban [user mention]` to ban someone from this function.

## Motivation and Context
It's cool and adds 2-way communication between discord and ooc, instead of just 1-way, which was the previous setup.

## How Has This Been Tested?
I ran stress-tests, with a script designed to spam ooc as much as possible, there were no issues, and since it requires a comms_key, no one can build a script of their own for this

I also did basic tests privately.

## Screenshots (if appropriate):

![screenie](https://i.imgur.com/6w4Y7Y6.png)

## Changelog (necessary)
:cl:
add: Added discord piping to ooc
config: added use_discord_ooc to config
/:cl:
