### PR TITLE
There's a knife in my boot

### DIFF
--- a/code/datums/components/storage/concrete/pockets.dm
+++ b/code/datums/components/storage/concrete/pockets.dm
@@ -56,7 +56,7 @@
 		/obj/item/scalpel, /obj/item/reagent_containers/syringe, /obj/item/dnainjector,
 		/obj/item/reagent_containers/hypospray/medipen, /obj/item/reagent_containers/dropper,
 		/obj/item/implanter, /obj/item/screwdriver, /obj/item/weldingtool/mini,
-		/obj/item/firing_pin
+		/obj/item/firing_pin, /obj/item/throwing_star/throwingknife
 		))
 
 /datum/component/storage/concrete/pockets/shoes/clown/Initialize()


### PR DESCRIPTION
## Description
Allows players to put the new crafting recipe throwing knife in their boot as it is a small item.

## Motivation and Context
You can shove normal sized cleavers and survival knives in there, why not be a ninja.

## Changelog (necessary)
:cl:
add: Rejoice edgelords, you can now carry throwing knives in your boot storage!
/:cl:
