### PR TITLE
Change Box Station's name to Sunnydale

### DIFF
--- a/_maps/boxstation.json
+++ b/_maps/boxstation.json
@@ -1,5 +1,5 @@
 {
-    "map_name": "Box Station",
+    "map_name": "Sunnydale",
     "map_path": "map_files/BoxStation",
     "map_file": "BoxStation.dmm",
     "shuttles": {


### PR DESCRIPTION
You cannot hide your code from me, supposedly lost codebases that I stalk.

## Description
Changes `map_name` to "Sunnydale" instead of "Box Station". This changes _nothing_ about the pathing of the map or the actual code, only its display name.

## Motivation and Context
The map is supposed to be called Sunnydale, but its creator decided to just overwrite Box Station instead. It confuses the fuck out of the average spessman.

## How Has This Been Tested?

- Works on my machine.
- Works on CrashpointF13's machine.

## Screenshots (if appropriate):
![image](https://user-images.githubusercontent.com/57928673/108380021-15ec3200-71cc-11eb-8790-f63b5a135e3e.png)

## Changelog (necessary)
:cl:
config: Box Station's name now appears as Sunnydale.
/:cl:
