### PR TITLE
Remove radiation effects due to performance issues

### DIFF
--- a/code/__HELPERS/radiation.dm
+++ b/code/__HELPERS/radiation.dm
@@ -9,6 +9,7 @@
 		var/static/list/ignored_things = typecacheof(list(
 			/mob/dead,
 			/mob/camera,
+			/obj/effect,
 			/obj/docking_port,
 			/atom/movable/lighting_object,
 			/obj/item/projectile

--- a/code/modules/fallout/obj/decals.dm
+++ b/code/modules/fallout/obj/decals.dm
@@ -14,7 +14,7 @@
 /obj/effect/decal/waste/New()
 	..()
 	icon_state = "goo[rand(1,13)]"
-	AddComponent(/datum/component/radioactive, 200, src, 0) //half-life of 0 because we keep on going.
+	//AddComponent(/datum/component/radioactive, 200, src, 0) //half-life of 0 because we keep on going.
 
 /obj/effect/decal/marking
 	name = "road marking"

--- a/code/modules/fallout/obj/structures/barrel.dm
+++ b/code/modules/fallout/obj/structures/barrel.dm
@@ -22,7 +22,7 @@
 
 /obj/structure/reagent_dispensers/barrel/dangerous/Initialize()
 	. = ..()
-	AddComponent(/datum/component/radioactive, 100, src, 0) //half-life of 0 because we keep on going.
+	//AddComponent(/datum/component/radioactive, 100, src, 0) //half-life of 0 because we keep on going.
 
 /obj/structure/reagent_dispensers/barrel/boom()
 	visible_message("<span class='danger'>\The [src] ruptures!</span>")


### PR DESCRIPTION
<!-- Thanks for choosing to take the time to contribute to our project! We have a few things below that we'd like you to fill out -->
<!-- The more detail you can give us, the faster we can code review, test, and merge your changes -->

<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
Removing radiation from puddles of goo and barrels.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Radiation seems to be hogging a lot of CPU resources.  Not sure how to fix it at the moment, so I'm removing it in hopes of reducing server load.

Tests on my local machine, showed radiation going from 44% CPU utilization to 0% after the change.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- This helps us replicate your tests, to speed up review. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->
Compiled.  Local hosted and tested.

## Screenshots (if appropriate):

## Changelog (necessary)
:cl:

del: Radiation effects from goo and barrels.


/:cl:
