### PR TITLE
First restart timer increase

### DIFF
--- a/config/game_options.txt
+++ b/config/game_options.txt
@@ -194,7 +194,7 @@ MIDROUND_ANTAG WIZARD
 
 
 ## The amount of time it takes for the emergency shuttle to be called, from round start.
-SHUTTLE_REFUEL_DELAY 60000
+SHUTTLE_REFUEL_DELAY 1150000
 
 ## Variables calculate how number of antagonists will scale to population.
 ## Used as (Antagonists = Population / Coeff)


### PR DESCRIPTION
<!-- Thanks for choosing to take the time to contribute to our project! We have a few things below that we'd like you to fill out -->
<!-- The more detail you can give us, the faster we can code review, test, and merge your changes -->

<!--- Provide a general summary of your changes in the Title above -->

## Description
The shuttle can't be called before 1:55 mark anymore, increased from 1:00.

## Motivation and Context
Games end too fucking early.

## How Has This Been Tested?
It wasn't.

## Screenshots (if appropriate):

## Changelog (necessary)
:cl:
config: A change in game_options.txt config file.
/:cl:
