### PR TITLE
Voting timer change

### DIFF
--- a/code/controllers/subsystem/vote.dm
+++ b/code/controllers/subsystem/vote.dm
@@ -16,7 +16,7 @@ SUBSYSTEM_DEF(vote)
 	var/list/voting = list()
 	var/list/generated_actions = list()
 	var/vote_sound = 'sound/f13/mysterious_stranger.ogg'
-	var/min_restart_time = 30 MINUTES
+	var/min_restart_time = 90 MINUTES
 
 /datum/controller/subsystem/vote/fire()	//called by master_controller
 	if(mode)

--- a/config/game_options.txt
+++ b/config/game_options.txt
@@ -194,7 +194,7 @@ MIDROUND_ANTAG WIZARD
 
 
 ## The amount of time it takes for the emergency shuttle to be called, from round start.
-SHUTTLE_REFUEL_DELAY 60000
+SHUTTLE_REFUEL_DELAY 90000
 
 ## Variables calculate how number of antagonists will scale to population.
 ## Used as (Antagonists = Population / Coeff)


### PR DESCRIPTION
<!-- Thanks for choosing to take the time to contribute to our project! We have a few things below that we'd like you to fill out -->
<!-- The more detail you can give us, the faster we can code review, test, and merge your changes -->

<!--- Provide a general summary of your changes in the Title above -->

## Description
Changed the shuttle delay and minimum time to vote to 90 minutes.
Changes in config and voting.dm files.

## Motivation and Context
Making Ren's memes come true. Also, 'I'm dead pls restart' will happen less often. 
## How Has This Been Tested?
It hasn't.

## Screenshots (if appropriate):

## Changelog (necessary)
:cl:
code: changed some code
config: changed some config setting
/:cl:
