### PR TITLE
Nerfs assault carbine

### DIFF
--- a/code/modules/projectiles/guns/ballistic/automatic.dm
+++ b/code/modules/projectiles/guns/ballistic/automatic.dm
@@ -543,8 +543,8 @@
 	fire_sound = 'sound/f13weapons/assault_carbine.ogg'
 	burst_size = 2
 	fire_delay = 4
-	burst_delay = 1.4
-	extra_damage = 25
+	burst_delay = 2
+	extra_damage = 20
 	spread = 8
 	extra_penetration = 10
 	w_class = WEIGHT_CLASS_BULKY


### PR DESCRIPTION
Increases burst delay from 1.4 to 2, and reduces damage from 25 to 20. Balance is better than removal.
