### PR TITLE
Remove loadout box exploit.

### DIFF
--- a/code/modules/jobs/loadout_ingame.dm
+++ b/code/modules/jobs/loadout_ingame.dm
@@ -111,6 +111,8 @@
 	var/mob/M = parent
 	var/obj/item/storage/box/kitbox = new
 	kitbox.name = "Outfit: [selected_datum.name]"
+	kitbox.desc = "A box, supplying what you need."
+	kitbox.w_class = WEIGHT_CLASS_BULKY
 	selected_datum.spawn_at(kitbox)
 	M.put_in_hands(kitbox)
 	disable_loadout_select(M)


### PR DESCRIPTION
Removes the ability for you to just shove your box with all your gear into your backpack until you need it.